### PR TITLE
Test infrastructure improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ uv sync                              # Set up venv + install all deps (editable 
 uv run pytest                        # Run all integration tests (needs test.env + Fabric)
 uv run pytest --dw                   # Run only Fabric (T-SQL) tests
 uv run pytest --de                   # Run only FabricSpark tests
+uv run pytest --dw --isolated        # Fabric tests with isolated DW (for multi-agent)
+uv run pytest --de --isolated        # FabricSpark tests with isolated Lakehouse
 uv run pytest --with-grants          # Include GRANT/authorization tests
 uv run pytest -k "TestClassName"     # Run a specific test class
 uv run ruff format --check .         # Check formatting
@@ -146,6 +148,7 @@ src/
           get_custom_name/             # Database name generation
 tests/
   conftest.py                         # Shared fixtures, adapter type detection, CLI flags
+  isolated_items.py                   # FabricTestItemManager for --isolated mode
   unit/                               # Unit tests (no Fabric connection needed)
   fabric/                             # Fabric (T-SQL) integration tests
     adapter/                          # ~20 test modules
@@ -273,7 +276,8 @@ Instructions:
 1. Read CLAUDE.md to understand the project and workflow.
 2. Read the failing test classes and their base classes to understand what they expect.
 3. Implement the fix in the target files.
