### PR TITLE
Add FabricSpark snapshot and clone materializations

### DIFF
--- a/src/dbt/include/fabricspark/macros/materializations/clone.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/clone.sql
@@ -1,0 +1,32 @@
+{% macro fabricspark__can_clone_table() %}
+    {{ return(False) }}
+{% endmacro %}
+
+
+{% materialization clone, adapter='fabricspark' %}
+
+  {%- set relations = {'relations': []} -%}
+
+  {%- if not defer_relation -%}
+      {{ log("No relation found in state manifest for " ~ model.unique_id, info=True) }}
+      {{ return(relations) }}
+  {%- endif -%}
+
+  {%- set existing_relation = load_cached_relation(this) -%}
+
+  {%- if existing_relation and not flags.FULL_REFRESH -%}
+      {{ log("Relation " ~ existing_relation ~ " already exists", info=True) }}
+      {{ return(relations) }}
+  {%- endif -%}
+
+  {%- set target_relation = this.incorporate(type='materialized_view') -%}
+
+  {% set search_name = "materialization_materialized_view_" ~ adapter.type() %}
+  {% if not search_name in context %}
+      {% set search_name = "materialization_materialized_view_default" %}
+  {% endif %}
+  {% set materialization_macro = context[search_name] %}
+  {% set relations = materialization_macro() %}
+  {{ return(relations) }}
+
+{% endmaterialization %}

