### PR TITLE
Add docstrings to custom Fabric adapter methods

### DIFF
--- a/src/dbt/adapters/fabric/base_connection_manager.py
+++ b/src/dbt/adapters/fabric/base_connection_manager.py
@@ -19,12 +19,14 @@ class BaseFabricConnectionManager(SQLConnectionManager, metaclass=abc.ABCMeta):
 
     @classmethod
     def get_fabric_token_provider(cls, credentials: BaseFabricCredentials) -> FabricTokenProvider:
+        """Return a shared FabricTokenProvider, creating one on first call."""
         if cls._fabric_token_provider is None:
             cls._fabric_token_provider = FabricTokenProvider(credentials)
         return cls._fabric_token_provider
 
     @classmethod
     def get_fabric_api_client(cls, credentials: BaseFabricCredentials) -> FabricApiClient:
+        """Return a shared FabricApiClient, creating one on first call."""
         if cls._fabric_api_client is None:
             cls._fabric_api_client = FabricApiClient(
                 credentials, cls.get_fabric_token_provider(credentials)

--- a/src/dbt/adapters/fabric/base_connection_manager.py
+++ b/src/dbt/adapters/fabric/base_connection_manager.py
@@ -19,14 +19,22 @@ class BaseFabricConnectionManager(SQLConnectionManager, metaclass=abc.ABCMeta):
 
     @classmethod
     def get_fabric_token_provider(cls, credentials: BaseFabricCredentials) -> FabricTokenProvider:
-        """Return a shared FabricTokenProvider, creating one on first call."""
+        """Return a shared FabricTokenProvider, creating one on first call.
+
+        Args:
+            credentials: Fabric connection credentials used to configure the provider.
+        """
         if cls._fabric_token_provider is None:
             cls._fabric_token_provider = FabricTokenProvider(credentials)
         return cls._fabric_token_provider
 
     @classmethod
     def get_fabric_api_client(cls, credentials: BaseFabricCredentials) -> FabricApiClient:
-        """Return a shared FabricApiClient, creating one on first call."""
+        """Return a shared FabricApiClient, creating one on first call.
+
+        Args:
+            credentials: Fabric connection credentials used to configure the client.
+        """
         if cls._fabric_api_client is None:
             cls._fabric_api_client = FabricApiClient(
                 credentials, cls.get_fabric_token_provider(credentials)

--- a/src/dbt/adapters/fabric/fabric_adapter.py
+++ b/src/dbt/adapters/fabric/fabric_adapter.py
@@ -253,6 +253,7 @@ class FabricAdapter(BaseFabricAdapter, SQLAdapter):
     def create_or_update_warehouse_snapshot(
         self, snapshot_name: str, description: str | None = None
     ) -> str:
+        """Create a new warehouse snapshot or update an existing one with the same name."""
         api = self.connections.get_fabric_api_client(self.config.credentials)
         api.create_or_update_warehouse_snapshot(snapshot_name, description)
         return ""

--- a/src/dbt/adapters/fabric/fabric_adapter.py
+++ b/src/dbt/adapters/fabric/fabric_adapter.py
@@ -253,7 +253,15 @@ class FabricAdapter(BaseFabricAdapter, SQLAdapter):
     def create_or_update_warehouse_snapshot(
         self, snapshot_name: str, description: str | None = None
     ) -> str:
-        """Create a new warehouse snapshot or update an existing one with the same name."""
+        """Create a new warehouse snapshot or update an existing one with the same name.
+
+        Exposed as a Jinja macro via ``@available``, so it can be called from
+        ``on-run-start``, ``on-run-end``, ``post-hook``, or any other Jinja context.
+
+        Args:
+            snapshot_name: Display name for the snapshot.
+            description: Optional description for the snapshot.
+        """
         api = self.connections.get_fabric_api_client(self.config.credentials)
         api.create_or_update_warehouse_snapshot(snapshot_name, description)
         return ""

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -35,7 +35,12 @@ class FabricApiClient:
     def create(
         cls, credentials: BaseFabricCredentials, token_provider: FabricTokenProvider
     ) -> Self:
-        """Return a shared singleton instance, creating one on first call."""
+        """Return a shared singleton instance, creating one on first call.
+
+        Args:
+            credentials: Fabric connection credentials.
+            token_provider: Provider for Azure access tokens.
+        """
         if cls._instance is None:
             cls._instance = FabricApiClient(credentials, token_provider)
         return cls._instance
@@ -50,7 +55,16 @@ class FabricApiClient:
     def _api_request(
         self, url: str, method: str = "get", body: dict | None = None
     ) -> requests.Response:
-        """Send an authenticated HTTP request, retrying automatically on 429."""
+        """Send an authenticated HTTP request, retrying automatically on 429.
+
+        Args:
+            url: The full API URL.
+            method: HTTP method (get, post, patch, delete).
+            body: Optional JSON body for the request.
+
+        Raises:
+            DbtRuntimeError: If the response status code is not 2xx.
+        """
         response = requests.request(method, url, json=body, headers=self._get_auth_headers())
 
         if response.status_code == 429:
@@ -77,7 +91,15 @@ class FabricApiClient:
         return self._api_request(url, method="delete")
 
     def get_workspace_id(self) -> str:
-        """Resolve the Fabric workspace ID from config or by looking up the workspace name."""
+        """Resolve the Fabric workspace ID from config or by looking up the workspace name.
+
+        Uses the cached value if available, then falls back to ``workspace_id``
+        from credentials, and finally queries the Power BI API by ``workspace_name``.
+
+        Raises:
+            DbtConfigError: If neither workspace_id nor workspace_name is configured.
+            DbtRuntimeError: If no workspace matches the configured name.
+        """
         if self._workspace_id is not None:
             return self._workspace_id
         if self._credentials.workspace_id:
@@ -104,7 +126,12 @@ class FabricApiClient:
         return self._workspace_id
 
     def get_warehouses(self, fetch_all: bool = True) -> list[dict]:
-        """List all Data Warehouses in the workspace, with pagination and caching."""
+        """List all Data Warehouses in the workspace, with pagination and caching.
+
+        Args:
+            fetch_all: If True, follow pagination and cache the full result.
+                If False, return only the first page without caching.
+        """
         if self._cached_warehouses is not None:
             return self._cached_warehouses
 
@@ -123,7 +150,12 @@ class FabricApiClient:
         return warehouses
 
     def get_lakehouses(self, fetch_all: bool = True) -> list[dict]:
-        """List all Lakehouses in the workspace, with pagination and caching."""
+        """List all Lakehouses in the workspace, with pagination and caching.
+
+        Args:
+            fetch_all: If True, follow pagination and cache the full result.
+                If False, return only the first page without caching.
+        """
         if self._cached_lakehouses is not None:
             return self._cached_lakehouses
 
@@ -142,7 +174,14 @@ class FabricApiClient:
         return lakehouses
 
     def get_warehouse_connection_string(self) -> str:
-        """Return the SQL endpoint connection string from any warehouse or lakehouse."""
+        """Return the SQL endpoint connection string from any warehouse or lakehouse.
+
+        All items in a workspace share the same connection string, so the first
+        warehouse or lakehouse found is used.
+
+        Raises:
+            DbtRuntimeError: If no warehouses or lakehouses exist in the workspace.
+        """
         if self._warehouse_connection_string is not None:
             return self._warehouse_connection_string
 
@@ -167,7 +206,12 @@ class FabricApiClient:
         )
 
     def get_lakehouse_id(self) -> str:
-        """Resolve the Lakehouse ID by matching the configured lakehouse name."""
+        """Resolve the Lakehouse ID by matching the configured lakehouse name.
+
+        Raises:
+            DbtConfigError: If no lakehouse name is configured.
+            DbtRuntimeError: If no lakehouse matches the configured name.
+        """
         if self._lakehouse_id is not None:
             return self._lakehouse_id
         if not self._credentials.lakehouse_name:
@@ -184,7 +228,11 @@ class FabricApiClient:
         )
 
     def get_warehouse_id(self) -> str:
