### PR TITLE
Fix CI workflows to trigger on main branch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,10 +6,10 @@ on:
     - cron: '0 1 * * 0'
   pull_request:
     branches:
-      - forked-version
+      - main
   push:
     branches:
-      - forked-version
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -5,10 +5,10 @@ permissions:
 on:
   push:
     branches:
-      - forked-version
+      - main
   pull_request:
     branches:
-      - forked-version
+      - main
 
 jobs:
   lint-format:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,7 +9,7 @@ on:
       - '.github/CI.Dockerfile'
       - '.github/workflows/publish-docker.yml'
     branches:
-      - forked-version
+      - main
 
 jobs:
   publish-docker-client:


### PR DESCRIPTION
## Summary
- All CI workflows (integration tests, lint/format, publish Docker) were still configured to trigger on the old `forked-version` branch instead of `main`
- Updated `pull_request` and `push` branch filters in all three workflow files to use `main`
- `release-version.yml` was already correct (triggers on tags)

## Test plan
- [ ] Verify lint workflow triggers on PR to main
- [ ] Verify integration tests trigger on PR to main
- [ ] Verify Docker publish triggers on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)