-4. Run ONLY the specific failing test: uv run pytest -k "TestClassName" --dw -v (or --de)
+4. Run ONLY the specific failing test: uv run pytest -k "TestClassName" --dw --isolated -v (or --de --isolated)
+   The --isolated flag creates a temporary DW/Lakehouse for your run so you don't conflict with other agents.
 5. If you discover a recurring pattern, add it to the "Lessons learned" section of CLAUDE.md.
 6. Report back: what you changed, which tests pass/fail, any lessons learned.
 ```
@@ -306,7 +310,8 @@ After workers complete:
 - **Read CLAUDE.md first** — it contains everything you need about the project, architecture, and patterns.
 - **Read the base test class** — understand what the test expects before fixing. The fix often becomes obvious from reading the base class SQL.
 - **Minimal fixes only** — fix the root cause, don't refactor. If a macro works, don't also clean up unrelated macros.
-- **Only run your own specific tests** — never run the full test suite. Fabric infrastructure is slow (Livy sessions, rate-limited APIs). Run only the test class you are fixing: `uv run pytest -k "TestClassName" --dw -v` (or `--de`). The coordinator handles regression checks after merging.
+- **Always use `--isolated`** — every worker must pass `--isolated` when running tests. This creates a temporary DW/Lakehouse for your run so you don't conflict with other agents or the coordinator. Items are automatically cleaned up when your test session ends.
+- **Only run your own specific tests** — never run the full test suite. Fabric infrastructure is slow (Livy sessions, rate-limited APIs). Run only the test class you are fixing: `uv run pytest -k "TestClassName" --dw --isolated -v` (or `--de --isolated`). The coordinator handles regression checks after merging.
 - **Validate and commit before finishing** — after your fix works, run `uv run ruff format .` and `uv run ruff check --fix .`, then commit only your own changes (not unrelated changes in the repo). Use a descriptive commit message.
 - **Report clearly** — list: files changed, tests that now pass, tests that still fail (if any), and any lessons learned.
 - **Update CLAUDE.md** — if you find a pattern that will help future work, add it to "Lessons learned". This is part of your job, not optional.
@@ -350,6 +355,26 @@ Common fixture overrides:
 - `tests/fabricspark/**` → adapter type `fabricspark`
 
 This controls which connection profile and dbt_project.yml defaults are used.
+
+### Isolated test infrastructure (`--isolated`)
+
+When multiple agents run tests in parallel, they must not share the same Data Warehouse or Lakehouse — otherwise schema operations, catalog queries, and DDL can collide. The `--isolated` flag solves this by creating temporary Fabric items for each test session.
+
+**How it works:**
+
+1. At session start, `conftest.py` creates a uniquely-named DW (`dbt-test-dw-<uuid>`) and/or Lakehouse (`dbt-test-lh-<uuid>`) via the Fabric REST API using Azure CLI credentials.
+2. It waits for provisioning to complete (can take 1-3 minutes).
+3. It overrides `FABRIC_TEST_DWH_NAME` and/or `FABRIC_TEST_LAKEHOUSE_NAME` env vars so all tests in the session use the isolated items.
+4. At session end (even on failure), it deletes the temporary items.
+
+**Which items are created:**
+- `--dw --isolated` → creates only a Data Warehouse
+- `--de --isolated` → creates only a Lakehouse (with schemas enabled)
+- `--isolated` (no filter) → creates both
+
+**Orphaned items:** if the process is killed with SIGKILL, cleanup won't run. Orphaned items can be identified by the `dbt-test-` name prefix and deleted manually from the Fabric workspace.
+
+**Requirements:** Azure CLI must be logged in (`az login`). The logged-in identity needs permission to create and delete warehouses/lakehouses in the workspace specified by `FABRIC_TEST_WORKSPACE_NAME`.
 
 ### Integration tests require real infrastructure
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,12 @@ def pytest_addoption(parser):
     parser.addoption(
         "--dw", action="store_true", default=False, help="run only Fabric T-SQL tests"
     )
+    parser.addoption(
+        "--isolated",
+        action="store_true",
+        default=False,
+        help="create a temporary DW/Lakehouse for this test run (for multi-agent parallelism)",
+    )
 
 
 def pytest_configure(config):
@@ -177,6 +183,64 @@ def fabric_api_client(
     return FabricApiClient.create(credentials, fabric_token_provider)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolated_fabric_items(request):
+    if not request.config.getoption("--isolated"):
+        yield
+        return
+
+    from tests.isolated_items import FabricTestItemManager
+
+    workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
+    if not workspace_name:
+        raise ValueError("FABRIC_TEST_WORKSPACE_NAME must be set for --isolated mode")
+
+    manager = FabricTestItemManager(workspace_name)
+    suffix = manager.generate_suffix()
+
+    run_dw = request.config.getoption("--dw") or not request.config.getoption("--de")
+    run_de = request.config.getoption("--de") or not request.config.getoption("--dw")
+
+    dw_name = f"dbt-test-dw-{suffix}" if run_dw else None
+    lh_name = f"dbt-test-lh-{suffix}" if run_de else None
+
+    try:
+        if dw_name:
+            print(f"\n=== Creating isolated Data Warehouse: {dw_name}")
+            manager.create_warehouse(dw_name)
+
+        if lh_name:
+            print(f"\n=== Creating isolated Lakehouse: {lh_name}")
+            manager.create_lakehouse(lh_name)
+
+        print("\n=== Waiting for Fabric items to provision...")
+        manager.wait_for_all()
+
+        if dw_name:
+            os.environ["FABRIC_TEST_DWH_NAME"] = dw_name
+            print(f"=== Data Warehouse ready: {dw_name}")
+
+        if lh_name:
+            os.environ["FABRIC_TEST_LAKEHOUSE_NAME"] = lh_name
+            print(f"=== Lakehouse ready: {lh_name}")
+
+        yield
+    finally:
+        print("\n=== Cleaning up isolated Fabric items...")
+        manager.delete_all()
+        print("=== Cleanup complete")
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Deep merge override into base. Returns the merged dict (mutates base)."""
+    for key, value in override.items():
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
 @pytest.fixture(scope="class")
 def dbt_project_yml(project_root, project_config_update, adapter_type: str):
     project_config = {
@@ -189,10 +253,12 @@ def dbt_project_yml(project_root, project_config_update, adapter_type: str):
         project_config["models"] = {"+materialized": "materialized_view"}
 
     if project_config_update:
+        if isinstance(project_config_update, str):
+            project_config_update = yaml.safe_load(project_config_update)
         if isinstance(project_config_update, dict):
-            project_config.update(project_config_update)
+            _deep_merge(project_config, project_config_update)
         elif isinstance(project_config_update, str):
             updates = yaml.safe_load(project_config_update)
-            project_config.update(updates)
+            _deep_merge(project_config, updates)
     write_file(yaml.safe_dump(project_config), project_root, "dbt_project.yml")
     return project_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,8 +257,10 @@ def dbt_project_yml(project_root, project_config_update, adapter_type: str):
             project_config_update = yaml.safe_load(project_config_update)
         if isinstance(project_config_update, dict):
             _deep_merge(project_config, project_config_update)
-        elif isinstance(project_config_update, str):
-            updates = yaml.safe_load(project_config_update)
-            _deep_merge(project_config, updates)
+        else:
+            raise TypeError(
+                f"project_config_update must be a dict or YAML string, "
+                f"got {type(project_config_update).__name__}: {project_config_update!r}"
+            )
     write_file(yaml.safe_dump(project_config), project_root, "dbt_project.yml")
     return project_config

--- a/tests/fabric/adapter/test_split_part.py
+++ b/tests/fabric/adapter/test_split_part.py
@@ -35,7 +35,9 @@ class TestSplitPartInSelectClause:
         run_dbt(["run"])
 
         relation = relation_from_name(project.adapter, "split_part_model")
-        result = project.run_sql(f"select id, first_part, second_part from {relation} order by id", fetch="all")
+        result = project.run_sql(
+            f"select id, first_part, second_part from {relation} order by id", fetch="all"
+        )
 
         assert len(result) == 3
 

--- a/tests/fabric/adapter/test_store_test_failures.py
+++ b/tests/fabric/adapter/test_store_test_failures.py
@@ -52,7 +52,7 @@ class FabricStoreTestFailuresMixin:
                     raise
 
 
-class TestFabricStoreTestFailures(BaseStoreTestFailures):
+class TestFabricStoreTestFailures(FabricStoreTestFailuresMixin, BaseStoreTestFailures):
     @pytest.fixture(scope="class")
     def tests(self):
         return {
@@ -67,7 +67,9 @@ class TestFabricStoreTestFailuresAsGeneric(
     pass
 
 
-class TestFabricStoreTestFailuresAsExceptions(StoreTestFailuresAsExceptions):
+class TestFabricStoreTestFailuresAsExceptions(
+    FabricStoreTestFailuresMixin, StoreTestFailuresAsExceptions
+):
     pass
 
 

--- a/tests/fabric/adapter/test_store_test_failures.py
+++ b/tests/fabric/adapter/test_store_test_failures.py
@@ -1,4 +1,7 @@
+import time
+
 import pytest
+from dbt_common.exceptions import DbtDatabaseError
 
 from dbt.tests.adapter.store_test_failures_tests import fixtures
 from dbt.tests.adapter.store_test_failures_tests.basic import (
@@ -13,11 +16,40 @@ from dbt.tests.adapter.store_test_failures_tests.test_store_test_failures import
     BaseStoreTestFailures,
     BaseStoreTestFailuresLimit,
 )
+from dbt.tests.util import check_relation_types, run_dbt
 
 tests__passing_test = """
 select * from {{ ref('fine_model') }}
 where 1=0
 """
+
+
+class FabricStoreTestFailuresMixin:
+    """Retry check_relation_types to handle Fabric snapshot isolation errors.
+
+    When the full test suite runs in parallel, concurrent DDL from other test classes
+    can cause transient snapshot isolation failures in the sys.tables/sys.views queries
+    used by check_relation_types.
+    """
+
+    def run_and_assert(self, project, expected_results, expect_pass=False):
+        results = run_dbt(["test"], expect_pass=expect_pass)
+
+        actual = {(result.node.name, result.status) for result in results}
+        expected = {(result.name, result.status) for result in expected_results}
+        assert actual == expected
+
+        relation_to_type = {result.name: result.type for result in expected_results}
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                check_relation_types(project.adapter, relation_to_type)
+                break
+            except DbtDatabaseError:
+                if attempt < max_retries - 1:
+                    time.sleep(2)
+                else:
+                    raise
 
 
 class TestFabricStoreTestFailures(BaseStoreTestFailures):
@@ -29,7 +61,9 @@ class TestFabricStoreTestFailures(BaseStoreTestFailures):
         }
 
 
-class TestFabricStoreTestFailuresAsGeneric(StoreTestFailuresAsGeneric):
+class TestFabricStoreTestFailuresAsGeneric(
+    FabricStoreTestFailuresMixin, StoreTestFailuresAsGeneric
+):
     pass
 
 
@@ -37,19 +71,27 @@ class TestFabricStoreTestFailuresAsExceptions(StoreTestFailuresAsExceptions):
     pass
 
 
-class TestFabricStoreTestFailuresAsInteractions(StoreTestFailuresAsInteractions):
+class TestFabricStoreTestFailuresAsInteractions(
+    FabricStoreTestFailuresMixin, StoreTestFailuresAsInteractions
+):
     pass
 
 
-class TestFabricStoreTestFailuresAsProjectLevelEphemeral(StoreTestFailuresAsProjectLevelEphemeral):
+class TestFabricStoreTestFailuresAsProjectLevelEphemeral(
+    FabricStoreTestFailuresMixin, StoreTestFailuresAsProjectLevelEphemeral
+):
     pass
 
 
-class TestFabricStoreTestFailuresAsProjectLevelOff(StoreTestFailuresAsProjectLevelOff):
+class TestFabricStoreTestFailuresAsProjectLevelOff(
+    FabricStoreTestFailuresMixin, StoreTestFailuresAsProjectLevelOff
+):
     pass
 
 
-class TestFabricStoreTestFailuresAsProjectLevelView(StoreTestFailuresAsProjectLevelView):
+class TestFabricStoreTestFailuresAsProjectLevelView(
+    FabricStoreTestFailuresMixin, StoreTestFailuresAsProjectLevelView
+):
     pass
 
 

--- a/tests/fabric/adapter/test_timing.py
+++ b/tests/fabric/adapter/test_timing.py
@@ -60,12 +60,8 @@ class TestModelTimingPopulated:
         assert "execute" in timing_names, "Missing 'execute' timing entry"
 
         for timing in model_result.timing:
-            assert timing.started_at is not None, (
-                f"Timing '{timing.name}' has no started_at"
-            )
-            assert timing.completed_at is not None, (
-                f"Timing '{timing.name}' has no completed_at"
-            )
+            assert timing.started_at is not None, f"Timing '{timing.name}' has no started_at"
+            assert timing.completed_at is not None, f"Timing '{timing.name}' has no completed_at"
             assert timing.completed_at >= timing.started_at, (
                 f"Timing '{timing.name}': completed_at before started_at"
             )
@@ -75,8 +71,7 @@ class TestModelTimingPopulated:
         assert run_results is not None
 
         model_results = [
-            r for r in run_results["results"]
-            if r["unique_id"] == "model.test.timing_model"
+            r for r in run_results["results"] if r["unique_id"] == "model.test.timing_model"
         ]
         assert len(model_results) == 1
         result = model_results[0]
@@ -95,9 +90,7 @@ class TestModelTimingPopulated:
         json_str = log_output.split("TIMING_JSON=")[1].split("\n")[0].strip()
         timing_data = json.loads(json_str)
 
-        model_entries = [
-            e for e in timing_data if e["unique_id"] == "model.test.timing_model"
-        ]
+        model_entries = [e for e in timing_data if e["unique_id"] == "model.test.timing_model"]
         assert len(model_entries) == 1
         entry = model_entries[0]
 

--- a/tests/isolated_items.py
+++ b/tests/isolated_items.py
@@ -18,6 +18,7 @@ class FabricTestItemManager:
     FABRIC_API = "https://api.fabric.microsoft.com/v1"
     POWERBI_API = "https://api.powerbi.com/v1.0"
     PROVISION_TIMEOUT = 600
+    MAX_RETRIES = 10
 
     def __init__(self, workspace_name: str) -> None:
         self._workspace_name = workspace_name
@@ -43,11 +44,18 @@ class FabricTestItemManager:
         }
 
     def _request(self, method: str, url: str, body: dict | None = None) -> requests.Response:
-        resp = requests.request(method, url, json=body, headers=self._headers())
-        if resp.status_code == 429:
-            time.sleep(int(resp.headers.get("Retry-After", 5)))
-            return self._request(method, url, body)
-        return resp
+        for attempt in range(self.MAX_RETRIES):
+            resp = requests.request(method, url, json=body, headers=self._headers())
+            if resp.status_code != 429:
+                return resp
+            delay = int(resp.headers.get("Retry-After", 5))
+            if attempt == self.MAX_RETRIES - 1:
+                raise RuntimeError(
+                    f"Fabric API rate limit (429) not resolved after "
+                    f"{self.MAX_RETRIES} retries on {method.upper()} {url}"
+                )
+            time.sleep(delay)
+        raise RuntimeError("Unreachable")
 
     def get_workspace_id(self) -> str:
         if self._workspace_id:
@@ -63,19 +71,26 @@ class FabricTestItemManager:
         assert self._workspace_id is not None
         return self._workspace_id
 
+    def _create_item(self, item_type: str, url: str, name: str, body: dict) -> None:
+        resp = self._request("post", url, body)
+
+        if resp.status_code == 201:
+            self._items[name] = (item_type, resp.json()["id"])
+        elif resp.status_code == 202:
+            location = resp.headers.get("Location")
+            if not location:
+                raise RuntimeError(
+                    f"Fabric returned 202 Accepted for {item_type} '{name}' "
+                    f"but no Location header for polling"
+                )
+            self._pending.append((item_type, name, location))
+        else:
+            resp.raise_for_status()
+
     def create_warehouse(self, name: str) -> None:
         ws = self.get_workspace_id()
         url = f"{self.FABRIC_API}/workspaces/{ws}/warehouses"
-        resp = self._request("post", url, {"displayName": name})
-
-        if resp.status_code == 201:
-            self._items[name] = ("warehouse", resp.json()["id"])
-        elif resp.status_code == 202:
-            location = resp.headers.get("Location")
-            if location:
-                self._pending.append(("warehouse", name, location))
-        else:
-            resp.raise_for_status()
+        self._create_item("warehouse", url, name, {"displayName": name})
 
     def create_lakehouse(self, name: str) -> None:
         ws = self.get_workspace_id()
@@ -84,20 +99,11 @@ class FabricTestItemManager:
             "displayName": name,
             "creationPayload": {"enableSchemas": True},
         }
-        resp = self._request("post", url, body)
-
-        if resp.status_code == 201:
-            self._items[name] = ("lakehouse", resp.json()["id"])
-        elif resp.status_code == 202:
-            location = resp.headers.get("Location")
-            if location:
-                self._pending.append(("lakehouse", name, location))
-        else:
-            resp.raise_for_status()
+        self._create_item("lakehouse", url, name, body)
 
     def wait_for_all(self) -> None:
-        start = time.time()
         for item_type, name, location_url in self._pending:
+            start = time.time()
             while True:
                 elapsed = time.time() - start
                 if elapsed > self.PROVISION_TIMEOUT:
@@ -111,9 +117,13 @@ class FabricTestItemManager:
 
                 if status == "Succeeded":
                     result_location = resp.headers.get("Location")
-                    if result_location:
-                        result = self._request("get", result_location)
-                        self._items[name] = (item_type, result.json()["id"])
+                    if not result_location:
+                        raise RuntimeError(
+                            f"Provisioning succeeded for {item_type} '{name}' "
+                            f"but response has no Location header to retrieve item id"
+                        )
+                    result = self._request("get", result_location)
+                    self._items[name] = (item_type, result.json()["id"])
                     break
 
                 if status not in ("NotStarted", "Running"):
@@ -137,7 +147,8 @@ class FabricTestItemManager:
         else:
             return
 
-        self._request("delete", url)
+        resp = self._request("delete", url)
+        resp.raise_for_status()
 
     def delete_all(self) -> None:
         for name in list(self._items):

--- a/tests/isolated_items.py
+++ b/tests/isolated_items.py
@@ -1,0 +1,144 @@
+import time
+import urllib.parse
+import uuid
+
+import requests
+from azure.identity import AzureCliCredential
+
+
+class FabricTestItemManager:
+    """Creates and manages temporary Fabric items for isolated test runs.
+
+    Each call to create_warehouse / create_lakehouse fires a non-blocking
+    POST.  Call wait_for_all() once to block until every pending item is
+    provisioned.  Use delete_all() (or the matching delete_* helpers) to
+    tear everything down.
+    """
+
+    FABRIC_API = "https://api.fabric.microsoft.com/v1"
+    POWERBI_API = "https://api.powerbi.com/v1.0"
+    PROVISION_TIMEOUT = 600
+
+    def __init__(self, workspace_name: str) -> None:
+        self._workspace_name = workspace_name
+        self._credential = AzureCliCredential()
+        self._workspace_id: str | None = None
+        self._pending: list[tuple[str, str, str]] = []
+        self._items: dict[str, tuple[str, str]] = {}
+
+    @staticmethod
+    def generate_suffix() -> str:
+        return uuid.uuid4().hex[:8]
+
+    def _get_token(self) -> str:
+        return self._credential.get_token(
+            "https://analysis.windows.net/powerbi/api/.default"
+        ).token
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._get_token()}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def _request(self, method: str, url: str, body: dict | None = None) -> requests.Response:
+        resp = requests.request(method, url, json=body, headers=self._headers())
+        if resp.status_code == 429:
+            time.sleep(int(resp.headers.get("Retry-After", 5)))
+            return self._request(method, url, body)
+        return resp
+
+    def get_workspace_id(self) -> str:
+        if self._workspace_id:
+            return self._workspace_id
+
+        query = urllib.parse.quote_plus(f"name eq '{self._workspace_name}'")
+        resp = self._request("get", f"{self.POWERBI_API}/myorg/groups?$filter={query}")
+        resp.raise_for_status()
+        workspaces = resp.json().get("value", [])
+        if not workspaces:
+            raise RuntimeError(f"No workspace found: {self._workspace_name}")
+        self._workspace_id = workspaces[0]["id"]
+        assert self._workspace_id is not None
+        return self._workspace_id
+
+    def create_warehouse(self, name: str) -> None:
+        ws = self.get_workspace_id()
+        url = f"{self.FABRIC_API}/workspaces/{ws}/warehouses"
+        resp = self._request("post", url, {"displayName": name})
+
+        if resp.status_code == 201:
+            self._items[name] = ("warehouse", resp.json()["id"])
+        elif resp.status_code == 202:
+            location = resp.headers.get("Location")
+            if location:
+                self._pending.append(("warehouse", name, location))
+        else:
+            resp.raise_for_status()
+
+    def create_lakehouse(self, name: str) -> None:
+        ws = self.get_workspace_id()
+        url = f"{self.FABRIC_API}/workspaces/{ws}/lakehouses"
+        body: dict = {
+            "displayName": name,
+            "creationPayload": {"enableSchemas": True},
+        }
+        resp = self._request("post", url, body)
+
+        if resp.status_code == 201:
+            self._items[name] = ("lakehouse", resp.json()["id"])
+        elif resp.status_code == 202:
+            location = resp.headers.get("Location")
+            if location:
+                self._pending.append(("lakehouse", name, location))
+        else:
+            resp.raise_for_status()
+
+    def wait_for_all(self) -> None:
+        start = time.time()
+        for item_type, name, location_url in self._pending:
+            while True:
+                elapsed = time.time() - start
+                if elapsed > self.PROVISION_TIMEOUT:
+                    raise RuntimeError(
+                        f"Timed out after {self.PROVISION_TIMEOUT}s "
+                        f"provisioning {item_type} '{name}'"
+                    )
+
+                resp = self._request("get", location_url)
+                status = resp.json().get("status", "Unknown")
+
+                if status == "Succeeded":
+                    result_location = resp.headers.get("Location")
+                    if result_location:
+                        result = self._request("get", result_location)
+                        self._items[name] = (item_type, result.json()["id"])
+                    break
+
+                if status not in ("NotStarted", "Running"):
+                    raise RuntimeError(f"Failed to provision {item_type} '{name}': {status}")
+
+                time.sleep(int(resp.headers.get("Retry-After", 5)))
+
+        self._pending.clear()
+
+    def delete_item(self, name: str) -> None:
+        entry = self._items.get(name)
+        if not entry:
+            return
+        item_type, item_id = entry
+        ws = self.get_workspace_id()
+
+        if item_type == "warehouse":
+            url = f"{self.FABRIC_API}/workspaces/{ws}/warehouses/{item_id}"
+        elif item_type == "lakehouse":
+            url = f"{self.FABRIC_API}/workspaces/{ws}/lakehouses/{item_id}"
+        else:
+            return
+
+        self._request("delete", url)
+
+    def delete_all(self) -> None:
+        for name in list(self._items):
+            self.delete_item(name)


### PR DESCRIPTION
## Summary
- Fix shallow dict merge in `conftest.py` `dbt_project_yml` fixture — deep merge now preserves `+materialized: materialized_view` default for FabricSpark
- Add `--isolated` flag for multi-agent test parallelism (creates temporary DW/Lakehouse per session)
- Refactor timing assertions for clarity in `test_model_timing_populated`
- Add retry logic for transient snapshot isolation errors in DW `store_test_failures` tests

## Test plan
- [x] `uv run pytest --dw -k "TestStoreTestFailures" -v`
- [x] `uv run pytest --dw --isolated` — verify isolated DW creation and cleanup
- [x] `uv run pytest --de --isolated` — verify isolated Lakehouse creation and cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)