### PR TITLE
Document Lakehouse (FabricSpark) support across all docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,16 @@ Update this section by adding entries as patterns emerge. Format: short descript
 
 - **FabricSpark: `'view' is not a valid FabricSparkRelationType`** — dbt's default materialization is `view`, but Fabric Lakehouse with schemas doesn't support Spark SQL views. This will come up in almost every FabricSpark test class. Fix: override the test's `models` or `project_config_update` fixture to replace `view` with `materialized_view` or `table` depending on what the test is validating. Use `materialized_view` when the test is about read-only derived data (closest equivalent to a view), and `table` when the test needs DML or other table-specific behavior. The `conftest.py` sets `+materialized: materialized_view` as default, but this gets overwritten when a test provides its own `models` key in `project_config_update` (shallow dict merge).
 
+## Handling PR review comments
+
+When processing review comments on a pull request, follow this workflow for each comment:
+
+1. **Evaluate the comment** — Verify the claim against the actual code or documentation. Determine whether it's valid, partially valid, or not applicable.
+2. **Fix if needed** — If the comment is valid (or partially valid), implement the fix. If it's not applicable, prepare a clear explanation of why.
+3. **Reply to the comment** — Always reply to every comment on the PR via the GitHub API (`gh api repos/.../pulls/.../comments/{id}/replies`). Explain what was done to resolve it, or why the comment doesn't apply. Be specific: reference the code, the change made, or the reasoning.
+
+Never silently fix comments without replying, and never ignore comments without explaining why they don't apply.
+
 ## Multi-agent development
 
 When implementing multiple test classes or fixing many failures at once, use parallel agents to speed up the work. The main conversation acts as coordinator.

--- a/README.md
+++ b/README.md
@@ -9,20 +9,38 @@
   <img alt="Fabric logo" src="https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/fabric.png">
 </picture>
 