-        """Resolve the Data Warehouse ID by matching the configured database name."""
+        """Resolve the Data Warehouse ID by matching the configured database name.
+
+        Raises:
+            DbtRuntimeError: If no warehouse matches the configured database name.
+        """
         if self._warehouse_id is not None:
             return self._warehouse_id
 
@@ -222,7 +270,15 @@ class FabricApiClient:
     def create_warehouse_snapshot(
         self, snapshot_name: str, description: str | None = None
     ) -> None:
-        """Create a new warehouse snapshot and track its long-running operation."""
+        """Create a new warehouse snapshot and track its long-running operation.
+
+        If the API returns a 202 with a Location header, the operation URI is
+        stored so ``create_or_update_warehouse_snapshot`` can poll for completion.
+
+        Args:
+            snapshot_name: Display name for the new snapshot.
+            description: Optional description for the snapshot.
+        """
         url = f"{self._credentials.fabric_base_api_uri}/workspaces/{self.get_workspace_id()}/warehousesnapshots"
         body = {
             "displayName": snapshot_name,
@@ -243,7 +299,13 @@ class FabricApiClient:
     def update_warehouse_snapshot(
         self, snapshot_id: str, snapshot_name: str, description: str | None = None
     ) -> None:
-        """Update the description of an existing warehouse snapshot."""
+        """Update the description of an existing warehouse snapshot.
+
+        Args:
+            snapshot_id: The ID of the snapshot to update.
+            snapshot_name: Display name (used to track the long-running operation).
+            description: New description, or None to leave unchanged.
+        """
         url = f"{self._credentials.fabric_base_api_uri}/workspaces/{self.get_workspace_id()}/warehousesnapshots/{snapshot_id}"
         body: dict[str, Any] = {"properties": {}}
         if description is not None:
@@ -255,7 +317,14 @@ class FabricApiClient:
             self._warehouse_snapshot_operations[snapshot_name] = location_uri
 
     def wait_and_get_snapshot_id_from_operation(self, operation_uri: str) -> str:
-        """Poll a long-running operation until it completes and return the snapshot ID."""
+        """Poll a long-running operation until it completes and return the snapshot ID.
+
+        Args:
+            operation_uri: The Location URI returned by a snapshot create/update call.
+
+        Raises:
+            DbtRuntimeError: If the operation times out or fails.
+        """
         timer = time.time()
         while True:
             if time.time() - timer > self._WAREHOUSE_SNAPSHOT_TIMEOUT_SECONDS:
@@ -282,7 +351,15 @@ class FabricApiClient:
     def create_or_update_warehouse_snapshot(
         self, snapshot_name: str, description: str | None = None
     ) -> None:
-        """Create a snapshot if none exists with this name, otherwise update it."""
+        """Create a snapshot if none exists with this name, otherwise update it.
+
+        If a previous create operation is still pending, waits for it to complete
+        before deciding whether to update or create.
+
+        Args:
+            snapshot_name: Display name for the snapshot.
+            description: Optional description for the snapshot.
+        """
         existing_snapshot_id = None
 
         snapshot_operation_uri = self._warehouse_snapshot_operations.get(snapshot_name)
@@ -303,7 +380,11 @@ class FabricApiClient:
             self.create_warehouse_snapshot(snapshot_name, description)
 
     def delete_warehouse_snapshot(self, snapshot_name: str) -> None:
-        """Delete a warehouse snapshot by its display name."""
+        """Delete a warehouse snapshot by its display name.
+
+        Args:
+            snapshot_name: Display name of the snapshot to delete.
+        """
         for snapshot in self.get_warehouse_snapshots():
             if snapshot["displayName"] == snapshot_name:
                 self._api_delete(
@@ -339,7 +420,11 @@ class FabricApiClient:
         return response.json()["id"]
 
     def get_livy_session_id(self) -> str:
-        """Return the active Livy session ID, reusing an existing session or creating one."""
+        """Return the active Livy session ID, reusing an existing session or creating one.
+
+        Thread-safe: uses a lock to prevent multiple sessions from being created
+        concurrently when dbt runs with multiple threads.
+        """
         if self._livy_session_id is None:
             with _livy_session_thread_lock:
                 self._livy_session_id = (
@@ -357,25 +442,41 @@ class FabricApiClient:
         return response.json().get("state", "unknown")
 
     def get_livy_statement(self, statement_id: int) -> dict[str, Any]:
-        """Fetch the current status and output of a Livy statement."""
+        """Fetch the current status and output of a Livy statement.
+
+        Args:
+            statement_id: The statement ID returned by a submit call.
+        """
         url = self.get_livy_session_base_uri() + f"/statements/{statement_id}"
         response = self._api_get(url)
         return response.json()
 
     def submit_livy_python_statement(self, code: str) -> int:
-        """Submit Python code to the Livy session and return the statement ID."""
+        """Submit Python code to the Livy session and return the statement ID.
+
+        Args:
+            code: The Python/PySpark code to execute.
+        """
         url = self.get_livy_session_base_uri() + "/statements"
         response = self._api_post(url, {"code": code, "kind": "pyspark"})
         return response.json()["id"]
 
     def submit_livy_sql_statement(self, code: str) -> int:
-        """Submit SQL code to the Livy session and return the statement ID."""
+        """Submit SQL code to the Livy session and return the statement ID.
+
+        Args:
+            code: The Spark SQL code to execute.
+        """
         url = self.get_livy_session_base_uri() + "/statements"
         response = self._api_post(url, {"code": code, "kind": "sql"})
         return response.json()["id"]
 
     def cancel_livy_statement(self, statement_id: int) -> str:
-        """Cancel a running Livy statement."""
+        """Cancel a running Livy statement.
+
+        Args:
+            statement_id: The statement ID to cancel.
+        """
         url = self.get_livy_session_base_uri() + f"/statements/{statement_id}/cancel"
         response = self._api_post(url, {})
         return response.json()["msg"]

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -35,6 +35,7 @@ class FabricApiClient:
     def create(
         cls, credentials: BaseFabricCredentials, token_provider: FabricTokenProvider
     ) -> Self:
+        """Return a shared singleton instance, creating one on first call."""
         if cls._instance is None:
             cls._instance = FabricApiClient(credentials, token_provider)
         return cls._instance
@@ -49,6 +50,7 @@ class FabricApiClient:
     def _api_request(
         self, url: str, method: str = "get", body: dict | None = None
     ) -> requests.Response:
+        """Send an authenticated HTTP request, retrying automatically on 429."""
         response = requests.request(method, url, json=body, headers=self._get_auth_headers())
 
         if response.status_code == 429:
@@ -75,6 +77,7 @@ class FabricApiClient:
         return self._api_request(url, method="delete")
 
     def get_workspace_id(self) -> str:
+        """Resolve the Fabric workspace ID from config or by looking up the workspace name."""
         if self._workspace_id is not None:
             return self._workspace_id
         if self._credentials.workspace_id:
@@ -101,6 +104,7 @@ class FabricApiClient:
         return self._workspace_id
 
     def get_warehouses(self, fetch_all: bool = True) -> list[dict]:
+        """List all Data Warehouses in the workspace, with pagination and caching."""
         if self._cached_warehouses is not None:
             return self._cached_warehouses
 
@@ -119,6 +123,7 @@ class FabricApiClient:
         return warehouses
 
     def get_lakehouses(self, fetch_all: bool = True) -> list[dict]:
+        """List all Lakehouses in the workspace, with pagination and caching."""
         if self._cached_lakehouses is not None:
             return self._cached_lakehouses
 
@@ -137,6 +142,7 @@ class FabricApiClient:
         return lakehouses
 
     def get_warehouse_connection_string(self) -> str:
+        """Return the SQL endpoint connection string from any warehouse or lakehouse."""
         if self._warehouse_connection_string is not None:
             return self._warehouse_connection_string
 
@@ -161,6 +167,7 @@ class FabricApiClient:
         )
 
     def get_lakehouse_id(self) -> str:
+        """Resolve the Lakehouse ID by matching the configured lakehouse name."""
         if self._lakehouse_id is not None:
             return self._lakehouse_id
         if not self._credentials.lakehouse_name:
@@ -177,6 +184,7 @@ class FabricApiClient:
         )
 
     def get_warehouse_id(self) -> str:
+        """Resolve the Data Warehouse ID by matching the configured database name."""
         if self._warehouse_id is not None:
             return self._warehouse_id
 
@@ -191,6 +199,7 @@ class FabricApiClient:
         )
 
     def get_warehouse_snapshots(self) -> list[dict]:
