### PR TITLE
FabricSpark adapter core improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,6 +446,8 @@ CI authenticates to Azure via OIDC (federated credentials, no secrets stored). T
 - **Lint rules**: isort (`I`) + no commented-out code (`ERA`)
 - **No comments in code** unless the _why_ is non-obvious
 - **Always run ruff before committing**: `uv run ruff format .` and `uv run ruff check --fix .` must pass before every commit
+- **PEP 604 union syntax**: use `X | Y` instead of `typing.Union[X, Y]` — the project targets Python 3.13 and has no `from typing import Union` imports
+- **Class constants at the top**: group all class-level constants together at the top of the class body, before any methods
 
 ## Key concepts for working on this adapter
 

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(__name__)
 _livy_session_thread_lock = threading.Lock()
 
 
+class FabricApiError(dbt_common.exceptions.DbtRuntimeError):
+    def __init__(self, method: str, url: str, status_code: int, response_text: str) -> None:
+        self.status_code = status_code
+        super().__init__(
+            f"{method} request to {url} failed with status code {status_code}: {response_text}"
+        )
+
+
 class FabricApiClient:
     _LIVY_API_VERSION = "2023-12-01"
     _WAREHOUSE_SNAPSHOT_TIMEOUT_SECONDS = 60 * 30  # 30 minutes
@@ -60,9 +68,7 @@ class FabricApiClient:
             return self._api_request(url, method, body)
 
         if not (200 <= response.status_code < 300):
-            raise dbt_common.exceptions.DbtRuntimeError(
-                f"{method} request to {url} failed with status code {response.status_code}: {response.text}"
-            )
+            raise FabricApiError(method, url, response.status_code, response.text)
         return response
 
     def _api_get(self, url: str) -> requests.Response:
@@ -331,12 +337,10 @@ class FabricApiClient:
                 response = self._api_post(url, body)
                 time.sleep(10)
                 return response.json()["id"]
-            except dbt_common.exceptions.DbtRuntimeError as e:
-                error_msg = str(e)
-                is_404 = "status code 404" in error_msg
-                is_5xx = any(f"status code {c}" in error_msg for c in range(500, 600))
+            except FabricApiError as e:
+                is_transient = e.status_code == 404 or 500 <= e.status_code < 600
 
-                if not (is_404 or is_5xx) or attempt == max_attempts:
+                if not is_transient or attempt == max_attempts:
                     raise
 
                 last_exception = e

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import time
 import urllib.parse
@@ -8,6 +9,8 @@ import requests
 
 from dbt.adapters.fabric.base_credentials import BaseFabricCredentials
 from dbt.adapters.fabric.fabric_token_provider import FabricTokenProvider
+
+logger = logging.getLogger(__name__)
 
 _livy_session_thread_lock = threading.Lock()
 
@@ -317,9 +320,35 @@ class FabricApiClient:
 
     def initialize_livy_session(self) -> str:
         url = self.get_livy_base_api_uri() + "/sessions"
-        response = self._api_post(url, {"name": self._credentials.livy_session_name, "ttl": "30s"})
-        time.sleep(10)  # give it a moment to initialize before we try to use it
-        return response.json()["id"]
+        body = {"name": self._credentials.livy_session_name, "ttl": "30s"}
+
+        max_attempts = 3
+        backoff_seconds = 5
+        last_exception: Exception | None = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                response = self._api_post(url, body)
+                time.sleep(10)
+                return response.json()["id"]
+            except dbt_common.exceptions.DbtRuntimeError as e:
+                error_msg = str(e)
+                is_404 = "status code 404" in error_msg
+                is_5xx = any(f"status code {c}" in error_msg for c in range(500, 600))
+
+                if not (is_404 or is_5xx) or attempt == max_attempts:
+                    raise
+
+                last_exception = e
+                wait_time = backoff_seconds * (2 ** (attempt - 1))
+                logger.warning(
+                    f"Livy session creation returned a transient error (attempt {attempt}/{max_attempts}), "
+                    f"retrying in {wait_time}s: {e}"
+                )
+                time.sleep(wait_time)
+
+        assert last_exception is not None
+        raise last_exception
 
     def get_livy_session_id(self) -> str:
         if self._livy_session_id is None:

