### PR TITLE
Fix FabricSpark relation type change test

### DIFF
--- a/tests/fabricspark/adapter/test_relations.py
+++ b/tests/fabricspark/adapter/test_relations.py
@@ -9,7 +9,6 @@ class TestChangeRelationTypesFabricSpark(BaseChangeRelationTypeValidator):
         self._run_and_check_materialization("materialized_view")
         self._run_and_check_materialization("table")
         self._run_and_check_materialization("materialized_view")
-        self._run_and_check_materialization("incremental")
         self._run_and_check_materialization("table", extra_args=["--full-refresh"])
 
 

--- a/tests/fabricspark/adapter/test_relations.py
+++ b/tests/fabricspark/adapter/test_relations.py
@@ -1,16 +1,16 @@
-import pytest
-
 from dbt.tests.adapter.relations.test_changing_relation_type import (
     BaseChangeRelationTypeValidator,
 )
 from dbt.tests.adapter.relations.test_dropping_schema_named import BaseDropSchemaNamed
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark relation type changes between table and materialized_view need custom handling"
-)
 class TestChangeRelationTypesFabricSpark(BaseChangeRelationTypeValidator):
-    pass
+    def test_changing_materialization_changes_relation_type(self, project):
+        self._run_and_check_materialization("materialized_view")
+        self._run_and_check_materialization("table")
+        self._run_and_check_materialization("materialized_view")
+        self._run_and_check_materialization("incremental")
+        self._run_and_check_materialization("table", extra_args=["--full-refresh"])
 
 
 class TestDropSchemaNamedFabricSpark(BaseDropSchemaNamed):

--- a/tests/fabricspark/adapter/test_relations.py
+++ b/tests/fabricspark/adapter/test_relations.py
@@ -1,9 +1,14 @@
+import pytest
+
 from dbt.tests.adapter.relations.test_changing_relation_type import (
     BaseChangeRelationTypeValidator,
 )
 from dbt.tests.adapter.relations.test_dropping_schema_named import BaseDropSchemaNamed
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark relation type changes between table and materialized_view need custom handling"
+)
 class TestChangeRelationTypesFabricSpark(BaseChangeRelationTypeValidator):
     pass
 

--- a/tests/fabricspark/adapter/test_relations.py
+++ b/tests/fabricspark/adapter/test_relations.py
@@ -9,6 +9,7 @@ class TestChangeRelationTypesFabricSpark(BaseChangeRelationTypeValidator):
         self._run_and_check_materialization("materialized_view")
         self._run_and_check_materialization("table")
         self._run_and_check_materialization("materialized_view")
+        self._run_and_check_materialization("incremental")
         self._run_and_check_materialization("table", extra_args=["--full-refresh"])
 
 


### PR DESCRIPTION
## Summary
- Override the test method to use `materialized_view` instead of `view` (FabricSpark has no Spark SQL view support)
- Keep the `incremental` step — the FabricSpark incremental materialization (#63) uses real staging tables and `MERGE INTO` workarounds that handle the 3-part name issues

The test now covers: `materialized_view → table → materialized_view → incremental → table (--full-refresh)`.

## Test plan
- [ ] Run `uv run pytest -k "TestChangeRelationTypesFabricSpark" --de -v` to verify the test passes (requires #63 to be merged first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)