### PR TITLE
Fix FabricSpark unit testing tests

### DIFF
--- a/tests/fabricspark/adapter/test_unit_testing.py
+++ b/tests/fabricspark/adapter/test_unit_testing.py
@@ -8,9 +8,27 @@ from dbt.tests.adapter.unit_testing.test_quoted_reserved_word_column_names impor
 from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
 
 
-@pytest.mark.skip("TODO: FabricSpark unit test data type handling differs from standard adapters")
 class TestFabricSparkUnitTestingTypes(BaseUnitTestingTypes):
-    pass
+    @pytest.fixture
+    def data_types(self):
+        return [
+            ["1", "1"],
+            ["2.0", "2.0"],
+            ["'12345'", "12345"],
+            ["'string'", "string"],
+            ["true", "true"],
+            ["date '2011-11-11'", "2011-11-11"],
+            ["timestamp '2013-11-03 00:00:00-0'", "2013-11-03 00:00:00-0"],
+            ["array(1, 2, 3)", "'array(1, 2, 3)'"],
+            [
+                "map('10', 't', '15', 'f', '20', NULL)",
+                """'map("10", "t", "15", "f", "20", NULL)'""",
+            ],
+            [
+                'named_struct("a", 1, "b", 2, "c", 3)',
+                """'named_struct("a", 1, "b", 2, "c", 3)'""",
+            ],
+        ]
 
 
 class TestFabricSparkUnitTestCaseInsensivity(BaseUnitTestCaseInsensivity):
@@ -21,9 +39,6 @@ class TestFabricSparkUnitTestInvalidInput(BaseUnitTestInvalidInput):
     pass
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark quoted reserved word column names need Spark SQL compatible quoting"
-)
 class TestFabricSparkUnitTestQuotedReservedWordColumnNames(
     BaseUnitTestQuotedReservedWordColumnNames,
 ):

--- a/tests/fabricspark/adapter/test_unit_testing.py
+++ b/tests/fabricspark/adapter/test_unit_testing.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestCaseInsensivity
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
 from dbt.tests.adapter.unit_testing.test_quoted_reserved_word_column_names import (
@@ -6,6 +8,7 @@ from dbt.tests.adapter.unit_testing.test_quoted_reserved_word_column_names impor
 from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
 
 
+@pytest.mark.skip("TODO: FabricSpark unit test data type handling differs from standard adapters")
 class TestFabricSparkUnitTestingTypes(BaseUnitTestingTypes):
     pass
 
@@ -18,6 +21,9 @@ class TestFabricSparkUnitTestInvalidInput(BaseUnitTestInvalidInput):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark quoted reserved word column names need Spark SQL compatible quoting"
+)
 class TestFabricSparkUnitTestQuotedReservedWordColumnNames(
     BaseUnitTestQuotedReservedWordColumnNames,
 ):

--- a/tests/fabricspark/adapter/test_unit_testing.py
+++ b/tests/fabricspark/adapter/test_unit_testing.py
@@ -4,11 +4,17 @@ from dbt.tests.adapter.unit_testing.test_case_insensitivity import BaseUnitTestC
 from dbt.tests.adapter.unit_testing.test_invalid_input import BaseUnitTestInvalidInput
 from dbt.tests.adapter.unit_testing.test_quoted_reserved_word_column_names import (
     BaseUnitTestQuotedReservedWordColumnNames,
+    my_model_sql,
+    test_my_model_csv_fixtures_yml,
 )
 from dbt.tests.adapter.unit_testing.test_types import BaseUnitTestingTypes
 
 
 class TestFabricSparkUnitTestingTypes(BaseUnitTestingTypes):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+materialized": "table"}}
+
     @pytest.fixture
     def data_types(self):
         return [
@@ -17,17 +23,9 @@ class TestFabricSparkUnitTestingTypes(BaseUnitTestingTypes):
             ["'12345'", "12345"],
             ["'string'", "string"],
             ["true", "true"],
+            ["cast(1.0 as float)", "1.0"],
             ["date '2011-11-11'", "2011-11-11"],
             ["timestamp '2013-11-03 00:00:00-0'", "2013-11-03 00:00:00-0"],
-            ["array(1, 2, 3)", "'array(1, 2, 3)'"],
-            [
-                "map('10', 't', '15', 'f', '20', NULL)",
-                """'map("10", "t", "15", "f", "20", NULL)'""",
-            ],
-            [
-                'named_struct("a", 1, "b", 2, "c", 3)',
-                """'named_struct("a", 1, "b", 2, "c", 3)'""",
-            ],
         ]
 
 
@@ -42,4 +40,10 @@ class TestFabricSparkUnitTestInvalidInput(BaseUnitTestInvalidInput):
 class TestFabricSparkUnitTestQuotedReservedWordColumnNames(
     BaseUnitTestQuotedReservedWordColumnNames,
 ):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "my_upstream_model.sql": "select 1 as `GROUP`",
+            "unit_tests.yml": test_my_model_csv_fixtures_yml,
+        }


### PR DESCRIPTION
## Summary
- Override `data_types` fixture with Spark-compatible types
- Use `table` materialization for the types test (lake views reject schema changes between iterations)
- Override `models` fixture for the quoted reserved words test to use backtick quoting

## `data_types` fixture comparison

| Type | dbt-adapters (PG) | dbt-spark | dbt-databricks | Fabric DW | FabricSpark (this PR) |
|---|---|---|---|---|---|
| int | `1` | `1` | `1` | `1` | `1` |
| decimal | — | `2.0` | `2.0` | — | `2.0` |
| string (numeric) | `'1'` | `'12345'` | `'1'` | `'1'` | `'12345'` |
| string (alpha) | — | `'string'` | `'string'` | — | `'string'` |
| boolean | `true` | `true` | `true` | — | `true` |
| float | — | — | — | — | `cast(1.0 as float)` |
| date | `DATE '...'` | `date '...'` | `DATE '...'` | `CAST(... AS DATE)` | `date '...'` |
| timestamp | `TIMESTAMP '...'` | `timestamp '...'` | `TIMESTAMP '...'` | `CAST(... AS DATETIME2(6))` | `timestamp '...'` |
| timestamptz | `TIMESTAMPTZ '...'` | — | — | — | — |
| `::numeric` cast | ✅ | — | ✅ | — | — |
| `::json` cast | ✅ | — | — | — | — |
| array/map/struct | — (TODO) | ✅ | ✅ | — | — |

Complex types (array/map/struct) are included in dbt-spark and dbt-databricks, but fail in Fabric's Spark with `'dict' object has no attribute 'lower'` in the unit test comparison framework.

## `BaseUnitTestQuotedReservedWordColumnNames` comparison

| Adapter | Tests it? | Override |
|---|---|---|
| dbt-adapters (PG) | ✅ defines it | `select 1 as "GROUP"` |
| dbt-spark | ❌ | — |
| dbt-databricks | ❌ | — |
| Fabric DW | ✅ inherits base | None (T-SQL supports double-quoted identifiers) |
| FabricSpark (this PR) | ✅ | Overrides model to use `` `GROUP` `` (backtick quoting) |

## Test results
- [x] `TestFabricSparkUnitTestingTypes` — PASS
- [x] `TestFabricSparkUnitTestQuotedReservedWordColumnNames` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)