--- a/src/dbt/adapters/fabric/fabric_livy_session.py
+++ b/src/dbt/adapters/fabric/fabric_livy_session.py
@@ -1,6 +1,9 @@
+import json
 import time
 from dataclasses import dataclass, field
 from typing import Any
+
+import requests
 
 from dbt.adapters.base.impl import PythonSubmissionResult
 from dbt.adapters.events.logging import AdapterLogger
@@ -41,9 +44,35 @@ class LivySession:
     def get_logs_url(self) -> str:
         return f"https://app.fabric.microsoft.com/workloads/de-ds/sparkmonitor/{self._fabric_api_client.get_lakehouse_id()}/{self._fabric_api_client.get_livy_session_id()}"
 
+    _MAX_CONSECUTIVE_TRANSIENT_ERRORS = 5
+
     def wait_for_session_ready(self) -> None:
         start_time = time.time()
-        while self._fabric_api_client.get_livy_session_state() != "idle":
+        consecutive_errors = 0
+
+        while True:
+            try:
+                state = self._fabric_api_client.get_livy_session_state()
+                consecutive_errors = 0
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                json.JSONDecodeError,
+                requests.exceptions.RequestException,
+            ) as e:
+                consecutive_errors += 1
+                if consecutive_errors >= self._MAX_CONSECUTIVE_TRANSIENT_ERRORS:
+                    raise
+                logger.warning(
+                    f"Transient error polling Livy session state "
+                    f"({consecutive_errors}/{self._MAX_CONSECUTIVE_TRANSIENT_ERRORS}): {e}"
+                )
+                time.sleep(self._POLLING_INTERVAL)
+                continue
+
+            if state == "idle":
+                return
+
             if (
                 time.time() - start_time
                 >= self._fabric_api_client._credentials.spark_session_timeout

--- a/src/dbt/adapters/fabric/fabric_livy_session.py
+++ b/src/dbt/adapters/fabric/fabric_livy_session.py
@@ -37,14 +37,13 @@ class LivySessionResult:
 
 class LivySession:
     _POLLING_INTERVAL = 3  # seconds
+    _MAX_CONSECUTIVE_TRANSIENT_ERRORS = 5
 
     def __init__(self, fabric_api_client: FabricApiClient) -> None:
         self._fabric_api_client = fabric_api_client
 
     def get_logs_url(self) -> str:
         return f"https://app.fabric.microsoft.com/workloads/de-ds/sparkmonitor/{self._fabric_api_client.get_lakehouse_id()}/{self._fabric_api_client.get_livy_session_id()}"
-
-    _MAX_CONSECUTIVE_TRANSIENT_ERRORS = 5
 
     def wait_for_session_ready(self) -> None:
         start_time = time.time()
@@ -57,8 +56,8 @@ class LivySession:
             except (
                 requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout,
+                requests.exceptions.ChunkedEncodingError,
                 json.JSONDecodeError,
-                requests.exceptions.RequestException,
             ) as e:
                 consecutive_errors += 1
                 if consecutive_errors >= self._MAX_CONSECUTIVE_TRANSIENT_ERRORS:

--- a/src/dbt/adapters/fabricspark/fabricspark_connection_manager.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_connection_manager.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any, Union
+from typing import Any
 
 from dbt.adapters.contracts.connection import AdapterResponse, Connection, ConnectionState
 from dbt.adapters.events.logging import AdapterLogger
@@ -37,7 +37,7 @@ class FabricSparkConnectionManager(BaseFabricConnectionManager):
         )
 
     @classmethod
-    def data_type_code_to_name(cls, type_code: Union[type, str]) -> str:
+    def data_type_code_to_name(cls, type_code: type | str) -> str:
         if isinstance(type_code, str):
             return type_code
         return type_code.__name__.upper()

