### PR TITLE
Fix FabricSpark basic tests with materialized_view overrides

### DIFF
--- a/tests/fabricspark/adapter/test_basic.py
+++ b/tests/fabricspark/adapter/test_basic.py
@@ -1,9 +1,19 @@
 import pytest
 
-from dbt.tests.adapter.basic import files
+from dbt.tests.adapter.basic import expected_catalog, files
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
-from dbt.tests.adapter.basic.test_docs_generate import BaseDocsGenerate, BaseDocsGenReferences
+from dbt.tests.adapter.basic.test_docs_generate import (
+    BaseDocsGenerate,
+    BaseDocsGenReferences,
+    models__readme_md,
+    models__schema_yml,
+    ref_models__docs_md,
+    ref_models__ephemeral_copy_sql,
+    ref_models__ephemeral_summary_sql,
+    ref_models__schema_yml,
+    ref_sources__schema_yml,
+)
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
@@ -24,6 +34,7 @@ from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestam
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
 from dbt.tests.util import (
+    AnyInteger,
     check_relation_types,
     check_relations_equal,
     check_result_nodes_by_name,
@@ -206,18 +217,85 @@ class TestValidateConnectionSpark(BaseValidateConnection):
     pass
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark catalog types differ from defaults, needs expected_catalog override"
-)
 class TestDocsGenerateSpark(BaseDocsGenerate):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": models__schema_yml,
+            "second_model.sql": """
+{{
+    config(
+        materialized='materialized_view',
+        schema='test',
+    )
+}}
+
+select * from {{ ref('seed') }}
+""",
+            "readme.md": models__readme_md,
+            "model.sql": """
+{{
+    config(
+        materialized='materialized_view',
+    )
+}}
+
+select * from {{ ref('seed') }}
+""",
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_catalog(self, project, profile_user):
+        return expected_catalog.base_expected_catalog(
+            project,
+            role=None,
+            id_type="bigint",
+            text_type="string",
+            time_type="timestamp",
+            view_type="materialized_view",
+            table_type="table",
+            model_stats=expected_catalog.no_stats(),
+        )
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark catalog types differ from defaults, needs expected_catalog override"
-)
 class TestDocsGenReferencesSpark(BaseDocsGenReferences):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": ref_models__schema_yml,
+            "sources.yml": ref_sources__schema_yml,
+            "view_summary.sql": """
+{{
+  config(
+    materialized = "materialized_view"
+  )
+}}
+
+select first_name, ct from {{ref('ephemeral_summary')}}
+""",
+            "ephemeral_summary.sql": ref_models__ephemeral_summary_sql,
+            "ephemeral_copy.sql": ref_models__ephemeral_copy_sql,
+            "docs.md": ref_models__docs_md,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_catalog(self, project, profile_user):
+        catalog = expected_catalog.expected_references_catalog(
+            project,
+            role=None,
+            id_type="bigint",
+            text_type="string",
+            time_type="timestamp",
+            bigint_type="bigint",
+            view_type="materialized_view",
+            table_type="table",
+            model_stats=expected_catalog.no_stats(),
+        )
+        for section in catalog.values():
+            for node in section.values():
+                for col in node.get("columns", {}).values():
+                    col["index"] = AnyInteger()
+        return catalog
 
 
 class TestTableMaterializationSpark(BaseTableMaterialization):

--- a/tests/fabricspark/adapter/test_basic.py
+++ b/tests/fabricspark/adapter/test_basic.py
@@ -199,6 +199,7 @@ class TestBaseCachingSpark(BaseAdapterMethod):
 
     {%- do adapter.create_schema(upstream) -%}
 
+    {# upstream uses create_view_as — FabricSpark has no view support #}
     {% set sql = create_table_as(False, upstream, 'select 2 as id') %}
     {% do run_query(sql) %}
 {% endif %}

--- a/tests/fabricspark/adapter/test_basic.py
+++ b/tests/fabricspark/adapter/test_basic.py
@@ -137,7 +137,9 @@ class TestEphemeralSpark(BaseEphemeral):
 
 
 class TestIncrementalSpark(BaseIncremental):
-    pass
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "incremental", "models": {"+materialized": "table"}}
 
 
 class TestIncrementalNotSchemaChangeFabric(BaseIncrementalNotSchemaChange):
@@ -145,29 +147,75 @@ class TestIncrementalNotSchemaChangeFabric(BaseIncrementalNotSchemaChange):
 
 
 class TestGenericTestsSpark(BaseGenericTests):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "view_model.sql": """
+  {{ config(materialized="materialized_view") }}
+"""
+            + files.model_base,
+            "table_model.sql": files.base_table_sql,
+            "schema.yml": files.schema_base_yml,
+            "schema_view.yml": files.generic_test_view_yml,
+            "schema_table.yml": files.generic_test_table_yml,
+        }
 
 
 class TestSnapshotCheckColsSpark(BaseSnapshotCheckCols):
-    pass
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "snapshot_strategy_check_cols", "models": {"+materialized": "table"}}
 
 
 class TestSnapshotTimestampSpark(BaseSnapshotTimestamp):
