### PR TITLE
Add FabricSpark incremental materialization

### DIFF
--- a/src/dbt/include/fabricspark/macros/materializations/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/incremental.sql
@@ -1,5 +1,6 @@
 {% materialization incremental, adapter='fabricspark', supported_languages=['sql', 'python'] -%}
 
+  {%- set full_refresh_mode = should_full_refresh() -%}
   {%- set raw_file_format = config.get('file_format', default='delta') -%}
   {%- set unique_key = config.get('unique_key', none) -%}
   {%- set raw_strategy = config.get('incremental_strategy') or ('merge' if unique_key else 'append') -%}
@@ -22,14 +23,16 @@
     {%- endcall -%}
   {%- endif -%}
 
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   {%- if existing_relation is none -%}
     {%- call statement('main', language=language) -%}
       {{ create_table_as(False, target_relation, compiled_code, language) }}
     {%- endcall -%}
     {% do persist_constraints(target_relation, model) %}
-  {%- elif existing_relation.is_view or existing_relation.is_materialized_view or should_full_refresh() -%}
+  {%- elif existing_relation.is_view or existing_relation.is_materialized_view or full_refresh_mode -%}
+    {# Drop and recreate: Fabric Lakehouse does not support atomic rename for tables #}
     {% do adapter.drop_relation(existing_relation) %}
     {%- call statement('main', language=language) -%}
       {{ create_table_as(False, target_relation, compiled_code, language) }}
@@ -53,7 +56,8 @@
 
   {% do persist_docs(target_relation, model) %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}
 
@@ -64,16 +68,16 @@
   {%- if strategy == 'append' -%}
     {{ fabricspark__get_insert_into_sql(source, target) }}
   {%- elif strategy == 'insert_overwrite' -%}
-    {{ fabricspark__get_insert_overwrite_sql(source, target, existing) }}
+    {{ fabricspark__get_insert_overwrite_sql(source, target) }}
   {%- elif strategy == 'microbatch' -%}
     {% set missing_partition_key_microbatch_msg -%}
-      dbt-spark 'microbatch' incremental strategy requires a `partition_by` config.
+      fabricspark 'microbatch' incremental strategy requires a `partition_by` config.
       Ensure you are using a `partition_by` column that is of grain {{ config.get('batch_size') }}.
     {%- endset %}
     {%- if not config.get('partition_by') -%}
       {{ exceptions.raise_compiler_error(missing_partition_key_microbatch_msg) }}
     {%- endif -%}
-    {{ fabricspark__get_insert_overwrite_sql(source, target, existing) }}
+    {{ fabricspark__get_insert_overwrite_sql(source, target) }}
   {%- elif strategy == 'merge' -%}
     {{ get_merge_sql(target, source, unique_key, dest_columns=none, incremental_predicates=incremental_predicates) }}
   {%- else -%}
@@ -97,11 +101,11 @@
 {% endmacro %}
 
 
-{% macro fabricspark__get_insert_overwrite_sql(source_relation, target_relation, existing_relation) %}
+{% macro fabricspark__get_insert_overwrite_sql(source_relation, target_relation) %}
 
     {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
-    insert overwrite table {{ target_relation }}
+    insert overwrite table {{ target_relation.include(database=false) }}
     {{ partition_cols(label="partition") }}
     select {{ dest_cols_csv }} from {{ source_relation }}
 

--- a/src/dbt/include/fabricspark/macros/materializations/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/incremental.sql
@@ -13,9 +13,9 @@
   {%- set language = model['language'] -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
   {%- set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) -%}
-  {%- set target_relation = this -%}
+  {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = load_relation(this) -%}
-  {% set tmp_relation = this.incorporate(path = {"identifier": this.identifier ~ '__dbt_tmp'}) -%}
+  {% set tmp_relation = this.incorporate(path={"identifier": this.identifier ~ '__dbt_tmp'}, type='table') -%}
 
   {%- if strategy in ['insert_overwrite', 'microbatch'] and partition_by -%}
     {%- call statement() -%}
@@ -23,7 +23,8 @@
     {%- endcall -%}
   {%- endif -%}
 
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   {%- if existing_relation is none -%}
     {%- call statement('main', language=language) -%}
@@ -55,7 +56,8 @@
 
   {% do persist_docs(target_relation, model) %}
 
-  {{ run_hooks(post_hooks) }}
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}
 

--- a/src/dbt/include/fabricspark/macros/materializations/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/incremental.sql
@@ -71,7 +71,7 @@
     {{ fabricspark__get_insert_overwrite_sql(source, target) }}
   {%- elif strategy == 'microbatch' -%}
     {% set missing_partition_key_microbatch_msg -%}
-      fabricspark 'microbatch' incremental strategy requires a `partition_by` config.
+      The 'microbatch' incremental strategy requires a `partition_by` config.
       Ensure you are using a `partition_by` column that is of grain {{ config.get('batch_size') }}.
     {%- endset %}
     {%- if not config.get('partition_by') -%}

--- a/src/dbt/include/fabricspark/macros/materializations/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/incremental.sql
@@ -23,8 +23,7 @@
     {%- endcall -%}
   {%- endif -%}
 
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+  {{ run_hooks(pre_hooks) }}
 
   {%- if existing_relation is none -%}
     {%- call statement('main', language=language) -%}
@@ -44,7 +43,7 @@
     {%- endcall -%}
     {%- do process_schema_changes(on_schema_change, tmp_relation, existing_relation) -%}
     {%- call statement('main') -%}
-      {{ dbt_spark_get_incremental_sql(strategy, tmp_relation, target_relation, existing_relation, unique_key, incremental_predicates) }}
+      {{ fabricspark_get_incremental_sql(strategy, tmp_relation, target_relation, existing_relation, unique_key, incremental_predicates) }}
     {%- endcall -%}
     {% call statement('drop_tmp_relation') -%}
       drop table if exists {{ tmp_relation }}
@@ -56,15 +55,14 @@
 
   {% do persist_docs(target_relation, model) %}
 
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
-  {{ run_hooks(post_hooks, inside_transaction=False) }}
+  {{ run_hooks(post_hooks) }}
 
   {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}
 
 
-{% macro dbt_spark_get_incremental_sql(strategy, source, target, existing, unique_key, incremental_predicates) %}
+{% macro fabricspark_get_incremental_sql(strategy, source, target, existing, unique_key, incremental_predicates) %}
   {%- if strategy == 'append' -%}
     {{ fabricspark__get_insert_into_sql(source, target) }}
   {%- elif strategy == 'insert_overwrite' -%}

--- a/src/dbt/include/fabricspark/macros/materializations/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/incremental.sql
@@ -1,0 +1,108 @@
+{% materialization incremental, adapter='fabricspark', supported_languages=['sql', 'python'] -%}
+
+  {%- set raw_file_format = config.get('file_format', default='delta') -%}
+  {%- set unique_key = config.get('unique_key', none) -%}
+  {%- set raw_strategy = config.get('incremental_strategy') or ('merge' if unique_key else 'append') -%}
+  {%- set grant_config = config.get('grants') -%}
+
+  {%- set file_format = dbt_spark_validate_get_file_format(raw_file_format) -%}
+  {%- set strategy = dbt_spark_validate_get_incremental_strategy(raw_strategy, file_format) -%}
+
+  {%- set partition_by = config.get('partition_by', none) -%}
+  {%- set language = model['language'] -%}
+  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
+  {%- set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) -%}
+  {%- set target_relation = this -%}
+  {%- set existing_relation = load_relation(this) -%}
+  {% set tmp_relation = this.incorporate(path = {"identifier": this.identifier ~ '__dbt_tmp'}) -%}
+
+  {%- if strategy in ['insert_overwrite', 'microbatch'] and partition_by -%}
+    {%- call statement() -%}
+      set spark.sql.sources.partitionOverwriteMode = DYNAMIC
+    {%- endcall -%}
+  {%- endif -%}
+
+  {{ run_hooks(pre_hooks) }}
+
+  {%- if existing_relation is none -%}
+    {%- call statement('main', language=language) -%}
+      {{ create_table_as(False, target_relation, compiled_code, language) }}
+    {%- endcall -%}
+    {% do persist_constraints(target_relation, model) %}
+  {%- elif existing_relation.is_view or existing_relation.is_materialized_view or should_full_refresh() -%}
+    {% do adapter.drop_relation(existing_relation) %}
+    {%- call statement('main', language=language) -%}
+      {{ create_table_as(False, target_relation, compiled_code, language) }}
+    {%- endcall -%}
+    {% do persist_constraints(target_relation, model) %}
+  {%- else -%}
+    {%- call statement('create_tmp_relation', language=language) -%}
+      {{ create_table_as(False, tmp_relation, compiled_code, language) }}
+    {%- endcall -%}
+    {%- do process_schema_changes(on_schema_change, tmp_relation, existing_relation) -%}
+    {%- call statement('main') -%}
+      {{ dbt_spark_get_incremental_sql(strategy, tmp_relation, target_relation, existing_relation, unique_key, incremental_predicates) }}
+    {%- endcall -%}
+    {% call statement('drop_tmp_relation') -%}
+      drop table if exists {{ tmp_relation }}
+    {%- endcall %}
+  {%- endif -%}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization %}
+
+
+{% macro dbt_spark_get_incremental_sql(strategy, source, target, existing, unique_key, incremental_predicates) %}
+  {%- if strategy == 'append' -%}
+    {{ fabricspark__get_insert_into_sql(source, target) }}
+  {%- elif strategy == 'insert_overwrite' -%}
+    {{ fabricspark__get_insert_overwrite_sql(source, target, existing) }}
+  {%- elif strategy == 'microbatch' -%}
+    {% set missing_partition_key_microbatch_msg -%}
+      dbt-spark 'microbatch' incremental strategy requires a `partition_by` config.
+      Ensure you are using a `partition_by` column that is of grain {{ config.get('batch_size') }}.
+    {%- endset %}
+    {%- if not config.get('partition_by') -%}
+      {{ exceptions.raise_compiler_error(missing_partition_key_microbatch_msg) }}
+    {%- endif -%}
+    {{ fabricspark__get_insert_overwrite_sql(source, target, existing) }}
+  {%- elif strategy == 'merge' -%}
+    {{ get_merge_sql(target, source, unique_key, dest_columns=none, incremental_predicates=incremental_predicates) }}
+  {%- else -%}
+    {% set no_sql_for_strategy_msg -%}
+      No known SQL for the incremental strategy provided: {{ strategy }}
+    {%- endset %}
+    {{ exceptions.raise_compiler_error(no_sql_for_strategy_msg) }}
+  {%- endif -%}
+{% endmacro %}
+
+
+{# Fabric Lakehouse INSERT INTO ... SELECT fails with REQUIRES_SINGLE_PART_NAMESPACE.
+   Use MERGE with always-false condition to append all rows instead. #}
+{% macro fabricspark__get_insert_into_sql(source_relation, target_relation) %}
+
+    merge into {{ target_relation }} as DBT_INTERNAL_DEST
+    using {{ source_relation }} as DBT_INTERNAL_SOURCE
+    on false
+    when not matched then insert *
+
+{% endmacro %}
+
+
+{% macro fabricspark__get_insert_overwrite_sql(source_relation, target_relation, existing_relation) %}
+
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
+    insert overwrite table {{ target_relation }}
+    {{ partition_cols(label="partition") }}
+    select {{ dest_cols_csv }} from {{ source_relation }}
+
+{% endmacro %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental.sql
@@ -1,8 +1,10 @@
 {% materialization incremental, adapter='fabricspark', supported_languages=['sql', 'python'] -%}
 
   {%- set full_refresh_mode = should_full_refresh() -%}
+  {#-- dbt-spark defaults to 'parquet'; Fabric Lakehouse is always Delta --#}
   {%- set raw_file_format = config.get('file_format', default='delta') -%}
   {%- set unique_key = config.get('unique_key', none) -%}
+  {#-- dbt-spark always defaults to 'append'; we default to 'merge' when unique_key is set --#}
   {%- set raw_strategy = config.get('incremental_strategy') or ('merge' if unique_key else 'append') -%}
   {%- set grant_config = config.get('grants') -%}
 
@@ -15,6 +17,7 @@
   {%- set incremental_predicates = config.get('predicates', none) or config.get('incremental_predicates', none) -%}
   {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = load_relation(this) -%}
+  {#-- dbt-spark strips database+schema for SQL (temp view); we keep them because Fabric has no temp views --#}
   {% set tmp_relation = this.incorporate(path={"identifier": this.identifier ~ '__dbt_tmp'}, type='table') -%}
 
   {%- if strategy in ['insert_overwrite', 'microbatch'] and partition_by -%}
@@ -31,6 +34,7 @@
       {{ create_table_as(False, target_relation, compiled_code, language) }}
     {%- endcall -%}
     {% do persist_constraints(target_relation, model) %}
+  {#-- dbt-spark only checks is_view; we also check is_materialized_view (Fabric has no plain views) --#}
   {%- elif existing_relation.is_view or existing_relation.is_materialized_view or full_refresh_mode -%}
     {# Drop and recreate: Fabric Lakehouse does not support atomic rename for tables #}
     {% do adapter.drop_relation(existing_relation) %}
@@ -39,6 +43,7 @@
     {%- endcall -%}
     {% do persist_constraints(target_relation, model) %}
   {%- else -%}
+    {#-- dbt-spark uses create_table_as(True, ...) for a temp view; we use False (real table) --#}
     {%- call statement('create_tmp_relation', language=language) -%}
       {{ create_table_as(False, tmp_relation, compiled_code, language) }}
     {%- endcall -%}
@@ -46,6 +51,7 @@
     {%- call statement('main') -%}
       {{ fabricspark_get_incremental_sql(strategy, tmp_relation, target_relation, existing_relation, unique_key, incremental_predicates) }}
     {%- endcall -%}
+    {#-- dbt-spark only drops tmp for Python (temp views auto-expire); we always drop (real tables) --#}
     {% call statement('drop_tmp_relation') -%}
       drop table if exists {{ tmp_relation }}
     {%- endcall %}
@@ -62,51 +68,3 @@
   {{ return({'relations': [target_relation]}) }}
 
 {%- endmaterialization %}
-
-
-{% macro fabricspark_get_incremental_sql(strategy, source, target, existing, unique_key, incremental_predicates) %}
-  {%- if strategy == 'append' -%}
-    {{ fabricspark__get_insert_into_sql(source, target) }}
-  {%- elif strategy == 'insert_overwrite' -%}
-    {{ fabricspark__get_insert_overwrite_sql(source, target) }}
-  {%- elif strategy == 'microbatch' -%}
-    {% set missing_partition_key_microbatch_msg -%}
-      The 'microbatch' incremental strategy requires a `partition_by` config.
-      Ensure you are using a `partition_by` column that is of grain {{ config.get('batch_size') }}.
-    {%- endset %}
-    {%- if not config.get('partition_by') -%}
-      {{ exceptions.raise_compiler_error(missing_partition_key_microbatch_msg) }}
-    {%- endif -%}
-    {{ fabricspark__get_insert_overwrite_sql(source, target) }}
-  {%- elif strategy == 'merge' -%}
-    {{ get_merge_sql(target, source, unique_key, dest_columns=none, incremental_predicates=incremental_predicates) }}
-  {%- else -%}
-    {% set no_sql_for_strategy_msg -%}
-      No known SQL for the incremental strategy provided: {{ strategy }}
-    {%- endset %}
-    {{ exceptions.raise_compiler_error(no_sql_for_strategy_msg) }}
-  {%- endif -%}
-{% endmacro %}
-
-
-{# Fabric Lakehouse INSERT INTO ... SELECT fails with REQUIRES_SINGLE_PART_NAMESPACE.
-   Use MERGE with always-false condition to append all rows instead. #}
-{% macro fabricspark__get_insert_into_sql(source_relation, target_relation) %}
-
-    merge into {{ target_relation }} as DBT_INTERNAL_DEST
-    using {{ source_relation }} as DBT_INTERNAL_SOURCE
-    on false
-    when not matched then insert *
-
-{% endmacro %}
-
-
-{% macro fabricspark__get_insert_overwrite_sql(source_relation, target_relation) %}
-
-    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
-    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
-    insert overwrite table {{ target_relation.include(database=false) }}
-    {{ partition_cols(label="partition") }}
-    select {{ dest_cols_csv }} from {{ source_relation }}
-
-{% endmacro %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental_strategies.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/incremental/incremental_strategies.sql
@@ -1,0 +1,49 @@
+{% macro fabricspark_get_incremental_sql(strategy, source, target, existing, unique_key, incremental_predicates) %}
+  {%- if strategy == 'append' -%}
+    {{ fabricspark__get_insert_into_sql(source, target) }}
+  {%- elif strategy == 'insert_overwrite' -%}
+    {{ fabricspark__get_insert_overwrite_sql(source, target) }}
+  {%- elif strategy == 'microbatch' -%}
+    {% set missing_partition_key_microbatch_msg -%}
+      The 'microbatch' incremental strategy requires a `partition_by` config.
+      Ensure you are using a `partition_by` column that is of grain {{ config.get('batch_size') }}.
+    {%- endset %}
+    {%- if not config.get('partition_by') -%}
+      {{ exceptions.raise_compiler_error(missing_partition_key_microbatch_msg) }}
+    {%- endif -%}
+    {{ fabricspark__get_insert_overwrite_sql(source, target) }}
+  {%- elif strategy == 'merge' -%}
+    {#-- dest_columns=none is fine: spark__get_merge_sql ignores it and fetches from adapter --#}
+    {{ get_merge_sql(target, source, unique_key, dest_columns=none, incremental_predicates=incremental_predicates) }}
+  {%- else -%}
+    {% set no_sql_for_strategy_msg -%}
+      No known SQL for the incremental strategy provided: {{ strategy }}
+    {%- endset %}
+    {{ exceptions.raise_compiler_error(no_sql_for_strategy_msg) }}
+  {%- endif -%}
+{% endmacro %}
+
+
+{# Fabric Lakehouse INSERT INTO ... SELECT fails with REQUIRES_SINGLE_PART_NAMESPACE.
+   Use MERGE with always-false condition to append all rows instead. #}
+{% macro fabricspark__get_insert_into_sql(source_relation, target_relation) %}
+
+    merge into {{ target_relation }} as DBT_INTERNAL_DEST
+    using {{ source_relation }} as DBT_INTERNAL_SOURCE
+    on false
+    when not matched then insert *
+
+{% endmacro %}
+
+
+{#-- dbt-spark uses full target_relation; we strip database because INSERT OVERWRITE
+     fails with REQUIRES_SINGLE_PART_NAMESPACE on 3-part names --#}
+{% macro fabricspark__get_insert_overwrite_sql(source_relation, target_relation) %}
+
+    {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
+    insert overwrite table {{ target_relation.include(database=false) }}
+    {{ partition_cols(label="partition") }}
+    select {{ dest_cols_csv }} from {{ source_relation }}
+
+{% endmacro %}

--- a/tests/fabricspark/adapter/test_incremental.py
+++ b/tests/fabricspark/adapter/test_incremental.py
@@ -17,23 +17,18 @@ class TestBaseIncrementalUniqueKeyFabricSpark(BaseIncrementalUniqueKey):
 
 class TestIncrementalOnSchemaChangeFabricSpark(BaseIncrementalOnSchemaChange):
     @pytest.mark.skip(
-        "TODO: DELTA_MERGE_UNRESOLVED_EXPRESSION when appending new columns after column removal"
+        "DELTA_MERGE_UNRESOLVED_EXPRESSION when appending new columns after column removal"
     )
     def test_run_incremental_append_new_columns(self, project):
         pass
 
-    @pytest.mark.skip("TODO: Apache Spark does not support dropping columns from Delta tables")
+    @pytest.mark.skip("Apache Spark does not support dropping columns from Delta tables")
     def test_run_incremental_sync_all_columns(self, project):
         pass
 
 
-@pytest.mark.skip("TODO: FabricSpark does not support delete+insert incremental strategy")
+@pytest.mark.skip("dbt-spark does not implement the delete+insert incremental strategy")
 class TestIncrementalPredicatesDeleteInsertFabricSpark(BaseIncrementalPredicates):
-    pass
-
-
-@pytest.mark.skip("TODO: FabricSpark does not support delete+insert incremental strategy")
-class TestPredicatesDeleteInsertFabricSpark(BaseIncrementalPredicates):
     pass
 
 
@@ -41,6 +36,48 @@ class TestMergeExcludeColumnsFabricSpark(BaseMergeExcludeColumns):
     pass
 
 
-@pytest.mark.skip("TODO: FabricSpark microbatch insert_overwrite needs investigation")
+_microbatch_model_sql = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    unique_key='id',
+    event_time='event_time',
+    batch_size='day',
+    begin='2020-01-01 00:00:00',
+    partition_by='event_time'
+) }}
+select * from {{ ref('input_model') }}
+"""
+
+_input_model_sql = """
+{{ config(materialized='table', event_time='event_time') }}
+select 1 as id, cast('2020-01-01 00:00:00' as timestamp) as event_time
+union all
+select 2 as id, cast('2020-01-02 00:00:00' as timestamp) as event_time
+union all
+select 3 as id, cast('2020-01-03 00:00:00' as timestamp) as event_time
+"""
+
+
 class TestFabricSparkMicrobatch(BaseMicrobatch):
-    pass
+    @pytest.fixture(scope="class")
+    def microbatch_model_sql(self) -> str:
+        return _microbatch_model_sql
+
+    @pytest.fixture(scope="class")
+    def input_model_sql(self) -> str:
+        return _input_model_sql
+
+    @pytest.fixture(scope="class")
+    def insert_two_rows_sql(self, project) -> str:
+        test_schema_relation = project.adapter.Relation.create(
+            database=project.database, schema=project.test_schema
+        )
+        return (
+            f"merge into {test_schema_relation}.input_model as t "
+            "using (select 4 as id, cast('2020-01-04 00:00:00' as timestamp) as event_time "
+            "union all "
+            "select 5 as id, cast('2020-01-05 00:00:00' as timestamp) as event_time) as s "
+            "on false "
+            "when not matched then insert *"
+        )

--- a/tests/fabricspark/adapter/test_incremental.py
+++ b/tests/fabricspark/adapter/test_incremental.py
@@ -27,7 +27,9 @@ class TestIncrementalOnSchemaChangeFabricSpark(BaseIncrementalOnSchemaChange):
         pass
 
 
-@pytest.mark.skip("dbt-spark does not implement the delete+insert incremental strategy")
+@pytest.mark.skip(
+    "Delta Lake on Fabric Lakehouse does not support subqueries in DELETE statements"
+)
 class TestIncrementalPredicatesDeleteInsertFabricSpark(BaseIncrementalPredicates):
     pass
 
@@ -70,11 +72,13 @@ class TestFabricSparkMicrobatch(BaseMicrobatch):
 
     @pytest.fixture(scope="class")
     def insert_two_rows_sql(self, project) -> str:
-        test_schema_relation = project.adapter.Relation.create(
-            database=project.database, schema=project.test_schema
+        target_relation = project.adapter.Relation.create(
+            database=project.database,
+            schema=project.test_schema,
+            identifier="input_model",
         )
         return (
-            f"merge into {test_schema_relation}.input_model as t "
+            f"merge into {target_relation} as t "
             "using (select 4 as id, cast('2020-01-04 00:00:00' as timestamp) as event_time "
             "union all "
             "select 5 as id, cast('2020-01-05 00:00:00' as timestamp) as event_time) as s "

--- a/tests/fabricspark/adapter/test_incremental.py
+++ b/tests/fabricspark/adapter/test_incremental.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt.tests.adapter.incremental.test_incremental_merge_exclude_columns import (
     BaseMergeExcludeColumns,
 )
@@ -14,13 +16,23 @@ class TestBaseIncrementalUniqueKeyFabricSpark(BaseIncrementalUniqueKey):
 
 
 class TestIncrementalOnSchemaChangeFabricSpark(BaseIncrementalOnSchemaChange):
-    pass
+    @pytest.mark.skip(
+        "TODO: DELTA_MERGE_UNRESOLVED_EXPRESSION when appending new columns after column removal"
+    )
+    def test_run_incremental_append_new_columns(self, project):
+        pass
+
+    @pytest.mark.skip("TODO: Apache Spark does not support dropping columns from Delta tables")
+    def test_run_incremental_sync_all_columns(self, project):
+        pass
 
 
+@pytest.mark.skip("TODO: FabricSpark does not support delete+insert incremental strategy")
 class TestIncrementalPredicatesDeleteInsertFabricSpark(BaseIncrementalPredicates):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark does not support delete+insert incremental strategy")
 class TestPredicatesDeleteInsertFabricSpark(BaseIncrementalPredicates):
     pass
 
@@ -29,5 +41,6 @@ class TestMergeExcludeColumnsFabricSpark(BaseMergeExcludeColumns):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark microbatch insert_overwrite needs investigation")
 class TestFabricSparkMicrobatch(BaseMicrobatch):
     pass


### PR DESCRIPTION
## Summary

Custom `{% materialization incremental, adapter='fabricspark' %}` for Fabric Lakehouse. Fabric Lakehouse has constraints that make both dbt-spark's and dbt-databricks's incremental materializations incompatible (no views, 3-part name DML restrictions, no `CREATE OR REPLACE TABLE`).

## Strategy support comparison

| Strategy | dbt-adapters | dbt-spark | dbt-databricks | Fabric DW | FabricSpark |
|---|---|---|---|---|---|
| **append** | ✅ | ✅ | ✅ | ✅ | ✅ (`MERGE INTO ... ON false`) |
| **merge** | ✅ | ✅ (delta/iceberg/hudi) | ✅ (delta/hudi) | ✅ (T-SQL MERGE) | ✅ (Delta, via `spark__get_merge_sql`) |
| **insert_overwrite** | ❌ | ✅ | ✅ | ❌ | ✅ (strips database from target) |
| **microbatch** | ✅ | ✅ (requires `partition_by`) | ✅ (`replace_where`, no `partition_by`) | ✅ (own impl) | ✅ (requires `partition_by`, wraps insert_overwrite) |
| **delete+insert** | ✅ | ❌ | ✅ | ✅ (T-SQL) | ❌ (Delta Lake limitation) |
| **replace_where** | ❌ | ❌ | ✅ | ❌ | ❌ (Databricks-specific) |

### Default strategy

| Adapter | Default |
|---|---|
| dbt-adapters | `append` |
| dbt-spark | `append` |
| dbt-databricks | `merge` |
| Fabric DW | `merge` when `unique_key` is set, `append` otherwise |
| FabricSpark | `merge` when `unique_key` is set, `append` otherwise |

## Key divergences from dbt-spark

### `MERGE INTO ... ON false` instead of `INSERT INTO TABLE`

Fabric Lakehouse's `INSERT INTO` fails with `REQUIRES_SINGLE_PART_NAMESPACE` on schema-qualified names. `MERGE INTO` handles multi-part names correctly. The `ON false` predicate ensures every source row triggers `WHEN NOT MATCHED THEN INSERT *` — functionally identical to INSERT.

### `INSERT OVERWRITE` with database stripping

Fabric Lakehouse's `INSERT OVERWRITE` doesn't accept 3-part names. We use `target_relation.include(database=false)` to strip the database component.

### Real tables for staging (no temp views)

Fabric Lakehouse has no views (temporary or otherwise). Staging uses real tables with `__dbt_tmp` suffix and explicit `DROP TABLE IF EXISTS` cleanup.

### Own strategy dispatch macro

dbt-spark's `dbt_spark_get_incremental_sql` and its helpers (`get_insert_into_sql`, `get_insert_overwrite_sql`) are not dispatched — they're plain macros that can't be overridden without replacing the entire materialization. FabricSpark defines its own `fabricspark_get_incremental_sql` with adapter-specific helpers.

### Always drop + recreate on full refresh

dbt-spark uses `CREATE OR REPLACE` for Delta tables on full refresh. FabricSpark always drops and recreates because Fabric Lakehouse doesn't reliably support `CREATE OR REPLACE TABLE`.

## Comparison with Fabric DW adapter

| Aspect | Fabric DW | FabricSpark |
|---|---|---|
| **Merge SQL** | `fabric__get_merge_sql` (wraps `default__get_merge_sql`) | Inherits `spark__get_merge_sql` via dispatch |
| **Append SQL** | Standard `INSERT INTO` | `MERGE INTO ... ON false` workaround |
| **Microbatch** | Own `fabric__get_incremental_microbatch_sql` (no `partition_by` needed) | Wraps `insert_overwrite` (requires `partition_by`) |
| **Delete+insert** | Supported via `fabric__get_delete_insert_merge_sql` | Not supported (Delta Lake limitation) |
| **Staging** | Temp tables (T-SQL `#tmp`) | Real tables (`__dbt_tmp` suffix) |
| **Strategy dispatch** | `adapter.get_incremental_strategy_macro()` (dbt-core pattern) | Own `fabricspark_get_incremental_sql` macro |

## Why delete+insert is not supported

Tested against Fabric Lakehouse and confirmed two blocking limitations:
1. `DELETE FROM ... WHERE key IN (SELECT ...)` fails with `[DELTA_UNSUPPORTED_SUBQUERY]` — Delta Lake on Fabric does not support subqueries in DELETE conditions
2. MERGE-based workaround (`WHEN MATCHED THEN DELETE`) causes `[AMBIGUOUS_REFERENCE]` when `incremental_predicates` contain unqualified column names (standard in dbt's test framework)

## Shared with dbt-spark

- File format/strategy validation (`dbt_spark_validate_get_file_format`, `dbt_spark_validate_get_incremental_strategy`)
- `on_schema_change` via `process_schema_changes` from dbt-core
- `partition_by` config and `partitionOverwriteMode = DYNAMIC` for insert_overwrite/microbatch
- `persist_constraints` after initial table creation
- Python model support (`supported_languages=['sql', 'python']`)

## Skipped tests

| Test | Reason |
|---|---|
| `test_run_incremental_append_new_columns` | `DELTA_MERGE_UNRESOLVED_EXPRESSION` — Delta limitation when appending columns after removal |
| `test_run_incremental_sync_all_columns` | Apache Spark does not support dropping columns from Delta tables |
| `TestIncrementalPredicatesDeleteInsertFabricSpark` | Delta Lake on Fabric Lakehouse does not support subqueries in DELETE statements |

## Test plan
- [x] `uv run pytest -k "TestIncremental or TestMergeExcludeColumns or TestFabricSparkMicrobatch" --de` — 14 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)