### PR TITLE
Add FabricSpark persist_docs support

### DIFF
--- a/src/dbt/adapters/fabricspark/fabricspark_adapter.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_adapter.py
@@ -128,6 +128,8 @@ class FabricSparkAdapter(BaseFabricAdapter, SparkAdapter):
         rows = [row for row in raw_rows[0:pos] if not row["col_name"].startswith("#")]
         metadata = {col["col_name"]: col["data_type"] for col in raw_rows[pos + 1 :]}
 
+        table_comment = metadata.get("Comment") or None
+
         return [
             FabricSparkColumn(
                 table_catalog=relation.catalog,
@@ -136,9 +138,11 @@ class FabricSparkAdapter(BaseFabricAdapter, SparkAdapter):
                 table_name=relation.name,
                 table_type=FabricSparkRelation.try_translate_type(metadata.get("Type"))
                 or relation.type,
+                table_comment=table_comment,
                 column=column["col_name"],
                 column_index=idx,
                 dtype=column["data_type"],
+                column_comment=column.get("comment") or None,
             )
             for idx, column in enumerate(rows)
         ]

--- a/src/dbt/adapters/fabricspark/fabricspark_column.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_column.py
@@ -6,3 +6,5 @@ from dbt.adapters.spark.column import SparkColumn
 @dataclass
 class FabricSparkColumn(SparkColumn):
     table_catalog: str | None = None
+    table_comment: str | None = None
+    column_comment: str | None = None

--- a/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
@@ -7,23 +7,21 @@
     {% do run_query(comment_query) %}
   {% endif %}
   {% if for_columns and config.persist_column_docs() and model.columns %}
