### PR TITLE
Fix T-SQL identifier quoting to use brackets

### DIFF
--- a/src/dbt/adapters/fabric/fabric_adapter.py
+++ b/src/dbt/adapters/fabric/fabric_adapter.py
@@ -32,6 +32,10 @@ class FabricAdapter(BaseFabricAdapter, SQLAdapter):
     AdapterSpecificConfigs = FabricConfigs
     Relation = FabricRelation
 
+    @classmethod
+    def quote(cls, identifier):
+        return "[{}]".format(identifier)
+
     _capabilities: CapabilityDict = CapabilityDict(
         {
             Capability.SchemaMetadataByRelations: CapabilitySupport(support=Support.Full),

--- a/src/dbt/adapters/fabric/fabric_adapter.py
+++ b/src/dbt/adapters/fabric/fabric_adapter.py
@@ -34,7 +34,7 @@ class FabricAdapter(BaseFabricAdapter, SQLAdapter):
 
     @classmethod
     def quote(cls, identifier):
-        return "[{}]".format(identifier)
+        return "[{}]".format(identifier.replace("]", "]]"))
 
     _capabilities: CapabilityDict = CapabilityDict(
         {

--- a/src/dbt/adapters/fabric/fabric_column.py
+++ b/src/dbt/adapters/fabric/fabric_column.py
@@ -40,7 +40,7 @@ class FabricColumn(Column):
 
     @property
     def quoted(self) -> str:
-        return "[{}]".format(self.column)
+        return "[{}]".format(self.column.replace("]", "]]"))
 
     @property
     def data_type(self) -> str:

--- a/src/dbt/adapters/fabric/fabric_column.py
+++ b/src/dbt/adapters/fabric/fabric_column.py
@@ -39,6 +39,10 @@ class FabricColumn(Column):
         return self.dtype.lower() in ["numeric", "decimal", "money", "smallmoney"]
 
     @property
+    def quoted(self) -> str:
+        return "[{}]".format(self.column)
+
+    @property
     def data_type(self) -> str:
         if self.dtype == "datetime2":
             return f"datetime2({self.numeric_scale})"

--- a/src/dbt/adapters/fabric/fabric_relation.py
+++ b/src/dbt/adapters/fabric/fabric_relation.py
@@ -13,7 +13,7 @@ class FabricRelation(BaseRelation):
     require_alias: bool = True
 
     def quoted(self, identifier):
-        return "[{}]".format(identifier)
+        return "[{}]".format(identifier.replace("]", "]]"))
 
     @classproperty
     def get_relation_type(cls) -> Type[FabricRelationType]:

--- a/src/dbt/adapters/fabric/fabric_relation.py
+++ b/src/dbt/adapters/fabric/fabric_relation.py
@@ -12,6 +12,9 @@ class FabricRelation(BaseRelation):
     quote_policy: FabricQuotePolicy = field(default_factory=lambda: FabricQuotePolicy())
     require_alias: bool = True
 
+    def quoted(self, identifier):
+        return "[{}]".format(identifier)
+
     @classproperty
     def get_relation_type(cls) -> Type[FabricRelationType]:
         return FabricRelationType

--- a/src/dbt/include/fabric/macros/adapters/columns.sql
+++ b/src/dbt/include/fabric/macros/adapters/columns.sql
@@ -69,7 +69,7 @@
         FROM
         (
             SELECT
-            '[' + CAST(c.COLUMN_NAME AS VARCHAR(128)) + ']' AS ColumnName
+            '[' + REPLACE(CAST(c.COLUMN_NAME AS VARCHAR(128)), ']', ']]') + ']' AS ColumnName
             FROM INFORMATION_SCHEMA.TABLES t
             JOIN INFORMATION_SCHEMA.COLUMNS c
                 ON t.TABLE_SCHEMA = c.TABLE_SCHEMA
@@ -90,7 +90,7 @@
 
     {% set tempTable %}
         CREATE TABLE {{tempTableName}}
-        AS SELECT {{query_result_text}}, CAST([{{ column_name }}] AS {{new_column_type}}) AS [{{column_name}}] FROM {{ relation.schema }}.{{ relation.identifier }}
+        AS SELECT {{query_result_text}}, CAST([{{ column_name | replace(']', ']]') }}] AS {{new_column_type}}) AS [{{ column_name | replace(']', ']]') }}] FROM {{ relation.schema }}.{{ relation.identifier }}
         {{ apply_label() }}
     {% endset %}
 
@@ -128,12 +128,12 @@
   {% call statement('add_drop_columns') -%}
     {% if add_columns %}
         alter {{ relation.type }} {{ relation }}
-        add {% for column in add_columns %}[{{ column.name }}] {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
+        add {% for column in add_columns %}[{{ column.name | replace(']', ']]') }}] {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
     {% endif %}
 
     {% if remove_columns %}
         alter {{ relation.type }} {{ relation }}
-        drop column {% for column in remove_columns %}[{{ column.name }}]{{ ',' if not loop.last }}{% endfor %};
+        drop column {% for column in remove_columns %}[{{ column.name | replace(']', ']]') }}]{{ ',' if not loop.last }}{% endfor %};
     {% endif %}
   {%- endcall -%}
 {% endmacro %}

--- a/src/dbt/include/fabric/macros/adapters/columns.sql
+++ b/src/dbt/include/fabric/macros/adapters/columns.sql
@@ -69,14 +69,14 @@
         FROM
         (
             SELECT
-            '"' + CAST(c.COLUMN_NAME AS VARCHAR(128)) + '"' AS ColumnName
+            '[' + CAST(c.COLUMN_NAME AS VARCHAR(128)) + ']' AS ColumnName
             FROM INFORMATION_SCHEMA.TABLES t
             JOIN INFORMATION_SCHEMA.COLUMNS c
                 ON t.TABLE_SCHEMA = c.TABLE_SCHEMA
                 AND t.TABLE_NAME = c.TABLE_NAME
-                WHERE t.TABLE_NAME = REPLACE('{{table_name}}','"','')
-                AND t.TABLE_SCHEMA = REPLACE('{{schema_name}}','"','')
-                AND c.COLUMN_NAME <> REPLACE('{{column_name}}','"','')
+                WHERE t.TABLE_NAME = REPLACE(REPLACE('{{table_name}}','[',''),']','')
+                AND t.TABLE_SCHEMA = REPLACE(REPLACE('{{schema_name}}','[',''),']','')
+                AND c.COLUMN_NAME <> REPLACE(REPLACE('{{column_name}}','[',''),']','')
         ) T
     {% endset %}
 
@@ -90,7 +90,7 @@
 
     {% set tempTable %}
         CREATE TABLE {{tempTableName}}
-        AS SELECT {{query_result_text}}, CAST("{{ column_name }}" AS {{new_column_type}}) AS "{{column_name}}" FROM {{ relation.schema }}.{{ relation.identifier }}
+        AS SELECT {{query_result_text}}, CAST([{{ column_name }}] AS {{new_column_type}}) AS [{{column_name}}] FROM {{ relation.schema }}.{{ relation.identifier }}
         {{ apply_label() }}
     {% endset %}
 
@@ -128,12 +128,12 @@
   {% call statement('add_drop_columns') -%}
     {% if add_columns %}
         alter {{ relation.type }} {{ relation }}
-        add {% for column in add_columns %}"{{ column.name }}" {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
+        add {% for column in add_columns %}[{{ column.name }}] {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
     {% endif %}
 
     {% if remove_columns %}
         alter {{ relation.type }} {{ relation }}
-        drop column {% for column in remove_columns %}"{{ column.name }}"{{ ',' if not loop.last }}{% endfor %};
+        drop column {% for column in remove_columns %}[{{ column.name }}]{{ ',' if not loop.last }}{% endfor %};
     {% endif %}
   {%- endcall -%}
 {% endmacro %}

--- a/src/dbt/include/fabric/macros/adapters/metadata.sql
+++ b/src/dbt/include/fabric/macros/adapters/metadata.sql
@@ -21,7 +21,7 @@
 
 {%- macro fabric__get_use_database_sql(database) -%}
   {%- if database is not none -%}
-    USE [{{database | replace('"', '')}}];
+    USE [{{database | replace('[', '') | replace(']', '') | replace('"', '')}}];
   {%- endif -%}
 {%- endmacro -%}
 

--- a/src/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -34,7 +34,7 @@
 
             {% set listColumns %}
                 {% for column in model['columns'] %}
-                    {{ "["~column~"]" }}{{ ", " if not loop.last }}
+                    {{ "["~column | replace(']', ']]')~"]" }}{{ ", " if not loop.last }}
                 {% endfor %}
             {%endset%}
 

--- a/src/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
+++ b/src/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
@@ -6,7 +6,7 @@
 {% macro fabric__create_columns(relation, columns) %}
   {% for column in columns %}
     {% call statement() %}
-      alter table {{ relation.render() }} add "{{ column.name }}" {{ column.data_type }} NULL;
+      alter table {{ relation.render() }} add [{{ column.name }}] {{ column.data_type }} NULL;
     {% endcall %}
   {% endfor %}
 {% endmacro %}

--- a/src/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
+++ b/src/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
@@ -6,7 +6,7 @@
 {% macro fabric__create_columns(relation, columns) %}
   {% for column in columns %}
     {% call statement() %}
-      alter table {{ relation.render() }} add [{{ column.name }}] {{ column.data_type }} NULL;
+      alter table {{ relation.render() }} add [{{ column.name | replace(']', ']]') }}] {{ column.data_type }} NULL;
     {% endcall %}
   {% endfor %}
 {% endmacro %}

--- a/tests/fabric/adapter/test_quoting.py
+++ b/tests/fabric/adapter/test_quoting.py
@@ -1,0 +1,95 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+_MODEL_WITH_RESERVED_COLUMN_NAMES = """
+{{
+    config(materialized='table')
+}}
+
+select
+    1 as id,
+    'hello' as [order],
+    'world' as [select],
+    42 as [group]
+"""
+
+_MODEL_INCREMENTAL_APPEND_NEW_COLUMNS = """
+{{
+    config(
+        materialized='incremental',
+        unique_key='id',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+{% if is_incremental() %}
+
+select
+    1 as id,
+    'hello' as [order],
+    'world' as [select],
+    42 as [group],
+    'new_value' as [table]
+
+{% else %}
+
+select
+    1 as id,
+    'hello' as [order],
+    'world' as [select],
+    42 as [group]
+
+{% endif %}
+"""
+
+
+class TestBracketQuotingReservedWords:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "reserved_columns.sql": _MODEL_WITH_RESERVED_COLUMN_NAMES,
+        }
+
+    def test_reserved_column_names(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status.value == "success"
+
+        result = project.run_sql(
+            "select [order], [select], [group] from {schema}.reserved_columns".format(
+                schema=project.test_schema
+            ),
+            fetch="one",
+        )
+        assert result[0] == "hello"
+        assert result[1] == "world"
+        assert result[2] == 42
+
+
+class TestBracketQuotingSchemaChange:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_reserved.sql": _MODEL_INCREMENTAL_APPEND_NEW_COLUMNS,
+        }
+
+    def test_incremental_append_new_columns_with_reserved_words(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status.value == "success"
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status.value == "success"
+
+        result = project.run_sql(
+            "select [order], [select], [group], [table] from {schema}.incremental_reserved".format(
+                schema=project.test_schema
+            ),
+            fetch="one",
+        )
+        assert result[0] == "hello"
+        assert result[1] == "world"
+        assert result[2] == 42
+        assert result[3] == "new_value"

--- a/tests/unit/test_get_use_database_sql.py
+++ b/tests/unit/test_get_use_database_sql.py
@@ -1,0 +1,48 @@
+import pytest
+from jinja2 import Environment
+
+MACRO_TEMPLATE = """\
+{%- macro fabric__get_use_database_sql(database) -%}
+  {%- if database is not none -%}
+    USE [{{database | replace('"', '') | replace('[', '') | replace(']', '')}}];
+  {%- endif -%}
+{%- endmacro -%}
+{{ fabric__get_use_database_sql(test_database) }}"""
+
+
+@pytest.fixture
+def jinja_env():
+    return Environment()
+
+
+def _render(jinja_env, database):
+    template = jinja_env.from_string(MACRO_TEMPLATE)
+    return template.render(test_database=database).strip()
+
+
+def test_plain_database_name(jinja_env):
+    assert _render(jinja_env, "my_database") == "USE [my_database];"
+
+
+def test_double_quoted_database_name(jinja_env):
+    assert _render(jinja_env, '"my_database"') == "USE [my_database];"
+
+
+def test_bracket_quoted_database_name(jinja_env):
+    assert _render(jinja_env, "[my_database]") == "USE [my_database];"
+
+
+def test_bracket_and_double_quoted_database_name(jinja_env):
+    assert _render(jinja_env, '"[my_database]"') == "USE [my_database];"
+
+
+def test_none_database_returns_empty(jinja_env):
+    assert _render(jinja_env, None) == ""
+
+
+def test_database_with_spaces(jinja_env):
+    assert _render(jinja_env, "my database") == "USE [my database];"
+
+
+def test_database_with_brackets_and_spaces(jinja_env):
+    assert _render(jinja_env, "[my database]") == "USE [my database];"

--- a/tests/unit/test_get_use_database_sql.py
+++ b/tests/unit/test_get_use_database_sql.py
@@ -1,6 +1,10 @@
 import pytest
 from jinja2 import Environment
 
+# This test renders a simplified copy of the fabric__get_use_database_sql macro
+# directly via Jinja2, without a full dbt context. It validates the sanitization
+# logic in isolation but does not exercise the actual macro file. Integration
+# tests cover the real macro through adapter.dispatch().
 MACRO_TEMPLATE = """\
 {%- macro fabric__get_use_database_sql(database) -%}
   {%- if database is not none -%}
@@ -46,3 +50,11 @@ def test_database_with_spaces(jinja_env):
 
 def test_database_with_brackets_and_spaces(jinja_env):
     assert _render(jinja_env, "[my database]") == "USE [my database];"
+
+
+def test_database_with_closing_bracket_in_name(jinja_env):
+    assert _render(jinja_env, "my]database") == "USE [mydatabase];"
+
+
+def test_database_with_brackets_containing_closing_bracket(jinja_env):
+    assert _render(jinja_env, "[my]database]") == "USE [mydatabase];"


### PR DESCRIPTION
## Summary
- Fix identifier quoting in adapter, column, and relation classes to use `[brackets]` instead of `"double quotes"`
- Update columns and metadata macros for consistent bracket quoting
- Add unit tests for USE database bracket sanitization

## Test plan
- [x] `uv run pytest --dw -v` — verify no regressions in DW tests
- [x] `uv run pytest tests/unit/test_get_use_database_sql.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)