### PR TITLE
Mention original authorship in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A maintained and extended fork of the [dbt-fabric](https://github.com/microsoft/
 - **Fabric Data Warehouse** — T-SQL, uses the mssql-python driver (`type: fabric`)
 - **Fabric Lakehouse** — Spark SQL via Livy sessions (`type: fabricspark`)
 
-This fork has [additional features and bugfixes](https://dbt-fabric.debruyn.dev/feature-comparison/) compared to the original adapter, which was [originally developed by the community](https://github.com/microsoft/dbt-fabric/graphs/contributors) and later adopted by Microsoft. Given Microsoft's limited investments in the adapter, this fork aims to continue its development and maintenance.
+The dbt-fabric adapter was [originally developed by the community](https://github.com/microsoft/dbt-fabric/graphs/contributors) and later adopted by Microsoft. [Sam Debruyn](https://debruyn.dev), one of the original authors and core contributors, continues development and maintenance through this fork. It has [additional features and bugfixes](https://dbt-fabric.debruyn.dev/feature-comparison/) compared to Microsoft's version, which has seen limited investment since adoption.
 
 [![PyPI - Version](https://img.shields.io/pypi/v/dbt-fabric-samdebruyn)](https://pypi.org/project/dbt-fabric-samdebruyn/)
 

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -1,7 +1,6 @@
 # Comparison between dbt-fabric and dbt-fabric-samdebruyn
 
-This adapter has all the features of [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric), plus some additional features.
-The following features are exclusive to dbt-fabric-samdebruyn:
+The dbt-fabric adapter was originally built by community contributors, including [Sam Debruyn](https://debruyn.dev), who continues its development and maintenance through this fork. This adapter has all the features of [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric), plus the following additions:
 
 ## No ODBC driver required
 

--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -1,6 +1,6 @@
 # Comparison between dbt-fabric and dbt-fabric-samdebruyn
 
-The dbt-fabric adapter was originally built by community contributors, including [Sam Debruyn](https://debruyn.dev), who continues its development and maintenance through this fork. This adapter has all the features of [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric), plus the following additions:
+The dbt-fabric adapter was originally built by community contributors, including [Sam Debruyn](https://debruyn.dev), who continues its development and maintenance through this fork. This adapter builds on [Microsoft's dbt-fabric adapter](https://github.com/microsoft/dbt-fabric) with additional features, improvements, and bugfixes. Some of these have since been contributed back upstream.
 
 ## No ODBC driver required
 


### PR DESCRIPTION
## Summary
- Updated README intro to clarify that Sam Debruyn is one of the original authors and core contributors of dbt-fabric, continuing development through this fork
- Updated feature-comparison page with the same attribution

Makes clear to users that this is a continuation of the original work, not a new initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)