### PR TITLE
Add CLUSTER BY support for Fabric DW tables

### DIFF
--- a/docs/cluster-by.md
+++ b/docs/cluster-by.md
@@ -1,0 +1,133 @@
+# CLUSTER BY
+
+Fabric Data Warehouse supports [automatic data clustering](https://learn.microsoft.com/fabric/data-warehouse/statistics#automatic-clustering?WT.mc_id=MVP_310840) via the `CLUSTER BY` clause on `CREATE TABLE` statements. Clustering organizes data physically on disk based on the specified columns, which can significantly improve query performance for filters and joins on those columns.
+
+This adapter lets you configure clustering directly from your dbt model using the `cluster_by` config option.
+
+---
+
+## Usage
+
+Add `cluster_by` to your model's config block. It accepts a single column name or a list of column names:
+
+=== "Single column"
+
+    ```sql title="models/orders.sql"
+    {{ config(
+        materialized='table',
+        cluster_by='order_date'
+    ) }}
+
+    select
+        order_id,
+        order_date,
+        customer_id,
+        total_amount
+    from {{ source('raw', 'orders') }}
+    ```
+
+=== "Multiple columns"
+
+    ```sql title="models/orders.sql"
+    {{ config(
+        materialized='table',
+        cluster_by=['customer_id', 'order_date']
+    ) }}
+
+    select
+        order_id,
+        order_date,
+        customer_id,
+        total_amount
+    from {{ source('raw', 'orders') }}
+    ```
+
+=== "In dbt_project.yml"
+
+    ```yaml title="dbt_project.yml"
+    models:
+      my_project:
+        marts:
+          +cluster_by: ['customer_id', 'order_date']
+    ```
+
+The generated SQL will look like:
+
+```sql
+CREATE TABLE [schema].[orders]
+WITH (CLUSTER BY ([customer_id], [order_date]))
+AS select ...
+```
+
+---
+
+## Works with model contracts
+
+If your model has [contract enforcement](https://docs.getdbt.com/docs/collaborate/govern/model-contracts) enabled, the `CLUSTER BY` clause is added to the `CREATE TABLE` statement alongside the column constraints:
+
+```sql title="models/orders.sql"
+{{ config(
+    materialized='table',
+    cluster_by=['customer_id', 'order_date']
+) }}
+
+select
+    order_id,
+    order_date,
+    customer_id,
+    total_amount
+from {{ source('raw', 'orders') }}
+```
+
+```yaml title="models/schema.yml"
+models:
+  - name: orders
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: order_id
+        data_type: int
+      - name: order_date
+        data_type: date
+      - name: customer_id
+        data_type: int
+      - name: total_amount
+        data_type: decimal(18, 2)
+```
+
+---
+
+## Works with incremental models
+
+Clustering is also applied when incremental models create their initial table (full refresh or first run):
+
+```sql title="models/orders_incremental.sql"
+{{ config(
+    materialized='incremental',
+    unique_key='order_id',
+    cluster_by=['order_date']
+) }}
+
+select
+    order_id,
+    order_date,
+    customer_id,
+    total_amount
+from {{ source('raw', 'orders') }}
+{% if is_incremental() %}
+where order_date > (select max(order_date) from {{ this }})
+{% endif %}
+```
+
+---
+
+## When to use clustering
+
+Clustering is most effective when:
+
+- You frequently filter or join on specific columns (e.g. date columns, foreign keys)
+- Your table is large enough that physical data organization matters
+- The clustered columns have moderate cardinality
+
+Fabric manages the clustering automatically after the initial `CLUSTER BY` declaration — there is no need to manually re-cluster or maintain the data layout.

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -83,6 +83,19 @@ select * from source('my_source', 'my_table')
 {% endif %}
 ```
 
+## [CLUSTER BY](cluster-by.md) support
+
+Fabric Data Warehouse supports automatic data clustering via the `CLUSTER BY` clause, which organizes data physically on disk for better query performance. Microsoft's dbt-fabric adapter does not expose this feature. This adapter lets you configure clustering directly from your model config:
+
+```sql
+{{ config(
+    materialized='table',
+    cluster_by=['customer_id', 'order_date']
+) }}
+```
+
+This works with regular tables, incremental models, and models with contract enforcement.
+
 ## Better support for [warehouse snapshots](warehouse-snapshots.md)
 
 Both adapters support Fabric [warehouse snapshots](https://learn.microsoft.com/fabric/data-warehouse/warehouse-snapshot?WT.mc_id=MVP_310840), but Microsoft's implementation hijacks Python runtime components and does not respect the proper dbt lifecycle. This adapter exposes a macro you can call from `on-run-start`, `on-run-end`, `post-hook`, or any other Jinja context — giving you full control over when and how often snapshots are taken.

--- a/src/dbt/adapters/fabric/fabric_configs.py
+++ b/src/dbt/adapters/fabric/fabric_configs.py
@@ -6,3 +6,4 @@ from dbt.adapters.protocol import AdapterConfig
 @dataclass
 class FabricConfigs(AdapterConfig):
     auto_provision_aad_principals: bool | None = False
+    cluster_by: str | list[str] | None = None

--- a/src/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -13,6 +13,17 @@
 {% endmacro %}
 
 
+{% macro fabric__build_cluster_by_clause() %}
+    {%- set cluster_by = config.get('cluster_by') -%}
+    {%- if cluster_by is not none -%}
+        {%- if cluster_by is string -%}
+            {%- set cluster_by = [cluster_by] -%}
+        {%- endif -%}
+        WITH (CLUSTER BY ({{ cluster_by | join(', ') }}))
+    {%- endif -%}
+{% endmacro %}
+
+
 {% macro fabric__create_table_as(temporary, relation, compiled_code, language='sql') -%}
     {%- if language == 'sql' -%}
         {% set query_label = apply_label() %}
@@ -31,6 +42,7 @@
             CREATE TABLE {{relation}}
             {{ build_columns_constraints(relation) }}
             {{ get_assert_columns_equivalent(compiled_code)  }}
+            {{ fabric__build_cluster_by_clause() }}
 
             {% set listColumns %}
                 {% for column in model['columns'] %}
@@ -47,7 +59,9 @@
 
         {%- else %}
 
-            CREATE TABLE {{relation}} AS {{compiled_code}} {{ query_label }}
+            CREATE TABLE {{relation}}
+            {{ fabric__build_cluster_by_clause() }}
+            AS {{compiled_code}} {{ query_label }}
 
         {% endif %}
     {%- elif language == "python" -%}

--- a/src/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -13,13 +13,23 @@
 {% endmacro %}
 
 
-{% macro fabric__build_cluster_by_clause() %}
-    {%- set cluster_by = config.get('cluster_by') -%}
-    {%- if cluster_by is not none -%}
-        {%- if cluster_by is string -%}
-            {%- set cluster_by = [cluster_by] -%}
+{% macro build_cluster_by_clause(temporary) %}
+    {{ return(adapter.dispatch('build_cluster_by_clause', 'dbt')(temporary)) }}
+{% endmacro %}
+
+{% macro fabric__build_cluster_by_clause(temporary) %}
+    {%- if not temporary -%}
+        {%- set cluster_by = config.get('cluster_by') -%}
+        {%- if cluster_by is not none -%}
+            {%- if cluster_by is string -%}
+                {%- set cluster_by = [cluster_by] -%}
+            {%- endif -%}
+            {%- set quoted_columns = [] -%}
+            {%- for col in cluster_by -%}
+                {%- do quoted_columns.append('[' ~ col | replace(']', ']]') ~ ']') -%}
+            {%- endfor -%}
+            WITH (CLUSTER BY ({{ quoted_columns | join(', ') }}))
         {%- endif -%}
-        WITH (CLUSTER BY ({{ cluster_by | join(', ') }}))
     {%- endif -%}
 {% endmacro %}
 
@@ -42,7 +52,7 @@
             CREATE TABLE {{relation}}
             {{ build_columns_constraints(relation) }}
             {{ get_assert_columns_equivalent(compiled_code)  }}
-            {{ fabric__build_cluster_by_clause() }}
+            {{ build_cluster_by_clause(temporary) }}
 
             {% set listColumns %}
                 {% for column in model['columns'] %}
@@ -60,7 +70,7 @@
         {%- else %}
 
             CREATE TABLE {{relation}}
-            {{ fabric__build_cluster_by_clause() }}
+            {{ build_cluster_by_clause(temporary) }}
             AS {{compiled_code}} {{ query_label }}
 
         {% endif %}

--- a/tests/fabric/adapter/test_cluster_by.py
+++ b/tests/fabric/adapter/test_cluster_by.py
@@ -1,0 +1,104 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+model_single_cluster = """
+{{ config(materialized='table', cluster_by='id') }}
+select 1 as id, 'blue' as color
+"""
+
+model_multi_cluster = """
+{{ config(materialized='table', cluster_by=['id', 'color']) }}
+select 1 as id, 'blue' as color, cast('2024-01-01' as date) as date_day
+"""
+
+model_no_cluster = """
+{{ config(materialized='table') }}
+select 1 as id, 'blue' as color
+"""
+
+model_cluster_contract = """
+{{ config(materialized='table', cluster_by=['id', 'color']) }}
+select 1 as id, cast('blue' as varchar(100)) as color
+"""
+
+model_cluster_contract_schema = """
+version: 2
+models:
+  - name: model_cluster_contract
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+      - name: color
+        data_type: varchar(100)
+"""
+
+model_cluster_incremental = """
+{{ config(materialized='incremental', cluster_by=['id'], unique_key='id') }}
+select 1 as id, 'blue' as color
+"""
+
+
+class TestClusterBySingleColumn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_single.sql": model_single_cluster}
+
+    def test_cluster_by_single(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+class TestClusterByMultipleColumns:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_multi.sql": model_multi_cluster}
+
+    def test_cluster_by_multi(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+class TestClusterByNoCluster:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_no_cluster.sql": model_no_cluster}
+
+    def test_no_cluster_by(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+class TestClusterByWithContract:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_cluster_contract.sql": model_cluster_contract,
+            "schema.yml": model_cluster_contract_schema,
+        }
+
+    def test_cluster_by_with_contract(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+
+class TestClusterByIncremental:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_cluster_incr.sql": model_cluster_incremental}
+
+    def test_cluster_by_incremental(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"

--- a/tests/fabric/adapter/test_cluster_by.py
+++ b/tests/fabric/adapter/test_cluster_by.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from dbt.tests.util import run_dbt
@@ -42,6 +44,13 @@ select 1 as id, 'blue' as color
 """
 
 
+def _read_compiled_sql(project, model_name):
+    run_dir = Path(project.project_root) / "target" / "run"
+    candidates = list(run_dir.rglob(f"{model_name}.sql"))
+    assert candidates, f"No compiled SQL found for {model_name} in {run_dir}"
+    return candidates[0].read_text()
+
+
 class TestClusterBySingleColumn:
     @pytest.fixture(scope="class")
     def models(self):
@@ -51,6 +60,10 @@ class TestClusterBySingleColumn:
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_single")
+        assert "CLUSTER BY" in compiled_sql
+        assert "[id]" in compiled_sql
 
 
 class TestClusterByMultipleColumns:
@@ -63,6 +76,11 @@ class TestClusterByMultipleColumns:
         assert len(results) == 1
         assert results[0].status == "success"
 
+        compiled_sql = _read_compiled_sql(project, "model_multi")
+        assert "CLUSTER BY" in compiled_sql
+        assert "[id]" in compiled_sql
+        assert "[color]" in compiled_sql
+
 
 class TestClusterByNoCluster:
     @pytest.fixture(scope="class")
@@ -73,6 +91,9 @@ class TestClusterByNoCluster:
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_no_cluster")
+        assert "CLUSTER BY" not in compiled_sql
 
 
 class TestClusterByWithContract:
@@ -88,6 +109,11 @@ class TestClusterByWithContract:
         assert len(results) == 1
         assert results[0].status == "success"
 
+        compiled_sql = _read_compiled_sql(project, "model_cluster_contract")
+        assert "CLUSTER BY" in compiled_sql
+        assert "[id]" in compiled_sql
+        assert "[color]" in compiled_sql
+
 
 class TestClusterByIncremental:
     @pytest.fixture(scope="class")
@@ -98,6 +124,10 @@ class TestClusterByIncremental:
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_cluster_incr")
+        assert "CLUSTER BY" in compiled_sql
+        assert "[id]" in compiled_sql
 
         results = run_dbt(["run"])
         assert len(results) == 1

--- a/zensical.toml
+++ b/zensical.toml
@@ -28,6 +28,7 @@ nav = [
   ] },
   { "Feature guides" = [
     { "Authentication" = "authentication.md" },
+    { "CLUSTER BY" = "cluster-by.md" },
     { "Python models" = "python-models.md" },
     { "Warehouse snapshots" = "warehouse-snapshots.md" },
   ] },


### PR DESCRIPTION
## Summary
- Add `cluster_by` configuration option for Fabric DW table materializations
- When specified, the CREATE TABLE includes a CLUSTER BY clause for automatic data clustering

## Test plan
- [x] `uv run pytest --dw -k "TestClusterBy" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)