### PR TITLE
Port upstream: push schema filters into source CTEs

### DIFF
--- a/src/dbt/include/fabric/macros/adapters/metadata.sql
+++ b/src/dbt/include/fabric/macros/adapters/metadata.sql
@@ -51,6 +51,7 @@
           SCHEMA_NAME(t.schema_id) as [schema],
           'table' as table_type
       from sys.tables as t {{ information_schema_hints() }}
+      where SCHEMA_NAME(t.schema_id) like '{{ schema_relation.schema }}'
       union all
       select
           DB_NAME() as [database],
@@ -58,6 +59,7 @@
           SCHEMA_NAME(v.schema_id) as [schema],
           'view' as table_type
       from sys.views as v {{ information_schema_hints() }}
+      where SCHEMA_NAME(v.schema_id) like '{{ schema_relation.schema }}'
       union all
       select
           DB_NAME() as [database],
@@ -66,9 +68,9 @@
           'function' as table_type
       from sys.objects as f {{ information_schema_hints() }}
       where f.type_desc like '%function%'
+        and SCHEMA_NAME(f.schema_id) like '{{ schema_relation.schema }}'
     )
     select * from base
-    where [schema] like '{{ schema_relation.schema }}'
     {{ apply_label() }}
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}


### PR DESCRIPTION
## Summary

- Moves WHERE clause (`SCHEMA_NAME(x.schema_id) like ...`) from the outer CTE select into each individual UNION branch in `fabric__list_relations_without_caching`
- Filtering at the source (`sys.tables`, `sys.views`, `sys.objects`) instead of after the UNION reduces row scans and may reduce exposure to lock contention from concurrent DDL

## Origin

Ported from [microsoft/dbt-fabric#365](https://github.com/microsoft/dbt-fabric/pull/365) by @tderk.

Our version has a third UNION branch for functions (`sys.objects`) that the upstream doesn't — the schema filter was pushed into that branch as well.

## Test plan

- [x] `TestListRelationsWithoutCachingSingle` — PASSED
- [x] `TestListRelationsWithoutCachingFull` — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)