### PR TITLE
Fix FabricSpark alias tests

### DIFF
--- a/tests/fabricspark/adapter/test_aliases.py
+++ b/tests/fabricspark/adapter/test_aliases.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dbt.tests.adapter.aliases import fixtures
+from dbt.tests.adapter.aliases.fixtures import MACROS__EXPECT_VALUE_SQL
 from dbt.tests.adapter.aliases.test_aliases import (
     BaseAliasErrors,
     BaseAliases,
@@ -8,51 +8,26 @@ from dbt.tests.adapter.aliases.test_aliases import (
     BaseSameAliasDifferentSchemas,
 )
 
-# Spark SQL does not support PostgreSQL-style '...'::text casts.
-# The test fixture dispatches with macro_namespace='test', so the adapter-level
-# fabricspark__string_literal is not found. Override the macro here instead.
-MACROS__CAST_SQL_SPARK = """
-{% macro string_literal(s) -%}
-  {{ adapter.dispatch('string_literal', macro_namespace='test')(s) }}
-{%- endmacro %}
-
-{% macro default__string_literal(s) %}
-    '{{ s }}'
-{% endmacro %}
-"""
-
 
 class TestAliasesFabricSpark(BaseAliases):
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL_SPARK,
-            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
-        }
+        return {"expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
 
 class TestAliasErrorsFabricSpark(BaseAliasErrors):
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL_SPARK,
-            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
-        }
+        return {"expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
 
 class TestSameAliasDifferentSchemasFabricSpark(BaseSameAliasDifferentSchemas):
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL_SPARK,
-            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
-        }
+        return {"expect_value.sql": MACROS__EXPECT_VALUE_SQL}
 
 
 class TestSameAliasDifferentDatabasesFabricSpark(BaseSameAliasDifferentDatabases):
     @pytest.fixture(scope="class")
     def macros(self):
-        return {
-            "cast.sql": MACROS__CAST_SQL_SPARK,
-            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
-        }
+        return {"expect_value.sql": MACROS__EXPECT_VALUE_SQL}

--- a/tests/fabricspark/adapter/test_aliases.py
+++ b/tests/fabricspark/adapter/test_aliases.py
@@ -1,3 +1,6 @@
+import pytest
+
+from dbt.tests.adapter.aliases import fixtures
 from dbt.tests.adapter.aliases.test_aliases import (
     BaseAliasErrors,
     BaseAliases,
@@ -5,18 +8,51 @@ from dbt.tests.adapter.aliases.test_aliases import (
     BaseSameAliasDifferentSchemas,
 )
 
+# Spark SQL does not support PostgreSQL-style '...'::text casts.
+# The test fixture dispatches with macro_namespace='test', so the adapter-level
+# fabricspark__string_literal is not found. Override the macro here instead.
+MACROS__CAST_SQL_SPARK = """
+{% macro string_literal(s) -%}
+  {{ adapter.dispatch('string_literal', macro_namespace='test')(s) }}
+{%- endmacro %}
+
+{% macro default__string_literal(s) %}
+    '{{ s }}'
+{% endmacro %}
+"""
+
 
 class TestAliasesFabricSpark(BaseAliases):
-    pass
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "cast.sql": MACROS__CAST_SQL_SPARK,
+            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
+        }
 
 
 class TestAliasErrorsFabricSpark(BaseAliasErrors):
-    pass
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "cast.sql": MACROS__CAST_SQL_SPARK,
+            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
+        }
 
 
 class TestSameAliasDifferentSchemasFabricSpark(BaseSameAliasDifferentSchemas):
-    pass
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "cast.sql": MACROS__CAST_SQL_SPARK,
+            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
+        }
 
 
 class TestSameAliasDifferentDatabasesFabricSpark(BaseSameAliasDifferentDatabases):
-    pass
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "cast.sql": MACROS__CAST_SQL_SPARK,
+            "expect_value.sql": fixtures.MACROS__EXPECT_VALUE_SQL,
+        }


### PR DESCRIPTION
## Summary
- Override macros fixture to drop the PostgreSQL `cast.sql` (with `::text`), relying on the global `string_literal` dispatch (`macro_namespace='dbt'`) to find `fabricspark__string_literal`
- Matches the approach used by the Fabric DW alias tests

Split from #65.

## Root cause

The base alias test fixtures in `dbt-tests-adapter` define a test-local `string_literal` macro (in `fixtures.MACROS__CAST_SQL`) that:
1. Dispatches with `macro_namespace='test'`
2. Provides `default__string_literal` returning `'{{ s }}'::text`

The `::text` cast is PostgreSQL syntax and fails on Spark SQL. While the adapter provides `fabricspark__string_literal` (in `src/dbt/include/fabricspark/macros/adapters/string_literal.sql`), it is **not found** by the test's dispatch because `macro_namespace='test'` limits the search to the test project's own macros — it does not search adapter macros.

### Fix approach

Instead of providing a custom `MACROS__CAST_SQL_SPARK` override (the original approach), we simply omit `cast.sql` from the macros fixture. Without a local override, models call `{{ string_literal(this.name) }}`, which resolves to dbt's global `string_literal` macro. That macro dispatches with `macro_namespace='dbt'` and finds `fabricspark__string_literal`, returning `'{{ value }}'` — no `::text` cast needed.

This matches how the Fabric DW alias tests handle the same problem.

## Comparison with dbt-spark / dbt-databricks

| Aspect | dbt-spark | dbt-databricks | dbt-fabric (T-SQL) | This PR (FabricSpark) |
|---|---|---|---|---|
| Has alias tests? | No (not implemented) | Yes | Yes | Yes |
| Has adapter `string_literal`? | No | N/A (uses test macro) | No (uses global default) | Yes (`fabricspark__string_literal`) |
| Fix approach | N/A | Override `cast.sql` with `databricks__string_literal` using `cast('...' as STRING)` | Drop `cast.sql` entirely; global `string_literal` dispatches via `macro_namespace='dbt'` and finds `default__string_literal` | Drop `cast.sql` entirely; global `string_literal` dispatches via `macro_namespace='dbt'` and finds `fabricspark__string_literal` |

## Test plan
- [x] Run `uv run pytest -k "FabricSpark and (TestAliases or TestAliasErrors or TestSameAlias)" --de -v`
- [x] Verify all 4 alias test classes pass with simplified macros fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)