--- a/src/dbt/include/fabricspark/macros/materializations/snapshot.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/snapshot.sql
@@ -1,0 +1,184 @@
+{% macro fabricspark__build_snapshot_staging_table(strategy, sql, target_relation) %}
+    {% set tmp_identifier = target_relation.identifier ~ '__dbt_tmp' %}
+
+    {%- set tmp_relation = api.Relation.create(
+        identifier=tmp_identifier,
+        schema=target_relation.schema,
+        database=target_relation.database,
+        type='table'
+    ) -%}
+
+    {% set select = snapshot_staging_table(strategy, sql, target_relation) %}
+
+    {{ adapter.drop_relation(tmp_relation) }}
+
+    {% call statement('build_snapshot_staging_relation') %}
+        {{ create_table_as(False, tmp_relation, select) }}
+    {% endcall %}
+
+    {% do return(tmp_relation) %}
+{% endmacro %}
+
+
+{% materialization snapshot, adapter='fabricspark' %}
+
+  {%- set target_table = model.get('alias', model.get('name')) -%}
+
+  {%- set strategy_name = config.get('strategy') -%}
+  {%- set unique_key = config.get('unique_key') %}
+  {%- set file_format = config.get('file_format') or 'delta' -%}
+  {%- set grant_config = config.get('grants') -%}
+
+  {% set target_relation_exists, target_relation = get_or_create_relation(
+          database=model.database,
+          schema=model.schema,
+          identifier=target_table,
+          type='table') -%}
+
+  {%- if file_format not in ['delta', 'iceberg', 'hudi'] -%}
+    {% set invalid_format_msg -%}
+      Invalid file format: {{ file_format }}
+      Snapshot functionality requires file_format be set to 'delta' or 'iceberg' or 'hudi'
+    {%- endset %}
+    {% do exceptions.raise_compiler_error(invalid_format_msg) %}
+  {% endif %}
+
+  {%- if not target_relation.is_table -%}
+    {% do exceptions.relation_wrong_type(target_relation, 'table') %}
+  {%- endif -%}
+
+  {% if not adapter.check_schema_exists(model.database, model.schema) %}
+    {% do create_schema(model.schema) %}
+  {% endif %}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set strategy_macro = strategy_dispatch(strategy_name) %}
+  {% set strategy = strategy_macro(model, "snapshotted_data", "source_data", model['config'], target_relation_exists) %}
+
+  {% if not target_relation_exists %}
+
+      {% set build_sql = build_snapshot_table(strategy, model['compiled_code']) %}
+      {% set final_sql = create_table_as(False, target_relation, build_sql) %}
+
+  {% else %}
+
+      {% set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() %}
+
+      {{ adapter.valid_snapshot_target(target_relation, columns) }}
+
+      {% set staging_table = fabricspark__build_snapshot_staging_table(strategy, sql, target_relation) %}
+
+      {% do adapter.expand_target_column_types(from_relation=staging_table,
+                                               to_relation=target_relation) %}
+
+      {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)
+                                   | rejectattr('name', 'equalto', 'dbt_change_type')
+                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')
+                                   | rejectattr('name', 'equalto', 'dbt_unique_key')
+                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')
+                                   | list %}
+
+      {% do create_columns(target_relation, missing_columns) %}
+
+      {% set source_columns = adapter.get_columns_in_relation(staging_table)
+                                   | rejectattr('name', 'equalto', 'dbt_change_type')
+                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')
+                                   | rejectattr('name', 'equalto', 'dbt_unique_key')
+                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')
+                                   | list %}
+
+      {% set quoted_source_columns = [] %}
+      {% for column in source_columns %}
+        {% do quoted_source_columns.append(adapter.quote(column.name)) %}
+      {% endfor %}
+
+      {% set final_sql = snapshot_merge_sql(
+            target = target_relation,
+            source = staging_table,
+            insert_cols = quoted_source_columns
+         )
+      %}
+
+  {% endif %}
+
+  {% call statement('main') %}
+      {{ final_sql }}
+  {% endcall %}
+
+  {% set should_revoke = should_revoke(target_relation_exists, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke) %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ adapter.commit() }}
+
+  {% if staging_table is defined %}
+      {% do post_snapshot(staging_table) %}
+  {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{% endmaterialization %}
+
+
+{% macro fabricspark__post_snapshot(staging_relation) %}
+    {% do adapter.drop_relation(staging_relation) %}
+{% endmacro %}
+
+
+{% macro fabricspark__snapshot_hash_arguments(args) -%}
+    md5({%- for arg in args -%}
+        coalesce(cast({{ arg }} as string ), '')
+        {% if not loop.last %} || '|' || {% endif %}
+    {%- endfor -%})
+{%- endmacro %}
+
+
+{% macro fabricspark__snapshot_string_as_time(timestamp) -%}
+    {%- set result = "to_timestamp('" ~ timestamp ~ "')" -%}
+    {{ return(result) }}
+{%- endmacro %}
+
+
+{% macro fabricspark__snapshot_merge_sql(target, source, insert_cols) -%}
+    {%- set columns = config.get("snapshot_table_column_names") or get_snapshot_table_column_names() -%}
+
+    merge into {{ target }} as DBT_INTERNAL_DEST
+    using {{ source }} as DBT_INTERNAL_SOURCE
+    on DBT_INTERNAL_SOURCE.{{ columns.dbt_scd_id }} = DBT_INTERNAL_DEST.{{ columns.dbt_scd_id }}
+    when matched
+     {% if config.get("dbt_valid_to_current") %}
+       and ( DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} = {{ config.get('dbt_valid_to_current') }} or
+             DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null )
+     {% else %}
+       and DBT_INTERNAL_DEST.{{ columns.dbt_valid_to }} is null
+     {% endif %}
+     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
+        then update
+        set {{ columns.dbt_valid_to }} = DBT_INTERNAL_SOURCE.{{ columns.dbt_valid_to }}
+
+    when not matched
+     and DBT_INTERNAL_SOURCE.dbt_change_type = 'insert'
+        then insert *
+    ;
+{% endmacro %}
+
+
+{% macro fabricspark__create_columns(relation, columns) %}
+    {% if columns|length > 0 %}
+    {% call statement() %}
+      alter table {{ relation }} add columns (
+        {% for column in columns %}
+          `{{ column.name }}` {{ column.data_type }} {{- ',' if not loop.last -}}
+        {% endfor %}
+      );
+    {% endcall %}
+    {% endif %}
+{% endmacro %}

--- a/src/dbt/include/fabricspark/macros/materializations/snapshot.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/snapshot.sql
@@ -48,8 +48,10 @@
   {%- endif -%}
 
   {% if not adapter.check_schema_exists(model.database, model.schema) %}
-    {% do create_schema(model.schema) %}
+    {% do create_schema(target_relation) %}
   {% endif %}