--- a/src/dbt/adapters/fabricspark/fabricspark_connection_manager.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_connection_manager.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Union
 
 from dbt.adapters.contracts.connection import AdapterResponse, Connection, ConnectionState
 from dbt.adapters.events.logging import AdapterLogger
@@ -35,6 +35,12 @@ class FabricSparkConnectionManager(BaseFabricConnectionManager):
             query_id=str(cursor.statement_id),
             code=cursor.status_code,
         )
+
+    @classmethod
+    def data_type_code_to_name(cls, type_code: Union[type, str]) -> str:
+        if isinstance(type_code, str):
+            return type_code
+        return type_code.__name__.upper()
 
     @classmethod
     def open(cls, connection: Connection) -> Connection:

--- a/src/dbt/adapters/fabricspark/fabricspark_relation.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_relation.py
@@ -9,6 +9,25 @@ from dbt.adapters.spark.relation import SparkIncludePolicy, SparkQuotePolicy
 from dbt.adapters.utils import classproperty
 
 
+# SparkQuotePolicy defaults database/schema to False, causing dbt to
+# lowercase those components in cache lookups — ApproximateMatchError
+# with mixed-case Fabric names. Override to True for case preservation.
+@dataclass
+class FabricSparkQuotePolicy(SparkQuotePolicy):
+    database: bool = True
+    schema: bool = True
+
+
+# SparkIncludePolicy defaults database to False because vanilla Spark
+# treats database and schema as synonyms. In Fabric Lakehouse they're
+# distinct: database = lakehouse name, schema = schema within it.
+# Include database so relations render as 3-part names, which is
+# required for cross-lakehouse writes.
+@dataclass
+class FabricSparkIncludePolicy(SparkIncludePolicy):
+    database: bool = True
+
+
 class FabricSparkRelationType(StrEnum):
     Table = "table"
     CTE = "cte"
@@ -22,8 +41,8 @@ class FabricSparkRelationType(StrEnum):
 
 @dataclass(frozen=True, eq=False, repr=False)
 class FabricSparkRelation(BaseRelation):
-    quote_policy: Policy = field(default_factory=lambda: SparkQuotePolicy())
-    include_policy: Policy = field(default_factory=lambda: SparkIncludePolicy())
+    quote_policy: Policy = field(default_factory=lambda: FabricSparkQuotePolicy())
+    include_policy: Policy = field(default_factory=lambda: FabricSparkIncludePolicy())
     quote_character: str = "`"
     require_alias: bool = False
     information: str | None = None

--- a/src/dbt/include/fabricspark/macros/adapters/string_literal.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/string_literal.sql
@@ -1,0 +1,3 @@
+{% macro fabricspark__string_literal(value) -%}
+    '{{ value }}'
+{%- endmacro %}

--- a/tests/unit/test_fabricspark_relation.py
+++ b/tests/unit/test_fabricspark_relation.py
@@ -1,3 +1,6 @@
+import pytest
+
+from dbt.adapters.exceptions.compilation import ApproximateMatchError
 from dbt.adapters.fabricspark.fabricspark_relation import (
     FabricSparkIncludePolicy,
     FabricSparkQuotePolicy,
@@ -102,11 +105,11 @@ class TestFabricSparkRelationCasePreservation:
             identifier="my_model",
         )
 
-    def test_no_approximate_match_error_on_mixed_case(self):
-        """When quote_policy.database/schema=True, matches() does exact
-        case-sensitive comparison. This prevents ApproximateMatchError
-        that would occur if the search terms were lowercased by
-        _make_match_kwargs but the stored values kept original case."""
+    def test_lowered_search_raises_approximate_match_error(self):
+        """With quote_policy.database/schema=True, matches() uses exact
+        case-sensitive comparison. Lowercased search terms will not
+        exact-match mixed-case stored values but will approximate-match,
+        raising ApproximateMatchError instead of silently returning True."""
         r = FabricSparkRelation.create(
             database="DBTTest",
             schema="TestSchema",
@@ -114,8 +117,9 @@ class TestFabricSparkRelationCasePreservation:
             type=FabricSparkRelationType.Table,
             dbt_created=True,
         )
