### PR TITLE
Fix FabricSpark PySpark dataframe test

### DIFF
--- a/tests/fabricspark/adapter/test_python_model.py
+++ b/tests/fabricspark/adapter/test_python_model.py
@@ -8,6 +8,7 @@ from dbt.tests.adapter.python_model.test_python_model import (
     BasePythonSampleTests,
 )
 from dbt.tests.adapter.python_model.test_spark import BasePySparkTests
+from dbt.tests.util import run_dbt
 
 pytestmark = pytest.mark.python_model
 
@@ -21,7 +22,9 @@ class TestPythonIncrementalTestsFabricSpark(BasePythonIncrementalTests):
 
 
 class TestPySparkTestsFabricSpark(BasePySparkTests):
-    pass
+    def test_different_dataframes(self, project):
+        results = run_dbt(["run", "--exclude", "koalas_df"])
+        assert len(results) == 3
 
 
 class TestPythonEmptyTestsFabricSpark(BasePythonEmptyTests):


### PR DESCRIPTION
## Summary

The `BasePySparkTests.test_different_dataframes` base test runs 4 Python model types: `pandas_df`, `pyspark_df`, `pandas_on_spark_df`, and `koalas_df`. The `koalas_df` model uses `databricks.koalas`, a deprecated library that is not available on Fabric Spark runtimes. Without an override, the inherited test fails because the koalas import errors out.

This PR overrides `test_different_dataframes` to exclude `koalas_df` and assert 3 successful results, following the same pattern as dbt-spark.

## Comparison with other adapters

| Layer | What it does |
|---|---|
| **dbt-adapters** (base) | Runs all 4 dataframe types, expects 4 results |
| **dbt-spark** | Excludes `koalas_df` via `--exclude`, expects 3 results — koalas is unavailable on Spark >3.1 |
| **dbt-databricks** | Overrides the `models` fixture to remove `pandas_on_spark_df` (ANSI mode issues), expects 2 results |
| **Fabric DW** | Skips the entire `TestPySparkTests` class — only PySpark dataframes are supported via Livy |
| **FabricSpark (this PR)** | Excludes `koalas_df` via `--exclude`, expects 3 results — identical to dbt-spark's approach |

No macro changes needed — this is a library availability issue, not a SQL dialect issue.

## Test plan

- [x] `uv run pytest -k "TestPySparkTests" --de --with-python -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)