+
+  {% set full_refresh_mode = should_full_refresh() %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
@@ -74,20 +76,22 @@
       {% do adapter.expand_target_column_types(from_relation=staging_table,
                                                to_relation=target_relation) %}
 
+      {% set remove_columns = ['dbt_change_type', 'DBT_CHANGE_TYPE', 'dbt_unique_key', 'DBT_UNIQUE_KEY'] %}
+      {% if unique_key | is_list %}
+          {% for key in strategy.unique_key %}
+              {{ remove_columns.append('dbt_unique_key_' + loop.index|string) }}
+              {{ remove_columns.append('DBT_UNIQUE_KEY_' + loop.index|string) }}
+          {% endfor %}
+      {% endif %}
+
       {% set missing_columns = adapter.get_missing_columns(staging_table, target_relation)
-                                   | rejectattr('name', 'equalto', 'dbt_change_type')
-                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')
-                                   | rejectattr('name', 'equalto', 'dbt_unique_key')
-                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')
+                                   | rejectattr('name', 'in', remove_columns)
                                    | list %}
 
       {% do create_columns(target_relation, missing_columns) %}
 
       {% set source_columns = adapter.get_columns_in_relation(staging_table)
-                                   | rejectattr('name', 'equalto', 'dbt_change_type')
-                                   | rejectattr('name', 'equalto', 'DBT_CHANGE_TYPE')
-                                   | rejectattr('name', 'equalto', 'dbt_unique_key')
-                                   | rejectattr('name', 'equalto', 'DBT_UNIQUE_KEY')
+                                   | rejectattr('name', 'in', remove_columns)
                                    | list %}
 
       {% set quoted_source_columns = [] %}

--- a/tests/fabricspark/adapter/test_dbt_clone.py
+++ b/tests/fabricspark/adapter/test_dbt_clone.py
@@ -1,22 +1,118 @@
+import pytest
+
+from dbt.tests.adapter.dbt_clone import fixtures
 from dbt.tests.adapter.dbt_clone.test_dbt_clone import (
     BaseCloneNotPossible,
-    BaseClonePossible,
-    BaseCloneSameSourceAndTarget,
     BaseCloneSameTargetAndState,
 )
+from dbt.tests.util import run_dbt
+
+fabricspark_view_model_sql = """
+{{ config(materialized='materialized_view') }}
+select * from {{ ref('seed') }}
+
+-- establish a macro dependency that trips infinite recursion if not handled
+-- depends on: {{ my_infinitely_recursive_macro() }}
+"""
+
+fabricspark_snapshot_sql = """
+{% snapshot my_cool_snapshot %}
+
+    {{
+        config(
+            target_database=database,
+            target_schema=schema,
+            unique_key='id',
+            strategy='check',
+            check_cols=['id'],
+            file_format='delta',
+        )
+    }}
+    select * from {{ ref('view_model') }}
+
+{% endsnapshot %}
+"""
 
 
 class TestFabricSparkCloneNotPossible(BaseCloneNotPossible):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model.sql": fixtures.table_model_sql,
+            "view_model.sql": fabricspark_view_model_sql,
+            "ephemeral_model.sql": fixtures.ephemeral_model_sql,
+            "schema.yml": fixtures.schema_yml,
+            "exposures.yml": fixtures.exposures_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {
+            "snapshot.sql": fabricspark_snapshot_sql,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "macros.sql": fixtures.macros_sql,
+            "my_can_clone_tables.sql": fixtures.custom_can_clone_tables_false_macros_sql,
+            "infinite_macros.sql": fixtures.infinite_macros_sql,
+            "get_schema_name.sql": fixtures.get_schema_name_sql,
+        }
+
+    def test_can_clone_false(self, project, unique_schema, other_schema):
+        project.create_test_schema(other_schema)
+        self.run_and_save_state(project.project_root, with_snapshot=True)
+
+        clone_args = [
+            "clone",
+            "--state",
+            "state",
+            "--target",
+            "otherschema",
+        ]
+
+        results = run_dbt(clone_args)
+        assert len(results) == 4
+
+        schema_relations = project.adapter.list_relations(
+            database=project.database, schema=other_schema
+        )
+        assert all(r.type == "materialized_view" for r in schema_relations)
+
+        results = run_dbt(clone_args)
+        assert len(results) == 4
+        assert all("no-op" in r.message.lower() for r in results)
+
+        results = run_dbt([*clone_args, "--full-refresh"])
+        assert len(results) == 4
+
+        results = run_dbt([*clone_args, "--resource-type", "model"])
+        assert len(results) == 2
+        assert all("no-op" in r.message.lower() for r in results)
 
 
 class TestFabricSparkCloneSameTargetAndState(BaseCloneSameTargetAndState):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model.sql": fixtures.table_model_sql,
+            "view_model.sql": fabricspark_view_model_sql,
+            "ephemeral_model.sql": fixtures.ephemeral_model_sql,
+            "schema.yml": fixtures.schema_yml,
+            "exposures.yml": fixtures.exposures_yml,
+        }
+
+
+@pytest.mark.skip(
+    "TODO: Fabric Lakehouse does not support SHALLOW CLONE (Databricks-specific Delta feature)"
+)
+class TestFabricSparkClonePossible(BaseCloneNotPossible):
     pass
 
 
