### PR TITLE
Fix rows_affected reporting -1 for table materializations

### DIFF
--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -265,7 +265,6 @@ class FabricConnectionManager(BaseFabricConnectionManager):
     ) -> tuple[AdapterResponse, agate.Table]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
-        response = self.get_response(cursor)
         if fetch:
             # Get the result of the first non-empty result set (if any)
             while cursor.description is None:
@@ -279,6 +278,7 @@ class FabricConnectionManager(BaseFabricConnectionManager):
         while cursor.nextset():
             logger.debug("Stepping through remaining result sets...")
             pass
+        response = self.get_response(cursor)
         return response, table
 
     def add_query(

--- a/tests/fabric/adapter/test_rows_affected.py
+++ b/tests/fabric/adapter/test_rows_affected.py
@@ -1,0 +1,39 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+seed_csv = """id,name,value
+1,alice,100
+2,bob,200
+3,charlie,300
+""".lstrip()
+
+model_sql = """
+select * from {{ ref('test_seed') }}
+"""
+
+
+class TestRowsAffected:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"test_seed.csv": seed_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"test_model.sql": model_sql}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "test_rows_affected",
+            "models": {"+materialized": "table"},
+        }
+
+    def test_rows_affected_is_positive(self, project, logs_dir):
+        run_dbt(["seed"])
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        result = results[0]
+        assert result.adapter_response["rows_affected"] > 0, (
+            f"Expected rows_affected > 0, got {result.adapter_response['rows_affected']}"
+        )


### PR DESCRIPTION
## Summary
- Fix connection manager to report correct row counts instead of -1 for table materializations

## Test plan
- [x] `uv run pytest --dw -k "TestRowsAffected" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)