-This is a maintained and extended fork of the [dbt-fabric](https://github.com/microsoft/dbt-fabric) adapter. This fork has [additional features and bugfixes](https://dbt-fabric.debruyn.dev/feature-comparison/) compared to the original adapter.
+A maintained and extended fork of the [dbt-fabric](https://github.com/microsoft/dbt-fabric) adapter, supporting **both** Microsoft Fabric compute engines:
 
-The adapter was [originally developed by the community](https://github.com/microsoft/dbt-fabric/graphs/contributors) and later adopted by Microsoft.
-Given Microsoft's limited investments in the adapter, this fork aims to continue its development and maintenance.
+- **Fabric Data Warehouse** — T-SQL, uses the mssql-python driver (`type: fabric`)
+- **Fabric Lakehouse** — Spark SQL via Livy sessions (`type: fabricspark`)
+
+This fork has [additional features and bugfixes](https://dbt-fabric.debruyn.dev/feature-comparison/) compared to the original adapter, which was [originally developed by the community](https://github.com/microsoft/dbt-fabric/graphs/contributors) and later adopted by Microsoft. Given Microsoft's limited investments in the adapter, this fork aims to continue its development and maintenance.
 
 [![PyPI - Version](https://img.shields.io/pypi/v/dbt-fabric-samdebruyn)](https://pypi.org/project/dbt-fabric-samdebruyn/)
 
+## Quick start
+
+### Data Warehouse (T-SQL)
+
+Drop-in replacement for the original `dbt-fabric` adapter:
+
+```bash
+pip install dbt-fabric-samdebruyn dbt-core
+```
+
+If you are migrating from the original adapter, all you need is `pip uninstall dbt-fabric` first.
+
+### Lakehouse (Spark SQL)
+
+```bash
+pip install dbt-fabric-samdebruyn[spark] dbt-core
+```
+
+This installs [dbt-spark](https://github.com/dbt-labs/dbt-spark) as a dependency. See the [Lakehouse guide](https://dbt-fabric.debruyn.dev/lakehouse/) for configuration and usage.
+
 ## Documentation
 
-A website with all documentation with regards to using dbt with Microsoft Fabric can be found at [http://dbt-fabric.debruyn.dev/](http://dbt-fabric.debruyn.dev/).
-
-## Drop-in replacement
-
-This adapter is a drop-in replacement for the original `dbt-fabric` adapter. To start using this adapter, all you have to do is a `pip uninstall dbt-fabric` and a `pip install dbt-fabric-samdebruyn`.
+Full documentation for using dbt with Microsoft Fabric is available at [dbt-fabric.debruyn.dev](https://dbt-fabric.debruyn.dev/).
 
 ## Code of Conduct
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,6 +6,8 @@ The dbt-fabric-samdebruyn adapter supports a variety of authentication methods s
 
     All authentication methods on this page work with both `type: fabric` (Data Warehouse) and `type: fabricspark` (Lakehouse). The examples below use `type: fabric` -- substitute `type: fabricspark` when using the [Lakehouse adapter](lakehouse.md). Note that the FabricSpark adapter does not use the `host` option; it resolves the Livy endpoint from `workspace` or `workspace_id` automatically.
 
+    The full [configuration reference](configuration.md#authentication) lists additional methods (`ActiveDirectoryIntegrated`, `ActiveDirectoryPassword`) that only work with `type: fabric` because they are handled by the mssql-python driver.
+
 !!! tip "Quick recommendation"
 
     | Scenario | Recommended method |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -2,6 +2,10 @@
 
 The dbt-fabric-samdebruyn adapter supports a variety of authentication methods so you can connect to Microsoft Fabric from any environment. This guide walks through each method, explains when to use it, and provides ready-to-use `profiles.yml` examples.
 
+!!! info "Works with both adapter types"
+
+    All authentication methods on this page work with both `type: fabric` (Data Warehouse) and `type: fabricspark` (Lakehouse). The examples below use `type: fabric` -- substitute `type: fabricspark` when using the [Lakehouse adapter](lakehouse.md). Note that the FabricSpark adapter does not use the `host` option; it resolves the Livy endpoint from `workspace` or `workspace_id` automatically.
+
 !!! tip "Quick recommendation"
 
     | Scenario | Recommended method |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,7 +114,7 @@ Example value: `My Workspace`
 The name of your Fabric Workspace.
 
 - For `type: fabric`: used to automatically find the [`host`](#host) value. Not required if `host` is provided (except for Python models).
-- For `type: fabricspark`: **required**. The Lakehouse adapter always needs the workspace to resolve the Livy API endpoint.
+- For `type: fabricspark`: **required** (unless [`workspace_id`](#workspace_id) is provided). The Lakehouse adapter always needs the workspace to resolve the Livy API endpoint.
 
 Not used if [`workspace_id`](#workspace_id) is also provided.
 
@@ -355,7 +355,7 @@ Possible values: any integer (seconds) :timer:
 
 The timeout for executing a query.
 
-- For `type: fabric`: this can be useful if you are receiving the `Query timeout expired` error. The default is no timeout.
+- For `type: fabric`: this can be useful if you are receiving the `Query timeout expired` error. Default: **86400 seconds (24 hours)**.
 - For `type: fabricspark`: controls how long the adapter waits for a Livy statement to complete. Default: **86400 seconds (24 hours)**.
 
 ### `spark_session_timeout`
@@ -365,9 +365,9 @@ Default: `900` (15 minutes)
 
 The maximum time to wait for the Livy Spark session to become idle (ready to accept statements). This is relevant during the first statement of a dbt run, when a new session may need to be created.
 
-!!! info "FabricSpark only"
+!!! info "FabricSpark and Python models"
 
-    This option only applies to `type: fabricspark`. For Data Warehouse connection timeouts, see [`login_timeout`](#login_timeout).
+    This option applies to `type: fabricspark` for all Livy session management, and to `type: fabric` when running [Python models](python-models.md) (which also use Livy sessions). For Data Warehouse SQL connection timeouts, see [`login_timeout`](#login_timeout).
 
 ### `livy_session_name`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,21 +1,38 @@
 # Configuration
 
+!!! info "This page covers both adapter types"
+
+    This adapter supports two Microsoft Fabric compute engines: **Data Warehouse** (`type: fabric`) and **Lakehouse** (`type: fabricspark`). Configuration options that are specific to one adapter type are marked accordingly. For a comprehensive guide on using the Lakehouse adapter, see the [Lakehouse guide](lakehouse.md).
+
 You'll need to create a profile in the [profiles.yml](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml) file to connect to Microsoft Fabric. The adapter offers several ways to configure your connection so that it can be flexible to your needs.
 
 ## Example profiles.yml
 
-Here's an example `profiles.yml` file that connects to a Microsoft Fabric instance using automatic authentication:
+=== "Data Warehouse (T-SQL)"
 
-```yaml
-default:
-  target: dev
-    outputs:
-    dev:
-      type: fabric
-      workspace: your workspace name
-      database: name_of_your_data_warehouse
-      schema: schema_to_build_models_in
-```
+    ```yaml
+    default:
+      target: dev
+      outputs:
+        dev:
+          type: fabric
+          workspace: your workspace name
+          database: name_of_your_data_warehouse
+          schema: schema_to_build_models_in
+    ```
+
+=== "Lakehouse (Spark SQL)"
+
+    ```yaml
+    default:
+      target: dev
+      outputs:
+        dev:
+          type: fabricspark
+          workspace: your workspace name
+          database: name_of_your_lakehouse
+          schema: schema_in_your_lakehouse
+    ```
 
 ??? tip "Use environment variables anywhere"
 
@@ -40,9 +57,12 @@ default:
 
 **Required configuration option.**
 
-Only possible value: `fabric`
+Possible values: `fabric`, `fabricspark`
 
-The type of the adapter. This must be set to `fabric` to use this adapter.
+| Value | Compute engine | SQL dialect |
+| --- | --- | --- |
+| `fabric` | Fabric Data Warehouse | T-SQL |
+| `fabricspark` | Fabric Lakehouse | Spark SQL |
 
 ### `host`
 
@@ -53,13 +73,22 @@ The server part of your connection string. This is unique per Workspace in Fabri
 
 You can leave this empty and let the adapter find it automatically by providing information about your Workspace. See [`workspace_name`](#workspace_name) and [`workspace_id`](#workspace_id).
 
+!!! info "Not used for FabricSpark"
+
+    This option is not used when `type` is `fabricspark`. The Lakehouse adapter connects via the Fabric Livy API, not TDS. The Livy endpoint is resolved automatically from [`workspace_name`](#workspace_name) or [`workspace_id`](#workspace_id).
+
 ### `database`
 
 **Required configuration option.**
 
 Example value: `gold_dwh`
 
-The name of your data warehouse in Fabric. It's recommended to avoid using spaces in the name of your data warehouse, although it's supported.
+The name of the target item in Fabric:
+
+- For `type: fabric`: the name of your **Data Warehouse**.
+- For `type: fabricspark`: the name of your **Lakehouse**. The adapter uses this as the Lakehouse name for the Livy API connection.
+
+It's recommended to avoid using spaces in the name, although it's supported.
 
 ### `schema`
 
@@ -67,7 +96,7 @@ The name of your data warehouse in Fabric. It's recommended to avoid using space
 
 Example value: `dbt`
 
-The schema in your data warehouse where dbt will build models. You must have write access to this schema. It's recommended to avoid using spaces in the schema name, although it's supported.
+The schema where dbt will build models. You must have write access to this schema. It's recommended to avoid using spaces in the schema name, although it's supported.
 
 ??? tip "Override per model"
 
@@ -77,19 +106,21 @@ The schema in your data warehouse where dbt will build models. You must have wri
 
     You can even completely customize how dbt generates the schema name using the [`generate_schema_name`](https://docs.getdbt.com/docs/build/custom-schemas) macro.
 
-### `workspace_name` :fontawesome-brands-python:
+### `workspace_name`
 
 Alias: `workspace`<br>
 Example value: `My Workspace`
 
-The name of your Fabric Workspace. This is used to automatically find the [`host`](#host) value for you.
+The name of your Fabric Workspace.
+
+- For `type: fabric`: used to automatically find the [`host`](#host) value. Not required if `host` is provided (except for Python models).
+- For `type: fabricspark`: **required**. The Lakehouse adapter always needs the workspace to resolve the Livy API endpoint.
 
 Not used if [`workspace_id`](#workspace_id) is also provided.
-Not used for SQL models (so only for Python models) if `host` is provided.
 
-??? info "Python models"
+??? info "Python models (Data Warehouse)"
 
-    If you are using Python models in your project, either [`workspace_name`](#workspace_name) or [`workspace_id`](#workspace_id) must be provided.
+    If you are using Python models with `type: fabric`, either [`workspace_name`](#workspace_name) or [`workspace_id`](#workspace_id) must be provided.
 
 ??? info "auth: ActiveDirectoryServicePrincipal"
 
@@ -97,17 +128,18 @@ Not used for SQL models (so only for Python models) if `host` is provided.
 
 Behind the scenes, the adapter will do an API call to first find the Workspace ID, and then use that to find the server name.
 
-### `workspace_id` :fontawesome-brands-python:
+### `workspace_id`
 
 Example value: `7275c94d-9280-438b-bd67-ffeb8c305c9b`
 
-The ID of your Fabric Workspace. This is used to automatically find the `host` value for you.
+The ID of your Fabric Workspace. Can be used instead of [`workspace_name`](#workspace_name).
 
-Not used for SQL models (so only for Python models) if `host` is provided.
+- For `type: fabric`: used to automatically find the `host` value. Not required if `host` is provided (except for Python models).
+- For `type: fabricspark`: **required** (unless `workspace_name` is provided). The Lakehouse adapter always needs the workspace.
 
-??? info "Python models"
+??? info "Python models (Data Warehouse)"
 
-    If you are using Python models in your project, either [`workspace_name`](#workspace_name) or [`workspace_id`](#workspace_id) must be provided.
+    If you are using Python models with `type: fabric`, either [`workspace_name`](#workspace_name) or [`workspace_id`](#workspace_id) must be provided.
 
 ??? info "auth: ActiveDirectoryServicePrincipal"
 
@@ -264,16 +296,16 @@ Example value: `some_group_or_user`
 
 If your dbt project is using a schema which does not exist yet, dbt will create it for you. Use this configuration option to set the owner of the schema after creation. This can be a user or a group.
 
-### `lakehouse` :fontawesome-brands-python:
+### `lakehouse`
 
 Alias: `lakehouse_name`<br>
 Example value: `My Lakehouse`
 
 The name of the Lakehouse in Fabric you wish to use for running Python models.
 
-This is not used for SQL models.
+!!! info "Only needed for `type: fabric`"
 
-If you are using Python models in your project, this option must be provided.
+    This option is only needed when using `type: fabric` (Data Warehouse) with [Python models](python-models.md). For `type: fabricspark`, the [`database`](#database) field already specifies the Lakehouse — no separate `lakehouse` option is needed.
 
 When using this option together with [`authentication`](#authentication) set to `ActiveDirectoryServicePrincipal`, you also need to provide the [`tenant_id`](#tenant_id) option.
 
@@ -284,6 +316,10 @@ Default: `true`
 
 Whether to use encryption for the connection. It's recommended to leave this enabled. This could be disabled for advanced networking scenarios.
 
+!!! info "Data Warehouse only"
+
+    This option only applies to `type: fabric`. The FabricSpark adapter connects via HTTPS (Livy API), which is always encrypted.
+
 ### `trust_cert`
 
 Alias: `TrustServerCertificate`<br>
@@ -291,6 +327,10 @@ Possible values: `true`, `false`<br>
 Default: `false`
 
 Whether to trust the server certificate without validation. It's recommended to leave this disabled. This could be enabled for advanced networking scenarios.
+
+!!! info "Data Warehouse only"
+
+    This option only applies to `type: fabric`. The FabricSpark adapter connects via HTTPS (Livy API).
 
 ### `retries`
 
@@ -305,8 +345,36 @@ Possible values: any integer (seconds) :timer:
 
 The timeout for establishing a connection to the server. This can be useful if you are receiving the `Login timeout expired` error. A value of 30 seconds could improve the connection resiliency. The adapter has no default value and will use the driver's default if not set.
 
+!!! info "Data Warehouse only"
+
+    This option only applies to `type: fabric`. For FabricSpark, see [`spark_session_timeout`](#spark_session_timeout).
+
 ### `query_timeout`
 
 Possible values: any integer (seconds) :timer:
 
-The timeout for executing a query. This can be useful if you are receiving the `Query timeout expired` error. The default is no timeout.
+The timeout for executing a query.
+
+- For `type: fabric`: this can be useful if you are receiving the `Query timeout expired` error. The default is no timeout.
+- For `type: fabricspark`: controls how long the adapter waits for a Livy statement to complete. Default: **86400 seconds (24 hours)**.
+
+### `spark_session_timeout`
+
+Possible values: any integer (seconds) :timer:<br>
+Default: `900` (15 minutes)
+
+The maximum time to wait for the Livy Spark session to become idle (ready to accept statements). This is relevant during the first statement of a dbt run, when a new session may need to be created.
+
+!!! info "FabricSpark only"
+
+    This option only applies to `type: fabricspark`. For Data Warehouse connection timeouts, see [`login_timeout`](#login_timeout).
+
+### `livy_session_name`
+
+Default: `dbt-fabric-samdebruyn`
+
+The name of the Livy session. Sessions are reused across statements within a dbt run. If an existing session with this name is found in an `idle`, `starting`, `running`, or `busy` state, it will be reused instead of creating a new one.
+
+!!! info "Used by both adapter types"
+
+    This option is used by `type: fabricspark` for all SQL execution, and by `type: fabric` for Python model execution.

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -3,6 +3,12 @@
 This adapter has all the features of [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric), plus some additional features.
 The following features are exclusive to dbt-fabric-samdebruyn:
 
+## Fabric Lakehouse (Spark SQL) support
+
+This adapter supports both Fabric compute engines: **Data Warehouse (T-SQL)** and **Lakehouse (Spark SQL)**. Microsoft's dbt-fabric only supports Data Warehouse.
+
+The Lakehouse adapter (`type: fabricspark`) uses Spark SQL via Livy sessions and supports tables, materialized lake views, and Python models natively. See the [Lakehouse guide](lakehouse.md) for details.
+
 ## dbt Core 1.11 support
 
 This adapter is compatible with dbt Core 1.11, while Microsoft's dbt-fabric adapter is only compatible with dbt Core 1.10.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,5 @@
 ![dbt logo for dark mode](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/dbt-signature_tm_light.png#gh-dark-mode-only)
 ![fabric logo](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/fabric.png)
 
---8<-- "README.md:10:18"
---8<-- "README.md:22"
+--8<-- "README.md:11:19"
+--8<-- "README.md:44"

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,4 +5,5 @@
 ![fabric logo](https://raw.githubusercontent.com/sdebruyn/dbt-fabric/main/assets/fabric.png)
 
 --8<-- "README.md:11:19"
+--8<-- "README.md:20:40"
 --8<-- "README.md:44"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,8 +12,28 @@ python --version
 
 ## Install dbt-fabric-samdebruyn
 
-Install dbt-fabric-samdebruyn using pip:
+=== "Data Warehouse (T-SQL)"
 
-```bash
-pip install dbt-fabric-samdebruyn dbt-core
-```
+    Install dbt-fabric-samdebruyn for use with Fabric Data Warehouse:
+
+    ```bash
+    pip install dbt-fabric-samdebruyn dbt-core
+    ```
+
+    This is a drop-in replacement for the original `dbt-fabric` adapter. If you are migrating, run `pip uninstall dbt-fabric` first.
+
+=== "Lakehouse (Spark SQL)"
+
+    Install dbt-fabric-samdebruyn with the Spark extra for use with Fabric Lakehouse:
+
+    ```bash
+    pip install dbt-fabric-samdebruyn[spark] dbt-core
+    ```
+
+    The `[spark]` extra installs [dbt-spark](https://github.com/dbt-labs/dbt-spark) as a dependency, which provides the base Spark SQL adapter that the FabricSpark adapter builds on.
+
+    !!! info "The `[spark]` extra is only needed for Lakehouse"
+
+        If you only use Fabric Data Warehouse, you do not need the `[spark]` extra. The base `pip install dbt-fabric-samdebruyn dbt-core` is sufficient.
+
+    See the [Lakehouse guide](lakehouse.md) for configuration and usage details.

--- a/docs/lakehouse.md
+++ b/docs/lakehouse.md
@@ -37,7 +37,7 @@ For all configuration options, see the [configuration reference](configuration.m
 
 ### Authentication
 
-All [authentication methods](authentication.md) work with both adapter types. When following examples in the authentication guide, substitute `type: fabricspark` where the examples show `type: fabric`.
+The [authentication methods](authentication.md) documented in the authentication guide work with both adapter types. When following examples there, substitute `type: fabricspark` where the examples show `type: fabric`. Note that `ActiveDirectoryIntegrated` and `ActiveDirectoryPassword` are Data Warehouse-only methods and do not work with FabricSpark.
 
 The FabricSpark adapter does not use the [`host`](configuration.md#host) option -- it always resolves the Livy endpoint from the workspace and lakehouse information.
 
@@ -143,7 +143,7 @@ The adapter polls for statement completion every 3 seconds. Even very fast queri
 
 ### API rate limiting
 
-Fabric applies rate limits to the Livy API. The adapter handles HTTP 429 responses automatically with exponential backoff using the `Retry-After` header. During heavy workloads, you may see pauses of 5-30 seconds between statements.
+Fabric applies rate limits to the Livy API. The adapter handles HTTP 429 responses automatically by respecting the `Retry-After` header. During heavy workloads, you may see pauses of 5-30 seconds between statements.
 
 ### Practical impact
 

--- a/docs/lakehouse.md
+++ b/docs/lakehouse.md
@@ -1,0 +1,211 @@
+# Lakehouse (Spark SQL)
+
+The dbt-fabric-samdebruyn adapter supports Fabric Lakehouse via the `fabricspark` adapter type. This uses **Spark SQL** as the query language and connects to Fabric through the [Livy API](https://learn.microsoft.com/fabric/data-engineering/lakehouse-api?WT.mc_id=MVP_310840) -- an HTTP REST interface for submitting Spark statements.
+
+---
+
+## Getting started
+
+### Installation
+
+Install the adapter with the `[spark]` extra:
+
+```bash
+pip install dbt-fabric-samdebruyn[spark] dbt-core
+```
+
+This installs [dbt-spark](https://github.com/dbt-labs/dbt-spark) as a dependency.
+
+### Configuration
+
+Add a FabricSpark profile to your `profiles.yml`:
+
+```yaml
+default:
+  target: dev
+  outputs:
+    dev:
+      type: fabricspark
+      workspace: your workspace name
+      database: name_of_your_lakehouse
+      schema: dbt
+```
+
+The `workspace` (or `workspace_id`) is always required for FabricSpark -- the adapter uses it to resolve the Livy API endpoint. The `database` field is the name of your Lakehouse.
+
+For all configuration options, see the [configuration reference](configuration.md).
+
+### Authentication
+
+All [authentication methods](authentication.md) work with both adapter types. When following examples in the authentication guide, substitute `type: fabricspark` where the examples show `type: fabric`.
+
+The FabricSpark adapter does not use the [`host`](configuration.md#host) option -- it always resolves the Livy endpoint from the workspace and lakehouse information.
+
+---
+
+## How it works
+
+The FabricSpark adapter executes all SQL through Fabric Livy sessions. Here is the execution flow:
+
+```mermaid
+sequenceDiagram
+    participant dbt
+    participant Adapter
+    participant Livy API
+    participant Spark Session
+
+    dbt->>Adapter: Compiled Spark SQL
+    Adapter->>Livy API: GET /sessions (find existing session)
+    alt Session exists
+        Livy API-->>Adapter: Session ID
+    else No session
+        Adapter->>Livy API: POST /sessions (create new)
+        Livy API-->>Adapter: Session ID
+        Note over Adapter,Spark Session: Session startup: 1-5 minutes
+    end
+    Adapter->>Livy API: POST /sessions/{id}/statements
+    Livy API->>Spark Session: Execute Spark SQL
+    loop Poll every 3 seconds
+        Adapter->>Livy API: GET /statements/{id}
+        Livy API-->>Adapter: Status + results (when done)
+    end
+    Adapter-->>dbt: Parsed results
+```
+
+Key technical details:
+
+- **Session reuse** -- All statements in a dbt run share the same Livy session (named `dbt-fabric-samdebruyn` by default). This avoids the overhead of creating a new Spark session for each model.
+- **Session TTL** -- Sessions are created with a TTL of 30 seconds. If the session is idle for longer than that after the dbt run finishes, Fabric will automatically clean it up.
+- **Polling interval** -- The adapter polls for statement completion every 3 seconds.
+- **Rate limiting** -- The Fabric Livy API enforces rate limits. The adapter handles HTTP 429 responses automatically using the `Retry-After` header.
+- **DB-API 2.0 cursor** -- Results are returned as JSON and parsed into a [PEP 249](https://peps.python.org/pep-0249/) compatible cursor, so dbt interacts with the Lakehouse the same way it interacts with any other database.
+
+---
+
+## Materializations
+
+### Default materialization: `materialized_view`
+
+Unlike most dbt adapters where the default materialization is `view` or `table`, the FabricSpark adapter defaults to **`materialized_view`**. This creates Fabric [lake views](https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint?WT.mc_id=MVP_310840), a Fabric-specific concept.
+
+Lake views support:
+
+- `CREATE OR REPLACE` semantics
+- `PARTITIONED BY` clauses
+- `TBLPROPERTIES` (Spark table properties)
+- `CHECK` constraints with `ON MISMATCH` behavior
+
+### Supported materializations
+
+| Materialization | Supported | Notes |
+| --- | --- | --- |
+| `materialized_view` | Yes | Default. Creates a Fabric lake view. |
+| `table` | Yes | Creates a managed Delta table. |
+| `view` | No | Fabric Lakehouse with schemas does not support Spark SQL views. |
+| `incremental` | Yes | Supports `append` and `insert_overwrite` strategies. `merge` and `delete+insert` are not supported. |
+| `ephemeral` | Yes | Standard CTE-based ephemeral models. |
+
+!!! warning "No Spark SQL views"
+
+    Fabric Lakehouse with schemas enabled does not support Spark SQL views. If a model or package uses `materialized='view'`, you will see the error `'view' is not a valid FabricSparkRelationType`. Change the materialization to `materialized_view` or `table`.
+
+---
+
+## Identifier quoting
+
+FabricSpark uses **backticks** (`` ` ``) for identifier quoting, following Spark SQL conventions. This is different from the Data Warehouse adapter, which uses T-SQL brackets (`[]`).
+
+```sql
+-- FabricSpark (Spark SQL)
+SELECT `my column` FROM `my_schema`.`my_table`
+
+-- Fabric Data Warehouse (T-SQL)
+SELECT [my column] FROM [my_schema].[my_table]
+```
+
+---
+
+## Performance considerations
+
+The Livy API architecture has inherent performance characteristics that are important to understand.
+
+### Session startup
+
+Creating a new Spark session can take **1-5 minutes**. The adapter reuses sessions within a run, so this overhead is paid once per `dbt run`. Subsequent runs may reuse an existing session if it is still alive.
+
+### Statement execution
+
+Each SQL statement involves multiple HTTP API calls (submit + poll). This is inherently slower than a direct database connection like the TDS protocol used by the Data Warehouse adapter.
+
+### Polling overhead
+
+The adapter polls for statement completion every 3 seconds. Even very fast queries take at least 3 seconds to return.
+
+### API rate limiting
+
+Fabric applies rate limits to the Livy API. The adapter handles HTTP 429 responses automatically with exponential backoff using the `Retry-After` header. During heavy workloads, you may see pauses of 5-30 seconds between statements.
+
+### Practical impact
+
+A dbt run with many models will be significantly slower on FabricSpark than on Fabric Data Warehouse. This is inherent to the Livy API architecture, not a limitation of the adapter.
+
+### Recommendations
+
+- Use higher thread counts to parallelize model execution and amortize the per-statement overhead. However, higher parallelism also increases API call volume, which can trigger rate limiting sooner.
+- Keep models as consolidated as possible to reduce the total number of statements.
+- Monitor the Spark session in the [Fabric monitoring hub](https://learn.microsoft.com/fabric/data-engineering/spark-monitor-overview?WT.mc_id=MVP_310840) to understand execution patterns.
+
+---
+
+## Differences from Fabric Data Warehouse
+
+| Concept | Data Warehouse (`fabric`) | Lakehouse (`fabricspark`) |
+| --- | --- | --- |
+| SQL dialect | T-SQL | Spark SQL |
+| Connection | mssql-python (TDS protocol) | Livy sessions (HTTP REST) |
+| Identifier quoting | `[brackets]` | `` `backticks` `` |
+| Default materialization | `table` | `materialized_view` (lake view) |
+| Views | Supported | Not supported |
+| String type | `varchar(MAX)` | `string` |
+| Timestamp type | `datetime2(6)` | `timestamp` |
+| Pagination | `SELECT TOP N` | `LIMIT N` |
+| Catalog queries | `sys.tables`, `sys.columns` | `SHOW TABLES`, `DESCRIBE` |
+| Python models | Via Livy + separate lakehouse config | Native (same Livy session) |
+| MERGE incremental | Supported | Not supported |
+| [CLUSTER BY](cluster-by.md) | Supported | Not supported |
+| [Warehouse snapshots](warehouse-snapshots.md) | Supported | Not supported |
+| [Catalog statistics](catalog-stats.md) | Supported | Not supported |
+
+---
+
+## Python models
+
+Python models work differently depending on the adapter type:
+
+- **`type: fabric` (Data Warehouse):** Python models use Livy to execute PySpark code that reads from and writes to the Data Warehouse via the [synapsesql connector](https://learn.microsoft.com/fabric/data-engineering/spark-data-warehouse-connector?WT.mc_id=MVP_310840). You need both a [`lakehouse`](configuration.md#lakehouse) (for the Livy session) and a [`database`](configuration.md#database) (the DW target).
+- **`type: fabricspark` (Lakehouse):** Python models run on the same Livy session that handles all SQL models. The [`database`](configuration.md#database) field IS the lakehouse. No separate `lakehouse` config is needed.
+
+See the [Python models guide](python-models.md) for writing and debugging Python models.
+
+---
+
+## Limitations
+
+- **No Spark SQL views** -- only tables and materialized lake views (Fabric lake views) are supported.
+- **No incremental merge strategy** -- the Spark SQL `MERGE` syntax in Fabric Lakehouse is not supported by the adapter. Use `append` or `insert_overwrite` instead.
+- **API rate limiting** -- can slow down large runs with many models.
+- **Session startup time** -- 1-5 minutes for the first statement in a run.
+- **Data Warehouse-only features** -- [CLUSTER BY](cluster-by.md), [warehouse snapshots](warehouse-snapshots.md), and [catalog statistics](catalog-stats.md) are not available for Lakehouse.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Livy session did not become idle in time` | Session startup took too long | Increase [`spark_session_timeout`](configuration.md#spark_session_timeout), retry, or check Fabric capacity |
+| `HTTP 429` in logs | API rate limiting | Automatic -- the adapter retries. Reduce `threads` if excessive. |
+| `'view' is not a valid FabricSparkRelationType` | Model uses `view` materialization | Change to `materialized_view` or `table` |
+| Slow execution | Livy polling overhead | Expected behavior. Use higher thread count. |
+| Statement timeout | Long-running Spark query | Increase [`query_timeout`](configuration.md#query_timeout) |
+| `Either workspace_id or workspace_name must be provided` | Missing workspace configuration | Add [`workspace`](configuration.md#workspace_name) or [`workspace_id`](configuration.md#workspace_id) to your profile |

--- a/docs/python-models.md
+++ b/docs/python-models.md
@@ -1,8 +1,17 @@
 # Python models
 
-The dbt-fabric-samdebruyn adapter supports [Python models](https://docs.getdbt.com/docs/build/python-models), allowing you to use PySpark DataFrames to transform data in your Fabric Data Warehouse. This is a feature exclusive to this adapter — Microsoft's upstream dbt-fabric does not support it.
+The dbt-fabric-samdebruyn adapter supports [Python models](https://docs.getdbt.com/docs/build/python-models), allowing you to use PySpark DataFrames to transform data in Microsoft Fabric. This is a feature exclusive to this adapter -- Microsoft's upstream dbt-fabric does not support it.
 
 Python models are useful when you need transformations that are difficult or impossible to express in SQL, such as machine learning inference, complex string parsing, or calling external APIs.
+
+!!! info "Data Warehouse vs Lakehouse"
+
+    Python models work on both adapter types, but the execution model differs:
+
+    - **`type: fabric` (Data Warehouse):** Python models use Livy to execute PySpark code that reads from and writes to the Data Warehouse via the [synapsesql connector](https://learn.microsoft.com/fabric/data-engineering/spark-data-warehouse-connector?WT.mc_id=MVP_310840). You need both a [`lakehouse`](configuration.md#lakehouse) (for the Livy session) and a [`database`](configuration.md#database) (the DW target).
+    - **`type: fabricspark` (Lakehouse):** Python models run on the same Livy session that handles all SQL models. The [`database`](configuration.md#database) field IS the lakehouse. No separate `lakehouse` config is needed.
+
+    The rest of this page describes the Data Warehouse workflow. For Lakehouse-specific details, see the [Lakehouse guide](lakehouse.md).
 
 ---
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -30,6 +30,7 @@ nav = [
   ] },
   { "Feature guides" = [
     { "Authentication" = "authentication.md" },
+    { "Lakehouse (Spark SQL)" = "lakehouse.md" },
     { "CLUSTER BY" = "cluster-by.md" },
     { "Python models" = "python-models.md" },
     { "Warehouse snapshots" = "warehouse-snapshots.md" },


### PR DESCRIPTION
## Summary

- **README**: Rewritten intro to highlight both compute engines (Data Warehouse and Lakehouse), added Quick Start with install commands for both
- **New `docs/lakehouse.md`**: Comprehensive guide covering architecture (mermaid diagram), Livy session mechanics, materializations, performance considerations (honest about Livy overhead and rate limiting), comparison table with Data Warehouse, limitations, and troubleshooting
- **`docs/configuration.md`**: Added tabbed profiles.yml examples, documented all FabricSpark-specific options (`spark_session_timeout`, `livy_session_name`), annotated DW-only options throughout
- **`docs/installation.md`**: Tabbed install for Data Warehouse vs Lakehouse (`[spark]` extra)
- **`docs/feature-comparison.md`**: Lakehouse support highlighted as top differentiating feature
- **`docs/authentication.md`**: Added note that all auth methods work with both adapter types
- **`docs/python-models.md`**: Clarified how Python models differ between DW and Lakehouse
- **`zensical.toml`**: Added Lakehouse page to nav

## Test plan

- [x] `uv run zensical build --strict` passes with no issues
- [x] Visual review of rendered docs on Cloudflare Pages preview
- [x] Verify all internal links resolve correctly
- [x] Check mermaid diagram renders in lakehouse.md


🤖 Generated with [Claude Code](https://claude.com/claude-code)