### PR TITLE
Fix Cloudflare Pages build

### DIFF
--- a/docs_build/cloudflare_pages.sh
+++ b/docs_build/cloudflare_pages.sh
@@ -4,6 +4,6 @@ set -ex
 
 cd ..
 
-uv run --only-group docs zensical build -d ./docs_build/site
+uv run --only-group docs zensical build
 
 curl -sLo ./docs_build/site/t.js "https://cloud.umami.is/script.js"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,4 +1,5 @@
 [project]
+site_dir = "docs_build/site"
 site_name = "dbt-fabric-samdebruyn"
 site_description = "Documentation for dbt-fabric-samdebruyn"
 site_url = "https://dbt-fabric.debruyn.dev"


### PR DESCRIPTION
## Summary
- `zensical build` doesn't support the `-d` flag — it was causing the build to fail with "No such option: -d"
- Configured `site_dir = "docs_build/site"` in `zensical.toml` instead, which achieves the same output path

## Test plan
- [x] Verified `uv run --only-group docs zensical build` succeeds locally
- [x] Verified output lands in `docs_build/site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)