-        assert r.matches(
-            database="DBTTest",
-            schema="TestSchema",
-            identifier="my_model",
-        )
+        with pytest.raises(ApproximateMatchError):
+            r.matches(
+                database="dbttest",
+                schema="testschema",
+                identifier="my_model",
+            )

--- a/tests/unit/test_fabricspark_relation.py
+++ b/tests/unit/test_fabricspark_relation.py
@@ -1,0 +1,121 @@
+from dbt.adapters.fabricspark.fabricspark_relation import (
+    FabricSparkIncludePolicy,
+    FabricSparkQuotePolicy,
+    FabricSparkRelation,
+    FabricSparkRelationType,
+)
+
+
+class TestFabricSparkQuotePolicy:
+    def test_database_and_schema_quoting_enabled(self):
+        policy = FabricSparkQuotePolicy()
+        assert policy.database is True
+        assert policy.schema is True
+        assert policy.identifier is False
+
+    def test_relation_default_quote_policy(self):
+        r = FabricSparkRelation.create(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        assert r.quote_policy.database is True
+        assert r.quote_policy.schema is True
+
+
+class TestFabricSparkIncludePolicy:
+    def test_database_included(self):
+        policy = FabricSparkIncludePolicy()
+        assert policy.database is True
+        assert policy.schema is True
+        assert policy.identifier is True
+
+    def test_relation_default_include_policy(self):
+        r = FabricSparkRelation.create(
+            database="my_lakehouse",
+            schema="dbo",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        assert r.include_policy.database is True
+
+
+class TestFabricSparkRelationRendering:
+    def test_renders_three_part_name(self):
+        r = FabricSparkRelation.create(
+            database="my_lakehouse",
+            schema="dbo",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        rendered = str(r)
+        assert rendered == "`my_lakehouse`.`dbo`.my_model"
+
+    def test_mixed_case_preserved_in_rendering(self):
+        r = FabricSparkRelation.create(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        rendered = str(r)
+        assert "`DBTTest`" in rendered
+        assert "`TestSchema`" in rendered
+
+    def test_identifier_not_quoted_by_default(self):
+        r = FabricSparkRelation.create(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        rendered = str(r)
+        assert "my_model" in rendered
+        assert "`my_model`" not in rendered
+
+    def test_without_identifier_renders_database_and_schema(self):
+        r = FabricSparkRelation.create(
+            database="my_lakehouse",
+            schema="dbo",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        without_id = r.without_identifier()
+        rendered = str(without_id)
+        assert "`my_lakehouse`" in rendered
+        assert "`dbo`" in rendered
+        assert "my_model" not in rendered
+
+
+class TestFabricSparkRelationCasePreservation:
+    def test_matches_preserves_case_when_quoted(self):
+        r = FabricSparkRelation.create(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+        )
+        assert r.matches(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+        )
+
+    def test_no_approximate_match_error_on_mixed_case(self):
+        """When quote_policy.database/schema=True, matches() does exact
+        case-sensitive comparison. This prevents ApproximateMatchError
+        that would occur if the search terms were lowercased by
+        _make_match_kwargs but the stored values kept original case."""
+        r = FabricSparkRelation.create(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+            type=FabricSparkRelationType.Table,
+            dbt_created=True,
+        )
+        assert r.matches(
+            database="DBTTest",
+            schema="TestSchema",
+            identifier="my_model",
+        )


### PR DESCRIPTION
## Summary
- Enable 3-part relation names for cross-lakehouse writes in FabricSpark
- Fix `ApproximateMatchError` for mixed-case database/schema names
- Add retry and transient error handling to Livy session management
- Add `fabricspark__string_literal` adapter macro for Spark SQL compatibility
- Add `data_type_code_to_name` mapping in FabricSpark connection manager

## Test plan
- [x] `uv run pytest tests/unit/test_fabricspark_relation.py -v`
- [x] `uv run pytest --de -v` — verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)