### PR TITLE
Skip unsupported GRANT tests for FabricSpark

### DIFF
--- a/tests/fabricspark/adapter/test_grants.py
+++ b/tests/fabricspark/adapter/test_grants.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt.tests.adapter.grants.test_incremental_grants import BaseIncrementalGrants
 from dbt.tests.adapter.grants.test_invalid_grants import BaseInvalidGrants
 from dbt.tests.adapter.grants.test_model_grants import BaseModelGrants
@@ -5,21 +7,26 @@ from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
 from dbt.tests.adapter.grants.test_snapshot_grants import BaseSnapshotGrants
 
 
+@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
 class TestModelGrantsFabricSpark(BaseModelGrants):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
 class TestSeedGrantsFabricSpark(BaseSeedGrants):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
 class TestSnapshotGrantsFabricSpark(BaseSnapshotGrants):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
 class TestIncrementalGrantsFabricSpark(BaseIncrementalGrants):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
 class TestInvalidGrantsFabricSpark(BaseInvalidGrants):
     pass

--- a/tests/fabricspark/adapter/test_grants.py
+++ b/tests/fabricspark/adapter/test_grants.py
@@ -7,26 +7,26 @@ from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
 from dbt.tests.adapter.grants.test_snapshot_grants import BaseSnapshotGrants
 
 
-@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
+@pytest.mark.skip("FabricSpark Lakehouse uses workspace-level access control, not SQL GRANT")
 class TestModelGrantsFabricSpark(BaseModelGrants):
     pass
 
 
-@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
+@pytest.mark.skip("FabricSpark Lakehouse uses workspace-level access control, not SQL GRANT")
 class TestSeedGrantsFabricSpark(BaseSeedGrants):
     pass
 
 
-@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
+@pytest.mark.skip("FabricSpark Lakehouse uses workspace-level access control, not SQL GRANT")
 class TestSnapshotGrantsFabricSpark(BaseSnapshotGrants):
     pass
 
 
-@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
+@pytest.mark.skip("FabricSpark Lakehouse uses workspace-level access control, not SQL GRANT")
 class TestIncrementalGrantsFabricSpark(BaseIncrementalGrants):
     pass
 
 
-@pytest.mark.skip("TODO: FabricSpark Lakehouse does not support GRANT operations")
+@pytest.mark.skip("FabricSpark Lakehouse uses workspace-level access control, not SQL GRANT")
 class TestInvalidGrantsFabricSpark(BaseInvalidGrants):
     pass


### PR DESCRIPTION
## Summary
- Skip all GRANT test classes — Fabric Lakehouse uses workspace-level access control, not SQL GRANT

## Comparison with dbt-spark / dbt-databricks

| Adapter | Status | Implementation |
|---|---|---|
| **dbt-spark** | ✅ Implements | Spark SQL supports `GRANT ... ON ... TO` syntax. Custom privilege mapping (`insert` → `modify`). |
| **dbt-databricks** | ⚪ Skipped (infra) | Tests exist but are skipped due to missing test users (`DBT_TEST_USER_1/2/3`), not capability |
| **dbt-fabric (current)** | ❌ Skipped | Correctly identifies this as an architectural difference |

**Skip is justified**: While standard Spark SQL supports `GRANT/REVOKE`, Fabric Lakehouse does **not** expose SQL-level access control. Permissions are managed at the workspace/item level via the Fabric portal or REST API, not via SQL statements. This is a fundamental architectural difference — Fabric's security model doesn't map to SQL GRANT semantics. A shim would require integration with the Fabric permission REST API, which is out of scope for a dbt adapter.

## Test plan
- [x] Verify skipped tests show appropriate skip reason in pytest output

🤖 Generated with [Claude Code](https://claude.com/claude-code)