### PR TITLE
Add approximate row count statistics to catalog

### DIFF
--- a/docs/catalog-stats.md
+++ b/docs/catalog-stats.md
@@ -1,0 +1,44 @@
+# Catalog statistics
+
+When you run `dbt docs generate`, this adapter enriches the [catalog](https://docs.getdbt.com/reference/artifacts/catalog-json) with **approximate row counts** for every table in your Fabric Data Warehouse. These row counts appear in the dbt docs site alongside your column information, giving you a quick sense of table sizes without running any additional queries.
+
+---
+
+## How it works
+
+The catalog query uses the T-SQL function [`OBJECTPROPERTYEX`](https://learn.microsoft.com/sql/t-sql/functions/objectpropertyex-transact-sql?view=fabric&WT.mc_id=MVP_310840) with the `'Cardinality'` property to retrieve the optimizer's row count estimate for each table:
+
+```sql
+cast(objectpropertyex(object_id, 'Cardinality') as int)
+```
+
+This is the same estimate that the query optimizer uses internally, derived from table statistics. It is **not** an exact count — it is an approximation that avoids the cost of scanning the entire table.
+
+Row counts are included for **base tables only**. Views do not have cardinality statistics, so the row count stat is excluded from views in the catalog output.
+
+---
+
+## What you see in dbt docs
+
+After running `dbt docs generate` and opening the docs site, each table node shows a **Row Count** statistic with the approximate number of rows. Views show no row count.
+
+No configuration is needed — the statistics are included automatically whenever you generate the catalog.
+
+---
+
+## Why this adapter?
+
+Microsoft's upstream dbt-fabric adapter does not include any statistics in the catalog output. The base catalog query returns `null` for all stat columns, so the dbt docs site shows no table size information.
+
+This adapter adds row count statistics out of the box, which is especially useful for:
+
+- **Quickly assessing table sizes** during development and code review
+- **Spotting unexpected growth or emptiness** in tables after a dbt run
+- **Onboarding new team members** who want to understand the data landscape
+
+---
+
+## Limitations
+
+- Row counts are **approximate**. They come from the query optimizer's statistics, which may lag behind the actual row count if statistics have not been updated recently.
+- Row counts are only available for **Fabric Data Warehouse** (the `fabric` adapter type). The FabricSpark adapter does not include this feature.

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -87,6 +87,10 @@ select * from source('my_source', 'my_table')
 
 Both adapters support Fabric [warehouse snapshots](https://learn.microsoft.com/fabric/data-warehouse/warehouse-snapshot?WT.mc_id=MVP_310840), but Microsoft's implementation hijacks Python runtime components and does not respect the proper dbt lifecycle. This adapter exposes a macro you can call from `on-run-start`, `on-run-end`, `post-hook`, or any other Jinja context — giving you full control over when and how often snapshots are taken.
 
+## [Catalog statistics](catalog-stats.md)
+
+When you run `dbt docs generate`, this adapter includes **approximate row counts** for every table in the catalog output. Microsoft's upstream adapter does not include any statistics — the dbt docs site shows no table size information. With this adapter, table sizes are visible out of the box, with no extra configuration.
+
 ## Better support for popular packages
 
 [dbt-utils](https://hub.getdbt.com/dbt-labs/dbt_utils/latest/) is already fully supported and more packages are being tested and added.

--- a/src/dbt/include/fabric/macros/adapters/catalog.sql
+++ b/src/dbt/include/fabric/macros/adapters/catalog.sql
@@ -110,7 +110,11 @@
             cols.column_name,
             cols.column_index,
             cols.column_type,
-            null as column_comment
+            null as column_comment,
+            'Row Count' as [stats:row_count:label],
+            cast(objectpropertyex(tv.object_id, 'Cardinality') as int) as [stats:row_count:value],
+            'An approximate count of rows in this table' as [stats:row_count:description],
+            cast(case when tv.table_type = 'BASE TABLE' then 1 else 0 end as bit) as [stats:row_count:include]
         from tables_and_views tv
         join cols on tv.object_id = cols.object_id
         where ({%- for schema in schemas -%}
@@ -241,7 +245,11 @@
                 cols.column_name,
                 cols.column_index,
                 cols.column_type,
-                null as column_comment
+                null as column_comment,
+                'Row Count' as [stats:row_count:label],
+                cast(objectpropertyex(tv.object_id, 'Cardinality') as int) as [stats:row_count:value],
+                'An approximate count of rows in this table' as [stats:row_count:description],
+                cast(case when tv.table_type = 'BASE TABLE' then 1 else 0 end as bit) as [stats:row_count:include]
             from tables_and_views tv
             join cols on tv.object_id = cols.object_id
             where (

--- a/tests/fabric/adapter/test_basic.py
+++ b/tests/fabric/adapter/test_basic.py
@@ -29,6 +29,7 @@ from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCo
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
+from dbt.tests.util import AnyInteger
 
 
 class TestSimpleMaterializations(BaseSimpleMaterializations):
@@ -100,6 +101,25 @@ class TestValidateConnectionFabric(BaseValidateConnection):
     pass
 
 
+def _row_count_stats():
+    return {
+        "has_stats": {
+            "id": "has_stats",
+            "label": "Has Stats?",
+            "value": True,
+            "description": "Indicates whether there are statistics for this table",
+            "include": False,
+        },
+        "row_count": {
+            "id": "row_count",
+            "label": "Row Count",
+            "value": AnyInteger(),
+            "description": "An approximate count of rows in this table",
+            "include": True,
+        },
+    }
+
+
 class TestDocsGenerateFabric(BaseDocsGenerate):
     @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):
@@ -112,6 +132,7 @@ class TestDocsGenerateFabric(BaseDocsGenerate):
             view_type="VIEW",
             table_type="BASE TABLE",
             model_stats=expected_catalog.no_stats(),
+            seed_stats=_row_count_stats(),
         )
 
 
@@ -127,7 +148,9 @@ class TestDocsGenReferencesFabric(BaseDocsGenReferences):
             bigint_type="int",
             view_type="VIEW",
             table_type="BASE TABLE",
-            model_stats=expected_catalog.no_stats(),
+            model_stats=_row_count_stats(),
+            seed_stats=_row_count_stats(),
+            view_summary_stats=expected_catalog.no_stats(),
         )
 
     @pytest.fixture(scope="class")

--- a/tests/fabric/adapter/test_catalog_columns.py
+++ b/tests/fabric/adapter/test_catalog_columns.py
@@ -109,10 +109,30 @@ class TestCatalogColumnsPopulated:
                 f"Column '{col_name}': expected type containing '{expected_type}', got '{actual_type}'"
             )
 
+    def test_table_has_row_count_stat(self, catalog: CatalogArtifact):
+        node = catalog.nodes["model.test.catalog_columns_table"]
+        assert "row_count" in node.stats, "Table model should have row_count stat"
+        stat = node.stats["row_count"]
+        assert stat.label == "Row Count"
+        assert stat.include is True
+        assert isinstance(stat.value, (int, float))
+        assert stat.value >= 0
+
+    def test_seed_has_row_count_stat(self, catalog: CatalogArtifact):
+        node = catalog.nodes["seed.test.catalog_columns_seed"]
+        assert "row_count" in node.stats, "Seed should have row_count stat"
+        stat = node.stats["row_count"]
+        assert stat.include is True
+        assert isinstance(stat.value, (int, float))
+        assert stat.value >= 0
+
+    def test_view_has_no_row_count_stat(self, catalog: CatalogArtifact):
+        node = catalog.nodes["model.test.catalog_columns_view"]
+        if "row_count" in node.stats:
+            assert node.stats["row_count"].include is False
+
     def test_column_indexes_are_sequential(self, catalog: CatalogArtifact):
         node = catalog.nodes["model.test.catalog_columns_table"]
         indexes = sorted(col.index for col in node.columns.values())
         expected = list(range(indexes[0], indexes[0] + len(indexes)))
-        assert indexes == expected, (
-            f"Column indexes should be sequential, got {indexes}"
-        )
+        assert indexes == expected, f"Column indexes should be sequential, got {indexes}"


### PR DESCRIPTION
## Summary
- Add approximate row counts to `dbt docs generate` output using `OBJECTPROPERTYEX(object_id, 'Cardinality')` to retrieve the optimizer's row count estimate for each table
- Add documentation page for catalog statistics feature
- Update feature comparison page

## Test plan
- [ ] `uv run pytest --dw -k "TestBasic or TestCatalogColumns" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)