+        """List all warehouse snapshots belonging to the current Data Warehouse."""
         warehouse_id = self.get_warehouse_id()
         workspace_id = self.get_workspace_id()
 
@@ -213,6 +222,7 @@ class FabricApiClient:
     def create_warehouse_snapshot(
         self, snapshot_name: str, description: str | None = None
     ) -> None:
+        """Create a new warehouse snapshot and track its long-running operation."""
         url = f"{self._credentials.fabric_base_api_uri}/workspaces/{self.get_workspace_id()}/warehousesnapshots"
         body = {
             "displayName": snapshot_name,
@@ -233,6 +243,7 @@ class FabricApiClient:
     def update_warehouse_snapshot(
         self, snapshot_id: str, snapshot_name: str, description: str | None = None
     ) -> None:
+        """Update the description of an existing warehouse snapshot."""
         url = f"{self._credentials.fabric_base_api_uri}/workspaces/{self.get_workspace_id()}/warehousesnapshots/{snapshot_id}"
         body: dict[str, Any] = {"properties": {}}
         if description is not None:
@@ -244,6 +255,7 @@ class FabricApiClient:
             self._warehouse_snapshot_operations[snapshot_name] = location_uri
 
     def wait_and_get_snapshot_id_from_operation(self, operation_uri: str) -> str:
+        """Poll a long-running operation until it completes and return the snapshot ID."""
         timer = time.time()
         while True:
             if time.time() - timer > self._WAREHOUSE_SNAPSHOT_TIMEOUT_SECONDS:
@@ -270,6 +282,7 @@ class FabricApiClient:
     def create_or_update_warehouse_snapshot(
         self, snapshot_name: str, description: str | None = None
     ) -> None:
+        """Create a snapshot if none exists with this name, otherwise update it."""
         existing_snapshot_id = None
 
         snapshot_operation_uri = self._warehouse_snapshot_operations.get(snapshot_name)
@@ -290,6 +303,7 @@ class FabricApiClient:
             self.create_warehouse_snapshot(snapshot_name, description)
 
     def delete_warehouse_snapshot(self, snapshot_name: str) -> None:
+        """Delete a warehouse snapshot by its display name."""
         for snapshot in self.get_warehouse_snapshots():
             if snapshot["displayName"] == snapshot_name:
                 self._api_delete(
@@ -297,11 +311,13 @@ class FabricApiClient:
                 )
 
     def get_livy_base_api_uri(self) -> str:
+        """Build the Livy API base URI for the configured lakehouse."""
         workspace_id = self.get_workspace_id()
         lakehouse_id = self.get_lakehouse_id()
         return f"{self._credentials.fabric_base_api_uri}/workspaces/{workspace_id}/lakehouses/{lakehouse_id}/livyapi/versions/{self._LIVY_API_VERSION}"
 
     def get_existing_livy_session(self) -> str | None:
+        """Find an active Livy session matching the configured name, or return None."""
         url = self.get_livy_base_api_uri() + "/sessions"
         response = self._api_get(url)
         sessions = response.json().get("items", [])
@@ -316,12 +332,14 @@ class FabricApiClient:
         return None
 
     def initialize_livy_session(self) -> str:
+        """Create a new Livy session and wait briefly for it to start."""
         url = self.get_livy_base_api_uri() + "/sessions"
         response = self._api_post(url, {"name": self._credentials.livy_session_name, "ttl": "30s"})
         time.sleep(10)  # give it a moment to initialize before we try to use it
         return response.json()["id"]
 
     def get_livy_session_id(self) -> str:
+        """Return the active Livy session ID, reusing an existing session or creating one."""
         if self._livy_session_id is None:
             with _livy_session_thread_lock:
                 self._livy_session_id = (
@@ -330,28 +348,34 @@ class FabricApiClient:
         return self._livy_session_id
 
     def get_livy_session_base_uri(self) -> str:
+        """Build the API URI for the current Livy session."""
         return self.get_livy_base_api_uri() + f"/sessions/{self.get_livy_session_id()}"
 
     def get_livy_session_state(self) -> str:
+        """Query the current state of the Livy session (idle, busy, starting, etc.)."""
         response = self._api_get(self.get_livy_session_base_uri())
         return response.json().get("state", "unknown")
 
     def get_livy_statement(self, statement_id: int) -> dict[str, Any]:
+        """Fetch the current status and output of a Livy statement."""
         url = self.get_livy_session_base_uri() + f"/statements/{statement_id}"
         response = self._api_get(url)
         return response.json()
 
     def submit_livy_python_statement(self, code: str) -> int:
+        """Submit Python code to the Livy session and return the statement ID."""
         url = self.get_livy_session_base_uri() + "/statements"
         response = self._api_post(url, {"code": code, "kind": "pyspark"})
         return response.json()["id"]
 
     def submit_livy_sql_statement(self, code: str) -> int:
+        """Submit SQL code to the Livy session and return the statement ID."""
         url = self.get_livy_session_base_uri() + "/statements"
         response = self._api_post(url, {"code": code, "kind": "sql"})
         return response.json()["id"]
 
     def cancel_livy_statement(self, statement_id: int) -> str:
+        """Cancel a running Livy statement."""
         url = self.get_livy_session_base_uri() + f"/statements/{statement_id}/cancel"
         response = self._api_post(url, {})
         return response.json()["msg"]

--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -122,6 +122,7 @@ class FabricConnectionManager(BaseFabricConnectionManager):
 
     @classmethod
     def get_host(cls, credentials: FabricCredentials) -> str:
+        """Resolve the SQL endpoint hostname from config or via the Fabric API."""
         if cls._host is None:
             if credentials.host:
                 cls._host = credentials.host
@@ -257,6 +258,7 @@ class FabricConnectionManager(BaseFabricConnectionManager):
 
     @classmethod
     def data_type_code_to_name(cls, type_code: int | str) -> str:
+        """Map an mssql-python type code to its SQL Server data type name."""
         data_type = str(type_code)[str(type_code).index("'") + 1 : str(type_code).rindex("'")]
         return datatypes[data_type]
 

--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -122,7 +122,17 @@ class FabricConnectionManager(BaseFabricConnectionManager):
 
     @classmethod
     def get_host(cls, credentials: FabricCredentials) -> str:
-        """Resolve the SQL endpoint hostname from config or via the Fabric API."""
+        """Resolve the SQL endpoint hostname from config or via the Fabric API.
+
+        Checks ``credentials.host`` first, then falls back to querying the
+        Fabric API using the configured workspace.
+
+        Args:
+            credentials: Fabric connection credentials.
+
+        Raises:
+            DbtConfigError: If neither host nor workspace is configured.
+        """
         if cls._host is None:
             if credentials.host:
                 cls._host = credentials.host
@@ -258,7 +268,12 @@ class FabricConnectionManager(BaseFabricConnectionManager):
 
     @classmethod
     def data_type_code_to_name(cls, type_code: int | str) -> str:
-        """Map an mssql-python type code to its SQL Server data type name."""
+        """Map an mssql-python type code to its SQL Server data type name.
+
+        Args:
+            type_code: A type code from the cursor's ``description`` attribute,
+                in the format ``<class 'python_type_name'>``.
+        """
         data_type = str(type_code)[str(type_code).index("'") + 1 : str(type_code).rindex("'")]
         return datatypes[data_type]
 

--- a/src/dbt/adapters/fabric/fabric_livy_session.py
+++ b/src/dbt/adapters/fabric/fabric_livy_session.py
@@ -24,7 +24,11 @@ class LivySessionResult:
     json_data: dict[str, Any] | None = field(default_factory=dict)
 
     def to_submission_result(self, code: str) -> LivySubmissionResult:
-        """Convert this result to a LivySubmissionResult for the dbt adapter response."""
+        """Convert this result to a LivySubmissionResult for the dbt adapter response.
+
+        Args:
+            code: The compiled Python code that was submitted.
+        """
         return LivySubmissionResult(
             run_id=str(self.statement_id),
             compiled_code=code,
@@ -44,7 +48,12 @@ class LivySession:
         return f"https://app.fabric.microsoft.com/workloads/de-ds/sparkmonitor/{self._fabric_api_client.get_lakehouse_id()}/{self._fabric_api_client.get_livy_session_id()}"
 
     def wait_for_session_ready(self) -> None:
-        """Poll until the Livy session reaches the idle state, or raise TimeoutError."""
+        """Poll until the Livy session reaches the idle state.
+
+        Raises:
+            TimeoutError: If the session does not become idle within
+                the configured ``spark_session_timeout``.
+        """
         start_time = time.time()
         while self._fabric_api_client.get_livy_session_state() != "idle":
             if (
@@ -55,7 +64,15 @@ class LivySession:
             time.sleep(self._POLLING_INTERVAL)
 
     def wait_for_statement_ready(self, statement_id: int) -> dict[str, Any]:
-        """Poll a Livy statement until it reaches a terminal state, or raise TimeoutError."""
+        """Poll a Livy statement until it reaches a terminal state.
+
+        Args:
+            statement_id: The statement ID to poll.
+
+        Raises:
+            TimeoutError: If the statement does not complete within
+                the configured ``query_timeout``.
+        """
         start_time = time.time()
         while True:
             statement_response = self._fabric_api_client.get_livy_statement(statement_id)
@@ -67,7 +84,14 @@ class LivySession:
             time.sleep(self._POLLING_INTERVAL)
 
     def wait_and_get_statement_result(self, statement_id: int) -> LivySessionResult:
-        """Wait for a statement to complete and return its result, catching timeouts."""
+        """Wait for a statement to complete and return its result.
+
+        Unlike ``wait_for_statement_ready``, this method catches all exceptions
+        and returns a failed ``LivySessionResult`` instead of raising.
+
+        Args:
+            statement_id: The statement ID to wait for.
+        """
         try:
             response = self.wait_for_statement_ready(statement_id)
             return LivySessionResult(
@@ -98,7 +122,17 @@ class LivySession:
     def run_statement(
         self, statement_code: str, statement_language: str, wait_for_result: bool = True
     ) -> LivySessionResult | int:
-        """Submit a Python or SQL statement and optionally wait for its result."""
+        """Submit a Python or SQL statement and optionally wait for its result.
+
+        Waits for the session to be idle before submitting. If submission fails,
+        returns a failed ``LivySessionResult`` instead of raising.
+
+        Args:
+            statement_code: The code to execute.
+            statement_language: Either ``"sql"`` or ``"python"``.
+            wait_for_result: If True, block until the statement completes and
+                return a ``LivySessionResult``. If False, return the statement ID.
+        """
         try:
             self.wait_for_session_ready()
             func = (

--- a/src/dbt/adapters/fabric/fabric_livy_session.py
+++ b/src/dbt/adapters/fabric/fabric_livy_session.py
@@ -24,6 +24,7 @@ class LivySessionResult:
     json_data: dict[str, Any] | None = field(default_factory=dict)
 
     def to_submission_result(self, code: str) -> LivySubmissionResult:
+        """Convert this result to a LivySubmissionResult for the dbt adapter response."""
         return LivySubmissionResult(
             run_id=str(self.statement_id),
             compiled_code=code,
@@ -39,9 +40,11 @@ class LivySession:
         self._fabric_api_client = fabric_api_client
 
     def get_logs_url(self) -> str:
+        """Build the Fabric Portal URL to the Spark monitor logs for this session."""
         return f"https://app.fabric.microsoft.com/workloads/de-ds/sparkmonitor/{self._fabric_api_client.get_lakehouse_id()}/{self._fabric_api_client.get_livy_session_id()}"
 
     def wait_for_session_ready(self) -> None:
+        """Poll until the Livy session reaches the idle state, or raise TimeoutError."""
         start_time = time.time()
         while self._fabric_api_client.get_livy_session_state() != "idle":
             if (
@@ -52,6 +55,7 @@ class LivySession:
             time.sleep(self._POLLING_INTERVAL)
 
     def wait_for_statement_ready(self, statement_id: int) -> dict[str, Any]:
+        """Poll a Livy statement until it reaches a terminal state, or raise TimeoutError."""
         start_time = time.time()
         while True:
             statement_response = self._fabric_api_client.get_livy_statement(statement_id)
@@ -63,6 +67,7 @@ class LivySession:
             time.sleep(self._POLLING_INTERVAL)
 
     def wait_and_get_statement_result(self, statement_id: int) -> LivySessionResult:
+        """Wait for a statement to complete and return its result, catching timeouts."""
         try:
             response = self.wait_for_statement_ready(statement_id)
             return LivySessionResult(
@@ -93,6 +98,7 @@ class LivySession:
     def run_statement(
         self, statement_code: str, statement_language: str, wait_for_result: bool = True
     ) -> LivySessionResult | int:
+        """Submit a Python or SQL statement and optionally wait for its result."""
         try:
             self.wait_for_session_ready()
             func = (

--- a/src/dbt/adapters/fabric/fabric_token_provider.py
+++ b/src/dbt/adapters/fabric/fabric_token_provider.py
@@ -18,7 +18,11 @@ from dbt.adapters.fabric.base_credentials import BaseFabricCredentials
 
 
 def get_notebookutils_access_token(scope: str) -> AccessToken:
-    """Acquire an access token via Fabric notebookutils (for use inside Fabric notebooks)."""
+    """Acquire an access token via Fabric notebookutils (for use inside Fabric notebooks).
+
+    Args:
+        scope: The OAuth scope to request a token for.
+    """
     from notebookutils import credentials
 
     aad_token = credentials.getToken(scope)
@@ -41,7 +45,18 @@ class FabricTokenProvider:
         self.credentials = credentials
 
     def get_access_token(self, scope: str | None = None) -> str:
-        """Return a valid access token for the given scope, refreshing if near expiry."""
+        """Return a valid access token for the given scope, refreshing if near expiry.
+
+        Tokens are cached per scope and reused until they have less than 5 minutes
+        of validity remaining.
+
+        Args:
+            scope: The OAuth scope. Defaults to the Fabric API scope if not provided.
+
+        Raises:
+            ValueError: If the configured authentication method is not supported,
+                or if required credentials (client_id, etc.) are missing.
+        """
         MAX_REMAINING_TIME = 300
 
         if self.credentials.access_token:
@@ -102,7 +117,11 @@ class FabricTokenProvider:
         return token.token
 
     def get_sql_attrs_before(self) -> dict[int, bytes] | None:
-        """Build the SQL connection attrs_before dict with an encoded access token."""
+        """Build the SQL connection attrs_before dict with an encoded access token.
+
+        Returns None when ActiveDirectory authentication is used, since the
+        mssql-python driver handles token acquisition internally in that case.
+        """
         if "ActiveDirectory" in self.credentials.authentication:
             return None
 

--- a/src/dbt/adapters/fabric/fabric_token_provider.py
+++ b/src/dbt/adapters/fabric/fabric_token_provider.py
@@ -18,6 +18,7 @@ from dbt.adapters.fabric.base_credentials import BaseFabricCredentials
 
 
 def get_notebookutils_access_token(scope: str) -> AccessToken:
+    """Acquire an access token via Fabric notebookutils (for use inside Fabric notebooks)."""
     from notebookutils import credentials
 
     aad_token = credentials.getToken(scope)
@@ -40,6 +41,7 @@ class FabricTokenProvider:
         self.credentials = credentials
 
     def get_access_token(self, scope: str | None = None) -> str:
+        """Return a valid access token for the given scope, refreshing if near expiry."""
         MAX_REMAINING_TIME = 300
 
         if self.credentials.access_token:
@@ -100,6 +102,7 @@ class FabricTokenProvider:
         return token.token
 
     def get_sql_attrs_before(self) -> dict[int, bytes] | None:
+        """Build the SQL connection attrs_before dict with an encoded access token."""
         if "ActiveDirectory" in self.credentials.authentication:
             return None
 


### PR DESCRIPTION
## Summary
- Added one-line docstrings to all custom (non-override) methods in `src/dbt/adapters/fabric/`
- Covers 38 methods across 6 files: `FabricApiClient`, `LivySession`, `FabricTokenProvider`, `BaseFabricConnectionManager`, `FabricConnectionManager`, and `FabricAdapter`
- Only targets methods that are specific to this adapter, not overrides of dbt base classes which are already documented upstream

## Test plan
- [x] `ruff format` and `ruff check` pass
- [x] No functional code changes, docstrings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)