### PR TITLE
Port upstream: handle SCHEMA_NOT_FOUND in FabricSpark catalog queries

### DIFF
--- a/src/dbt/adapters/fabricspark/fabricspark_adapter.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_adapter.py
@@ -99,6 +99,17 @@ class FabricSparkAdapter(BaseFabricAdapter, SparkAdapter):
 
         return relations
 
+    def list_relations_without_caching(
+        self, schema_relation: FabricSparkRelation
+    ) -> list[FabricSparkRelation]:
+        try:
+            return super().list_relations_without_caching(schema_relation)
+        except DbtRuntimeError as e:
+            errmsg = getattr(e, "msg", "")
+            if "[SCHEMA_NOT_FOUND]" in errmsg:
+                return []
+            raise
+
     def get_relation(
         self, database: str, schema: str, identifier: str
     ) -> FabricSparkRelation | None:

--- a/tests/fabricspark/adapter/test_list_relations_without_caching.py
+++ b/tests/fabricspark/adapter/test_list_relations_without_caching.py
@@ -1,0 +1,32 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+
+TABLE_BASE_SQL = """
+{{ config(materialized='table') }}
+
+select 1 as id
+""".lstrip()
+
+
+class TestListRelationsWithoutCachingSchemaNotFound:
+    """Verify that list_relations_without_caching gracefully returns an empty list
+    when queried against a non-existent schema, instead of raising [SCHEMA_NOT_FOUND].
+
+    Ported from upstream microsoft/dbt-fabricspark@9d2a8136.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"my_model_base.sql": TABLE_BASE_SQL}
+
+    def test_nonexistent_schema_returns_empty(self, project):
+        run_dbt(["run"])
+
+        fake_schema_relation = project.adapter.Relation.create(
+            database=project.database,
+            schema="this_schema_does_not_exist_xyz",
+        )
+
+        result = project.adapter.list_relations_without_caching(fake_schema_relation)
+        assert result == []


### PR DESCRIPTION
## Summary

- Overrides `list_relations_without_caching` in `FabricSparkAdapter` to catch `[SCHEMA_NOT_FOUND]` errors and return an empty list
- Prevents errors during `dbt docs generate` when catalog queries fan out to source schemas in foreign lakehouses/catalogs
- The inherited SparkAdapter only catches `"Database 'X' not found"` but not Spark structured error codes like `[SCHEMA_NOT_FOUND]`

## Origin

Ported from [microsoft/dbt-fabricspark#180](https://github.com/microsoft/dbt-fabricspark/commit/9d2a8136) (fix(catalog): prevent retry_all storm on [SCHEMA_NOT_FOUND]).

The upstream also adds retry storm prevention (`_is_permanent_error`) in their connection layer — our fork doesn't have the `retry_all` mechanism, so only the `list_relations_without_caching` fix applies.

## Test plan

- [x] `TestListRelationsWithoutCachingSchemaNotFound` — verifies empty list returned for non-existent schema — PASSED
- [x] Regression: existing FabricSpark list_relations and catalog tests — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)