-    {% do alter_column_comment(relation, model.columns) %}
+    {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
+    {% set filtered_columns = validate_doc_columns(relation, model.columns, existing_columns) %}
+    {% do alter_column_comment(relation, filtered_columns) %}
   {% endif %}
 {% endmacro %}
 
 {% macro fabricspark__alter_column_comment(relation, column_dict) %}
-  {% set existing_columns = adapter.get_columns_in_relation(relation) %}
-  {% set existing_column_names = existing_columns | map(attribute='name') | list %}
   {% for column_name in column_dict %}
-    {% if column_name in existing_column_names %}
-      {% set comment = column_dict[column_name]['description'] %}
-      {% set escaped_comment = comment | replace('\'', '\\\'') %}
-      {% set comment_query %}
-        alter table {{ relation }} change column
-            {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
-            comment '{{ escaped_comment }}';
-      {% endset %}
-      {% do run_query(comment_query) %}
-    {% endif %}
+    {% set comment = column_dict[column_name]['description'] %}
+    {% set escaped_comment = comment | replace('\'', '\\\'') %}
+    {% set comment_query %}
+      alter table {{ relation }} change column
+          {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
+          comment '{{ escaped_comment }}';
+    {% endset %}
+    {% do run_query(comment_query) %}
   {% endfor %}
 {% endmacro %}

--- a/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
@@ -12,14 +12,18 @@
 {% endmacro %}
 
 {% macro fabricspark__alter_column_comment(relation, column_dict) %}
+  {% set existing_columns = adapter.get_columns_in_relation(relation) %}
+  {% set existing_column_names = existing_columns | map(attribute='name') | list %}
   {% for column_name in column_dict %}
-    {% set comment = column_dict[column_name]['description'] %}
-    {% set escaped_comment = comment | replace('\'', '\\\'') %}
-    {% set comment_query %}
-      alter table {{ relation }} change column
-          {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
-          comment '{{ escaped_comment }}';
-    {% endset %}
-    {% do run_query(comment_query) %}
+    {% if column_name in existing_column_names %}
+      {% set comment = column_dict[column_name]['description'] %}
+      {% set escaped_comment = comment | replace('\'', '\\\'') %}
+      {% set comment_query %}
+        alter table {{ relation }} change column
+            {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
+            comment '{{ escaped_comment }}';
+      {% endset %}
+      {% do run_query(comment_query) %}
+    {% endif %}
   {% endfor %}
 {% endmacro %}

--- a/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
@@ -1,0 +1,29 @@
+{% macro fabricspark__persist_docs(relation, model, for_relation, for_columns) -%}
+  {% if for_relation and config.persist_relation_docs() and model.description %}
+    {% set escaped_comment = model.description | replace("'", "\\'") %}
+    {% set comment_query %}
+      comment on table {{ relation }} is '{{ escaped_comment }}';
+    {% endset %}
+    {% do run_query(comment_query) %}
+  {% endif %}
+  {% if for_columns and config.persist_column_docs() and model.columns %}
+    {% do alter_column_comment(relation, model.columns) %}
+  {% endif %}
+{% endmacro %}
+
+{% macro fabricspark__alter_column_comment(relation, column_dict) %}
+  {% set existing_columns = adapter.get_columns_in_relation(relation) %}
+  {% set existing_column_names = existing_columns | map(attribute='name') | list %}
+  {% for column_name in column_dict %}
+    {% if column_name in existing_column_names %}
+      {% set comment = column_dict[column_name]['description'] %}
+      {% set escaped_comment = comment | replace('\'', '\\\'') %}
+      {% set comment_query %}
+        alter table {{ relation }} change column
+            {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
+            comment '{{ escaped_comment }}';
+      {% endset %}
+      {% do run_query(comment_query) %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}

--- a/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
@@ -12,18 +12,14 @@
 {% endmacro %}
 
 {% macro fabricspark__alter_column_comment(relation, column_dict) %}
-  {% set existing_columns = adapter.get_columns_in_relation(relation) %}
-  {% set existing_column_names = existing_columns | map(attribute='name') | list %}
   {% for column_name in column_dict %}
-    {% if column_name in existing_column_names %}
-      {% set comment = column_dict[column_name]['description'] %}
-      {% set escaped_comment = comment | replace('\'', '\\\'') %}
-      {% set comment_query %}
-        alter table {{ relation }} change column
-            {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
-            comment '{{ escaped_comment }}';
-      {% endset %}
-      {% do run_query(comment_query) %}
-    {% endif %}
+    {% set comment = column_dict[column_name]['description'] %}
+    {% set escaped_comment = comment | replace('\'', '\\\'') %}
+    {% set comment_query %}
+      alter table {{ relation }} change column
+          {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
+          comment '{{ escaped_comment }}';
+    {% endset %}
+    {% do run_query(comment_query) %}
   {% endfor %}
 {% endmacro %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/materialized_view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/materialized_view.sql
@@ -46,6 +46,8 @@
         {{ adapter.rename_relation(intermediate_relation, target_relation) }}
     {% endif %}
 
+    {% do persist_docs(target_relation, model) %}
+
     {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 

--- a/src/dbt/include/fabricspark/macros/relations/materialized_view/create.sql
+++ b/src/dbt/include/fabricspark/macros/relations/materialized_view/create.sql
@@ -1,6 +1,5 @@
 {% macro fabricspark__get_create_materialized_view_as_sql(relation, sql) %}
     {%- set partition_by = config.get('partition_by', none) -%}
-    {%- set comment = model.description if config.persist_relation_docs() and model.description else none -%}
     {%- set tblproperties = config.get('tblproperties', none) -%}
     {%- set raw_constraints = model['constraints'] -%}
 
@@ -16,9 +15,6 @@
     {%- endif %}
     {%- if partition_by %}
     PARTITIONED BY ({{ partition_by | join(', ') }})
-    {%- endif %}
-    {%- if comment %}
-    COMMENT "{{ comment }}"
     {%- endif %}
     {%- if tblproperties %}
     TBLPROPERTIES (

--- a/tests/fabricspark/adapter/test_persist_docs.py
+++ b/tests/fabricspark/adapter/test_persist_docs.py
@@ -21,6 +21,7 @@ select 2 as id, 'Bob' as name
         }
 
 
+@pytest.mark.skip("Fabric Lakehouse errors on ALTER TABLE CHANGE COLUMN for non-existent columns")
 class TestPersistDocsColumnMissingFabricSpark(BasePersistDocsColumnMissing):
     pass
 

--- a/tests/fabricspark/adapter/test_persist_docs.py
+++ b/tests/fabricspark/adapter/test_persist_docs.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dbt.tests.adapter.persist_docs import fixtures
 from dbt.tests.adapter.persist_docs.test_persist_docs import (
     BasePersistDocs,
     BasePersistDocsColumnMissing,
@@ -7,16 +8,22 @@ from dbt.tests.adapter.persist_docs.test_persist_docs import (
 )
 
 
-@pytest.mark.skip("TODO: FabricSpark does not support table/column comments via Spark SQL")
 class TestPersistDocsFabricSpark(BasePersistDocs):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "no_docs_model.sql": fixtures._MODELS__NO_DOCS_MODEL,
+            "table_model.sql": fixtures._MODELS__TABLE,
+            "view_model.sql": """
+{{ config(materialized='materialized_view') }}
+select 2 as id, 'Bob' as name
+""",
+        }
 
 
-@pytest.mark.skip("TODO: FabricSpark does not support table/column comments via Spark SQL")
 class TestPersistDocsColumnMissingFabricSpark(BasePersistDocsColumnMissing):
     pass
 
 
-@pytest.mark.skip("TODO: FabricSpark does not support table/column comments via Spark SQL")
 class TestPersistDocsCommentOnQuotedColumnFabricSpark(BasePersistDocsCommentOnQuotedColumn):
     pass

--- a/tests/fabricspark/adapter/test_persist_docs.py
+++ b/tests/fabricspark/adapter/test_persist_docs.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt.tests.adapter.persist_docs.test_persist_docs import (
     BasePersistDocs,
     BasePersistDocsColumnMissing,
@@ -5,13 +7,16 @@ from dbt.tests.adapter.persist_docs.test_persist_docs import (
 )
 
 
+@pytest.mark.skip("TODO: FabricSpark does not support table/column comments via Spark SQL")
 class TestPersistDocsFabricSpark(BasePersistDocs):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark does not support table/column comments via Spark SQL")
 class TestPersistDocsColumnMissingFabricSpark(BasePersistDocsColumnMissing):
     pass
 
 
+@pytest.mark.skip("TODO: FabricSpark does not support table/column comments via Spark SQL")
 class TestPersistDocsCommentOnQuotedColumnFabricSpark(BasePersistDocsCommentOnQuotedColumn):
     pass

--- a/tests/fabricspark/adapter/test_persist_docs.py
+++ b/tests/fabricspark/adapter/test_persist_docs.py
@@ -21,7 +21,6 @@ select 2 as id, 'Bob' as name
         }
 
 
-@pytest.mark.skip("Fabric Lakehouse errors on ALTER TABLE CHANGE COLUMN for non-existent columns")
 class TestPersistDocsColumnMissingFabricSpark(BasePersistDocsColumnMissing):
     pass
 


### PR DESCRIPTION
## Summary

Adds full persist_docs support for FabricSpark — both table-level and column-level comments are now written to Delta metadata and read back in the catalog.

### What changed

**New macro: `fabricspark__persist_docs`** — Overrides dbt-spark's persist_docs to use `COMMENT ON TABLE ... IS '...'` for table comments (the `COMMENT` clause in `CREATE MATERIALIZED LAKE VIEW` DDL is silently ignored by Fabric) and delegates column comments to `alter_column_comment`.

**New macro: `fabricspark__alter_column_comment`** — Overrides dbt-spark's version to skip the `file_format` check (Fabric Lakehouse tables are always Delta) and gracefully skip columns listed in schema.yml that don't exist in the actual table.

**Materialized view materialization** — Added `persist_docs()` call (was missing).

**Catalog support** — Added `table_comment` and `column_comment` fields to `FabricSparkColumn` and populated them from `DESCRIBE TABLE EXTENDED` output in `parse_describe_extended`. Comments now appear in `dbt docs generate` catalog output.

**DDL cleanup** — Removed the broken `COMMENT "..."` clause from the materialized lake view DDL (it used unescaped double quotes and Fabric silently discards the comment anyway).

### Key findings from manual testing

- All three Delta comment syntaxes work in Fabric Lakehouse: `COMMENT ON TABLE`, `ALTER TABLE CHANGE COLUMN COMMENT`, and `ALTER TABLE ALTER COLUMN COMMENT`
- Comments are stored in Delta Lake metadata and visible via `DESCRIBE TABLE EXTENDED`
- Comments are **not displayed in the Fabric UI**, but are accessible to catalog tools that read Delta metadata directly (e.g. Purview)
- The `COMMENT` clause in `CREATE MATERIALIZED LAKE VIEW` DDL is accepted but **silently discarded** — `COMMENT ON TABLE` after creation is the only way to persist table comments on materialized views

## Test plan

- [x] Manually verified `ALTER TABLE ... CHANGE COLUMN ... COMMENT` works in Fabric Lakehouse
- [x] `TestPersistDocsFabricSpark` — table + materialized view with table and column comments
- [x] `TestPersistDocsColumnMissingFabricSpark` — column in schema.yml but not in table is gracefully skipped
- [x] `TestPersistDocsCommentOnQuotedColumnFabricSpark` — backtick-quoted column name with comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)