### PR TITLE
Document mssql-python driver as key differentiator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,8 @@ tests/
 
 ## Development workflow (TDD)
 
+**Always work in a git worktree.** When working on a PR, feature, or bugfix, always create and use a separate git worktree (or use `isolation: "worktree"` when spawning agents). This avoids conflicts with other people or agents working in the same repository at the same time. The main working directory should stay on its current branch — all development happens in worktrees.
+
 Development follows a strict test-driven loop using `dbt-tests-adapter` base classes:
 
 1. **Add a base test class** — Find the relevant base class in `dbt.tests.adapter.*` and create a subclass in the appropriate test directory (`tests/fabric/` or `tests/fabricspark/`). Start with a bare `pass` body.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ The project has a documentation website at https://dbt-fabric.debruyn.dev, built
 
 The docs cover everything that is specific to this dbt adapter compared to other dbt adapters: installation, configuration, authentication, feature guides (Python models, warehouse snapshots), and a comparison with Microsoft's upstream `dbt-fabric`. When adding or changing adapter-specific behavior, update the relevant docs page. If a new feature has no existing page, add one under the appropriate nav section in `zensical.toml`.
 
+When linking to Microsoft Learn pages (anywhere in docs, code comments, or markdown), always append the MVP tracking parameter: `?WT.mc_id=MVP_310840` (or `&WT.mc_id=MVP_310840` if the URL already has query parameters).
+
 Current nav structure:
 
 - **Home** — Overview, comparison with upstream dbt-fabric, contributing, license

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -18,6 +18,16 @@ The first release of this fork was version 1.10.0. The adapter follows [dbt-adap
 | 3.12 | Yes |
 | 3.13 | Yes |
 
+## SQL Server driver
+
+This adapter uses [`mssql-python`](https://github.com/microsoft/mssql-python), Microsoft's official pure Python driver for SQL Server and Fabric. No ODBC drivers or system-level dependencies are required.
+
+| | dbt-fabric-samdebruyn | Microsoft's dbt-fabric |
+|---|---|---|
+| Driver | `mssql-python` | pyODBC + `msodbcsql18` |
+| System dependencies | None | ODBC driver manager + ODBC driver |
+| Installation | `pip install` only | `pip install` + platform-specific ODBC setup |
+
 ## Fabric compute types
 
 | Compute type | Adapter type | SQL dialect |

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -3,13 +3,6 @@
 This adapter has all the features of [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric), plus some additional features.
 The following features are exclusive to dbt-fabric-samdebruyn:
 
-<<<<<<< HEAD
-## Fabric Lakehouse (Spark SQL) support
-
-This adapter supports both Fabric compute engines: **Data Warehouse (T-SQL)** and **Lakehouse (Spark SQL)**. Microsoft's dbt-fabric only supports Data Warehouse.
-
-The Lakehouse adapter (`type: fabricspark`) uses Spark SQL via Livy sessions and supports tables, materialized lake views, and Python models natively. See the [Lakehouse guide](lakehouse.md) for details.
-=======
 ## No ODBC driver required
 
 This adapter uses Microsoft's official [`mssql-python`](https://github.com/microsoft/mssql-python) driver instead of pyODBC. This is a pure Python driver for SQL Server and Microsoft Fabric that communicates over the TDS protocol natively, without requiring any system-level ODBC components.
@@ -21,7 +14,12 @@ Microsoft's upstream dbt-fabric adapter depends on pyODBC, which requires:
 - Platform-specific installation steps that vary between Linux distributions, macOS, and Windows
 
 With dbt-fabric-samdebruyn, none of this is needed. Installation is a single `pip install` or `uv add` command, with no platform-specific setup. This eliminates a common source of installation issues and makes the adapter work consistently across all platforms, including containerized environments.
->>>>>>> 8f2c84e (Document mssql-python driver as key differentiator from upstream dbt-fabric)
+
+## Fabric Lakehouse (Spark SQL) support
+
+This adapter supports both Fabric compute engines: **Data Warehouse (T-SQL)** and **Lakehouse (Spark SQL)**. Microsoft's dbt-fabric only supports Data Warehouse.
+
+The Lakehouse adapter (`type: fabricspark`) uses Spark SQL via Livy sessions and supports tables, materialized lake views, and Python models natively. See the [Lakehouse guide](lakehouse.md) for details.
 
 ## dbt Core 1.11 support
 

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -3,11 +3,25 @@
 This adapter has all the features of [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric), plus some additional features.
 The following features are exclusive to dbt-fabric-samdebruyn:
 
+<<<<<<< HEAD
 ## Fabric Lakehouse (Spark SQL) support
 
 This adapter supports both Fabric compute engines: **Data Warehouse (T-SQL)** and **Lakehouse (Spark SQL)**. Microsoft's dbt-fabric only supports Data Warehouse.
 
 The Lakehouse adapter (`type: fabricspark`) uses Spark SQL via Livy sessions and supports tables, materialized lake views, and Python models natively. See the [Lakehouse guide](lakehouse.md) for details.
+=======
+## No ODBC driver required
+
+This adapter uses Microsoft's official [`mssql-python`](https://github.com/microsoft/mssql-python) driver instead of pyODBC. This is a pure Python driver for SQL Server and Microsoft Fabric that communicates over the TDS protocol natively, without requiring any system-level ODBC components.
+
+Microsoft's upstream dbt-fabric adapter depends on pyODBC, which requires:
+
+- A system-level ODBC driver manager (unixODBC on Linux/macOS)
+- The Microsoft ODBC Driver for SQL Server (`msodbcsql18`)
+- Platform-specific installation steps that vary between Linux distributions, macOS, and Windows
+
+With dbt-fabric-samdebruyn, none of this is needed. Installation is a single `pip install` or `uv add` command, with no platform-specific setup. This eliminates a common source of installation issues and makes the adapter work consistently across all platforms, including containerized environments.
+>>>>>>> 8f2c84e (Document mssql-python driver as key differentiator from upstream dbt-fabric)
 
 ## dbt Core 1.11 support
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,6 @@ No other system-level dependencies are required. Unlike Microsoft's upstream dbt
 
 === "Data Warehouse (T-SQL)"
 
-<<<<<<< HEAD
     Install dbt-fabric-samdebruyn for use with Fabric Data Warehouse:
 
     ```bash
@@ -40,10 +39,5 @@ No other system-level dependencies are required. Unlike Microsoft's upstream dbt
         If you only use Fabric Data Warehouse, you do not need the `[spark]` extra. The base `pip install dbt-fabric-samdebruyn dbt-core` is sufficient.
 
     See the [Lakehouse guide](lakehouse.md) for configuration and usage details.
-=======
-```bash
-pip install dbt-fabric-samdebruyn dbt-core
-```
 
 That's it. No ODBC driver setup, no platform-specific steps. The adapter works the same on Linux, macOS, and Windows.
->>>>>>> 8f2c84e (Document mssql-python driver as key differentiator from upstream dbt-fabric)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,10 +10,13 @@ Make sure you have [Python](https://www.python.org/) 3.11 or higher installed. Y
 python --version
 ```
 
+No other system-level dependencies are required. Unlike Microsoft's upstream dbt-fabric adapter (which depends on pyODBC and requires installing ODBC drivers like `msodbcsql18` and `unixODBC`), this adapter uses [`mssql-python`](https://github.com/microsoft/mssql-python) -- Microsoft's official pure Python driver for SQL Server and Fabric. It handles TDS protocol communication natively, so there is nothing else to install on your system.
+
 ## Install dbt-fabric-samdebruyn
 
 === "Data Warehouse (T-SQL)"
 
+<<<<<<< HEAD
     Install dbt-fabric-samdebruyn for use with Fabric Data Warehouse:
 
     ```bash
@@ -37,3 +40,10 @@ python --version
         If you only use Fabric Data Warehouse, you do not need the `[spark]` extra. The base `pip install dbt-fabric-samdebruyn dbt-core` is sufficient.
 
     See the [Lakehouse guide](lakehouse.md) for configuration and usage details.
+=======
+```bash
+pip install dbt-fabric-samdebruyn dbt-core
+```
+
+That's it. No ODBC driver setup, no platform-specific steps. The adapter works the same on Linux, macOS, and Windows.
+>>>>>>> 8f2c84e (Document mssql-python driver as key differentiator from upstream dbt-fabric)


### PR DESCRIPTION
## Summary

- Add mssql-python vs pyODBC comparison to the feature comparison page as the first listed advantage over Microsoft's upstream adapter
- Add "SQL Server driver" comparison table to the compatibility page showing driver, system dependencies, and installation differences
- Update installation page to clarify that no ODBC drivers or system-level dependencies are needed
- Add worktree requirement to CLAUDE.md development workflow

## Context

A key differentiator of this adapter is that it uses Microsoft's official `mssql-python` driver instead of pyODBC. This eliminates the need for system-level ODBC dependencies (`unixODBC`, `msodbcsql18`) and platform-specific installation steps that have historically caused many issues. The documentation now makes this advantage clearly visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)