### PR TITLE
Fix broken images and restore logo on docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # dbt-fabric-samdebruyn
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/dbt-signature_tm_light.png">
-  <img alt="dbt logo" src="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/dbt-signature_tm.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/dbt-signature_tm_light.png">
+  <img alt="dbt logo" src="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/dbt-signature_tm.png">
 </picture>
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/fabric.png">
-  <img alt="Fabric logo" src="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/fabric.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/fabric.png">
+  <img alt="Fabric logo" src="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/fabric.png">
 </picture>
 
 This is a maintained and extended fork of the [dbt-fabric](https://github.com/microsoft/dbt-fabric) adapter. This fork has [additional features and bugfixes](https://dbt-fabric.debruyn.dev/feature-comparison/) compared to the original adapter.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 --8<-- "README.md:0:1"
 
-![dbt logo for light mode](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/dbt-signature_tm.png#gh-light-mode-only)
-![dbt logo for dark mode](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/dbt-signature_tm_light.png#gh-dark-mode-only)
-![fabric logo](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/forked-version/assets/fabric.png)
+![dbt logo for light mode](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/dbt-signature_tm.png#gh-light-mode-only)
+![dbt logo for dark mode](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/dbt-signature_tm_light.png#gh-dark-mode-only)
+![fabric logo](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/fabric.png)
 
 --8<-- "README.md:10:18"
 --8<-- "README.md:22"

--- a/zensical.toml
+++ b/zensical.toml
@@ -60,7 +60,7 @@ features = [
 ]
 
 [project.theme.icon]
-logo = "lucide/receipt"
+logo = "material/receipt"
 repo = "fontawesome/brands/github"
 
 [[project.theme.palette]]


### PR DESCRIPTION
## Summary
- Fixed broken images on docs homepage — URLs referenced nonexistent `forked-version` branch, changed to `main`
- Restored header logo from `lucide/receipt` (dollar sign icon) back to `material/receipt` (original icon from before the Zensical migration)

## Test plan
- [x] Built docs locally with `zensical build`
- [x] Verified images load correctly on local dev server via Playwright
- [x] Verified logo renders correctly in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)