-    pass
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"name": "snapshot_strategy_timestamp", "models": {"+materialized": "table"}}
 
 
 class TestBaseCachingSpark(BaseAdapterMethod):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        adapter_methods_model_sql = """
+{% set upstream = ref('upstream') %}
+
+{% if execute %}
+    {%- do adapter.drop_schema(upstream) -%}
+    {% set existing = adapter.get_relation(upstream.database, upstream.schema, upstream.identifier) %}
+    {% if existing is not none %}
+        {% do exceptions.raise_compiler_error('expected ' ~ ' to not exist, but it did') %}
+    {% endif %}
+
+    {%- do adapter.create_schema(upstream) -%}
+
+    {% set sql = create_table_as(False, upstream, 'select 2 as id') %}
+    {% do run_query(sql) %}
+{% endif %}
+
+
+select * from {{ upstream }}
+"""
+        return {
+            "upstream.sql": "select 1 as id",
+            "expected.sql": "-- {{ ref('model') }}\nselect 2 as id",
+            "model.sql": adapter_methods_model_sql,
+        }
 
 
 class TestValidateConnectionSpark(BaseValidateConnection):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark catalog types differ from defaults, needs expected_catalog override"
+)
 class TestDocsGenerateSpark(BaseDocsGenerate):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark catalog types differ from defaults, needs expected_catalog override"
+)
 class TestDocsGenReferencesSpark(BaseDocsGenReferences):
     pass
 


### PR DESCRIPTION
## Summary

Override test fixtures in FabricSpark basic tests to accommodate the lack of Spark SQL view support in Fabric Lakehouse. All changes replace `view` materializations with `materialized_view` or `table`, and add `expected_catalog` overrides with FabricSpark-specific types.

## Comparison with base classes, dbt-spark, dbt-databricks, and Fabric DW

### TestEphemeralSpark (BaseEphemeral)

| Adapter | Approach |
|---|---|
| **Base class** | `view_model.sql` uses `config(materialized="view")` |
| **dbt-spark** | Passes as-is (Spark supports views) |
| **dbt-databricks** | Passes as-is (Databricks supports views) |
| **Fabric DW** | Passes as-is (T-SQL supports views) |
| **FabricSpark (this PR)** | Overrides `view_model.sql` to use `materialized_view` — Fabric Lakehouse has no Spark SQL view support |

### TestIncrementalSpark (BaseIncremental)

| Adapter | Approach |
|---|---|
| **Base class** | Sets `project_config_update = {"name": "incremental"}` |
| **dbt-spark** | Passes as-is |
| **dbt-databricks** | Passes as-is |
| **Fabric DW** | Passes as-is |
| **FabricSpark (this PR)** | Adds `+materialized: table` to `project_config_update` — without this, the base class's shallow merge drops conftest's `+materialized: materialized_view` default, causing seeds to use the unsupported `view` materialization |

### TestGenericTestsSpark (BaseGenericTests)

| Adapter | Approach |
|---|---|
| **Base class** | `view_model.sql` uses `config(materialized="view")` |
| **dbt-spark** | Passes as-is |
| **dbt-databricks** | Passes as-is |
| **Fabric DW** | Passes as-is |
| **FabricSpark (this PR)** | Same fix as TestEphemeralSpark: overrides `view_model.sql` to `materialized_view` |

### TestSnapshotCheckColsSpark / TestSnapshotTimestampSpark

| Adapter | Approach |
|---|---|
| **Base class** | Sets `project_config_update` with project name |
| **dbt-spark** | Adds `+file_format: delta` for seeds and snapshots |
| **dbt-databricks** | Passes as-is |
| **Fabric DW** | Passes as-is |
| **FabricSpark (this PR)** | Adds `+materialized: table` — same shallow-merge issue as TestIncrementalSpark. No `file_format` needed since Fabric Lakehouse always uses Delta. |

### TestBaseCachingSpark (BaseAdapterMethod)

| Adapter | Approach |
|---|---|
| **Base class** | Model SQL calls `create_view_as()` to test adapter caching |
| **dbt-spark** | Skipped (`@pytest.mark.skip_profile("spark_session")`) |
| **dbt-databricks** | Passes as-is (supports views) |
| **Fabric DW** | Passes as-is (supports views) |
| **FabricSpark (this PR)** | Replaces `create_view_as()` with `create_table_as(False, ...)` — tests the same adapter caching behavior without requiring view support |

### TestDocsGenerateSpark / TestDocsGenReferencesSpark (BaseDocsGenerate / BaseDocsGenReferences)

| Adapter | Approach |
|---|---|
| **Base class** | Expects `integer`/`text`/`timestamp without time zone`, `VIEW`/`BASE TABLE`, owner stats |
| **dbt-spark** | Not tested (not in dbt-spark's test suite) |
| **dbt-databricks** | Overrides `expected_catalog` with Spark types and custom matchers |
| **Fabric DW** | `int`/`varchar`/`datetime2`, `VIEW`/`BASE TABLE`, `role=profile_user`, `row_count` stats for seeds |
| **FabricSpark (this PR)** | `bigint`/`string`/`timestamp`, `materialized_view`/`table`, `role=None`, `no_stats()` |

Key differences from Fabric DW:
- **Types**: `bigint`/`string`/`timestamp` vs `int`/`varchar`/`datetime2`
- **Relation types**: `materialized_view`/`table` (lowercase) vs `VIEW`/`BASE TABLE` (uppercase)
- **Owner**: `role=None` (Spark's DESCRIBE TABLE EXTENDED doesn't expose owner) vs `role=profile_user`
- **Stats**: `no_stats()` for everything (Spark doesn't expose row counts) vs `row_count` stats for seeds
- **Models**: All model fixtures use `materialized_view` instead of `view`
- **Column index**: `AnyInteger()` for references catalog (Spark column ordering can vary)

## Test plan

- `uv run pytest --de -k "TestEphemeralSpark or TestIncrementalSpark or TestGenericTestsSpark or TestSnapshotCheckColsSpark or TestSnapshotTimestampSpark or TestBaseCachingSpark or TestDocsGenerateSpark or TestDocsGenReferencesSpark"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)