-class TestFabricSparkClonePossible(BaseClonePossible):
-    pass
-
-
-class TestFabricSparkCloneSameSourceAndTarget(BaseCloneSameSourceAndTarget):
+@pytest.mark.skip(
+    "TODO: Fabric Lakehouse does not support SHALLOW CLONE (Databricks-specific Delta feature)"
+)
+class TestFabricSparkCloneSameSourceAndTarget(BaseCloneNotPossible):
     pass

--- a/tests/fabricspark/adapter/test_simple_snapshot.py
+++ b/tests/fabricspark/adapter/test_simple_snapshot.py
@@ -6,7 +6,12 @@ from dbt.tests.adapter.simple_snapshot.test_snapshot import (
 
 
 class TestSimpleSnapshotFabricSpark(BaseSimpleSnapshot, BaseSimpleSnapshotBase):
-    pass
+    def add_fact_column(self, column=None, definition=None):
+        if definition and "default" in definition.lower():
+            definition = definition[: definition.lower().index("default")].strip()
+        if definition and "varchar" in definition.lower():
+            definition = "string"
+        super().add_fact_column(column, definition)
 
 
 class TestSnapshotCheckFabricSpark(BaseSnapshotCheck, BaseSimpleSnapshotBase):


### PR DESCRIPTION
## Summary
- Add snapshot materialization for Fabric Lakehouse that uses real tables for staging (not views)
- Add clone materialization that falls back to materialized_view instead of view
- Provide snapshot_merge_sql, snapshot_hash_arguments, snapshot_string_as_time, create_columns, and post_snapshot macros

## Implementation details

### Snapshot materialization

The FabricSpark snapshot is a custom `{% materialization snapshot, adapter='fabricspark' %}` because Fabric Lakehouse has constraints that make both dbt-core's default and dbt-spark's snapshot materializations incompatible.

#### Comparison with dbt-spark

The implementation is **based on dbt-spark's snapshot materialization** (`dbt/include/spark/macros/materializations/snapshot.sql`) but diverges in key areas:

| Aspect | dbt-spark | dbt-fabric (FabricSpark) | Why the difference |
|---|---|---|---|
| **Staging relation** | Non-temp **view** via `spark_build_snapshot_staging_table` (hardcoded function, not dispatched) | Real **table** via `fabricspark__build_snapshot_staging_table` (dispatched) | Fabric Lakehouse with schemas does not support Spark SQL views — only tables and materialized lake views. Creating a view would fail. |
| **Staging function call** | Calls `spark_build_snapshot_staging_table()` directly (non-dispatched, Spark-specific) | Calls `fabricspark__build_snapshot_staging_table()` (dispatched via adapter prefix) | FabricSpark can't inherit Spark's hardcoded call since it would create a view. Using dispatch allows clean override. |
| **Iceberg source reference** | `snapshot_merge_sql` uses `source.identifier` (bare name) for Iceberg targets | No Iceberg-specific handling | Fabric Lakehouse only supports Delta — Iceberg and Hudi are not available. |
| **File format validation** | Allows `delta`, `iceberg`, `hudi` (default: `parquet` → error) | Allows `delta`, `iceberg`, `hudi` (kept for forward-compat, default: `delta`) | Fabric currently only uses Delta, but validation is kept broad for potential future support. |
| **Database parameter** | Passes `database=none` everywhere (SparkRelation forbids it) | Passes `database=model.database` | FabricSpark relations support the database component (3-part names). |
| **Schema creation** | `create_schema(model.schema)` (passes string) | `create_schema(target_relation)` (passes relation) | FabricSpark's `create_schema` macro expects a relation object, not a string. |

#### Comparison with dbt-databricks

| Aspect | dbt-databricks | dbt-fabric (FabricSpark) | Why the difference |
|---|---|---|---|
| **Staging relation** | Temporary **view** via `databricks__make_temp_relation` + `create_temporary_view` | Real **table** | Fabric Lakehouse does not support temporary views or regular views. Tables are the only option for staging. |
| **`get_or_create_relation`** | Custom override with `needs_information=True` for metadata fetching | Uses default `get_or_create_relation` | Databricks needs delta/iceberg/hudi metadata on the relation object; FabricSpark only needs Delta. |
| **Optimizations** | Runs `OPTIMIZE` on snapshot table after merge | No optimization step | Fabric Lakehouse handles Delta optimization internally. |
| **Tags/constraints** | Applies tags, persists constraints after snapshot | No tag support | Fabric Lakehouse doesn't support Databricks-style table tags. |
| **`snapshot_staging_table` query** | Custom override for `dbt_is_deleted` (boolean `false`/`true` instead of string) | Uses dbt-core default | No hard-delete customization needed at this point. |

#### Macros that match dbt-spark exactly

These macros are functionally identical to dbt-spark's implementations because they use the same Spark SQL dialect:

- **`snapshot_hash_arguments`**: `md5(coalesce(cast(x as string), '') || '|' || ...)` — same as `spark__snapshot_hash_arguments`
- **`snapshot_string_as_time`**: `to_timestamp('...')` — same as `spark__snapshot_string_as_time`
- **`create_columns`**: `ALTER TABLE ... ADD COLUMNS (...)` with backtick quoting — same as `spark__create_columns`
- **`post_snapshot`**: `adapter.drop_relation(staging_relation)` — same as `spark__post_snapshot`
- **`snapshot_merge_sql`**: `MERGE INTO ... USING ... ON scd_id` with `insert *` — same as `spark__snapshot_merge_sql` but without Iceberg handling

### Clone materialization

#### Comparison with dbt-spark and dbt-databricks

| Aspect | dbt-spark | dbt-databricks | dbt-fabric (FabricSpark) |
|---|---|---|---|
| **`can_clone_table()`** | `True` (Delta shallow clone) | `True` (Delta shallow clone) | **`False`** |
| **Clone SQL** | `CREATE OR REPLACE TABLE ... SHALLOW CLONE ...` | Same + `LOCATION` clause for external tables | N/A — cloning disabled |
| **Fallback** | View materialization (dead code — format check errors first) | View materialization | **Materialized view** |
| **Why** | Delta Lake supports `SHALLOW CLONE` natively | Databricks extends with external table support | Fabric Lakehouse **does not support `SHALLOW CLONE`** — it's a Databricks-specific Delta Lake extension, not part of the open Delta Lake spec that Fabric implements |

The clone materialization delegates to the `materialized_view` materialization (Fabric's lake view) instead of `view` because Fabric Lakehouse with schemas does not support Spark SQL views.

### Test changes

- **`test_simple_snapshot.py`**: Overrides `add_fact_column` to strip `DEFAULT` clauses (unsupported in Fabric Lakehouse `ALTER TABLE ADD COLUMNS`) and convert `varchar` to `string` (Spark SQL type).
- **`test_dbt_clone.py`**: Overrides fixtures to use `materialized_view` instead of `view`. Asserts cloned relations are `materialized_view` type. Skips `ClonePossible` and `CloneSameSourceAndTarget` tests because `SHALLOW CLONE` is unavailable.

## Test plan
- [ ] `uv run pytest --de -k "TestSnapshot or TestClone" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)