### PR TITLE
Fix FabricSpark catalog relation type tests

### DIFF
--- a/tests/fabricspark/adapter/test_catalog.py
+++ b/tests/fabricspark/adapter/test_catalog.py
@@ -1,11 +1,43 @@
+import pytest
+
+from dbt.artifacts.schemas.catalog import CatalogArtifact
+from dbt.tests.adapter.catalog import files
 from dbt.tests.adapter.catalog.relation_types import CatalogRelationTypes
 from dbt.tests.adapter.catalog_integrations.test_catalog_integration import (
     BaseCatalogIntegrationValidation,
 )
 
+MY_MATERIALIZED_VIEW_FROM_SEED = """\
+{{ config(
+    materialized='materialized_view',
+) }}
+select *
+from {{ ref('my_seed') }}
+"""
+
 
 class TestCatalogRelationTypesFabricSpark(CatalogRelationTypes):
-    pass
+    @pytest.fixture(scope="class", autouse=True)
+    def models(self):
+        yield {
+            "my_table.sql": files.MY_TABLE,
+            "my_materialized_view.sql": files.MY_MATERIALIZED_VIEW,
+            "my_materialized_view_2.sql": MY_MATERIALIZED_VIEW_FROM_SEED,
+        }
+
+    @pytest.mark.parametrize(
+        "node_name,relation_type",
+        [
+            ("seed.test.my_seed", "table"),
+            ("model.test.my_table", "table"),
+            ("model.test.my_materialized_view", "materialized_view"),
+            ("model.test.my_materialized_view_2", "materialized_view"),
+        ],
+    )
+    def test_relation_types_populate_correctly(
+        self, docs: CatalogArtifact, node_name: str, relation_type: str
+    ):
+        super().test_relation_types_populate_correctly(docs, node_name, relation_type)
 
 
 class TestCatalogIntegrationValidationFabricSpark(BaseCatalogIntegrationValidation):

--- a/tests/fabricspark/adapter/test_catalog.py
+++ b/tests/fabricspark/adapter/test_catalog.py
@@ -7,22 +7,13 @@ from dbt.tests.adapter.catalog_integrations.test_catalog_integration import (
     BaseCatalogIntegrationValidation,
 )
 
-MY_MATERIALIZED_VIEW_FROM_SEED = """\
-{{ config(
-    materialized='materialized_view',
-) }}
-select *
-from {{ ref('my_seed') }}
-"""
-
 
 class TestCatalogRelationTypesFabricSpark(CatalogRelationTypes):
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture(scope="class")
     def models(self):
         yield {
             "my_table.sql": files.MY_TABLE,
             "my_materialized_view.sql": files.MY_MATERIALIZED_VIEW,
-            "my_materialized_view_2.sql": MY_MATERIALIZED_VIEW_FROM_SEED,
         }
 
     @pytest.mark.parametrize(
@@ -31,7 +22,6 @@ class TestCatalogRelationTypesFabricSpark(CatalogRelationTypes):
             ("seed.test.my_seed", "table"),
             ("model.test.my_table", "table"),
             ("model.test.my_materialized_view", "materialized_view"),
-            ("model.test.my_materialized_view_2", "materialized_view"),
         ],
     )
     def test_relation_types_populate_correctly(


### PR DESCRIPTION
## Summary
- Override `CatalogRelationTypes` test for FabricSpark to match the adapter's actual catalog metadata values (lowercase enum strings instead of SQL-standard uppercase)
- Replace `my_view.sql` with a materialized view model (FabricSpark has no views)

## Root cause

The base `CatalogRelationTypes` test expects SQL-standard catalog type strings like `"BASE TABLE"` and `"VIEW"` (from `information_schema`). FabricSpark builds catalog metadata in Python via `get_catalog_by_relations()` → `parse_describe_extended()`, which sets `table_type` to `FabricSparkRelationType` enum values. Since `FabricSparkRelationType` is a `StrEnum` with lowercase values (`"table"`, `"materialized_view"`), the catalog `node.metadata.type` field contains these lowercase names.

### Root cause chain

1. `FabricSparkRelationType(StrEnum)` defines `Table = "table"` and `MaterializedView = "materialized_view"`
2. `parse_describe_extended()` stores `FabricSparkRelation.try_translate_type(metadata.get("Type"))` as `table_type`
3. `try_translate_type("MANAGED")` → `"table"`, `try_translate_type("MATERIALIZED_LAKE_VIEW")` → `"materialized_view"`
4. These values flow through `to_column_dict()` → agate table → `CatalogTable.metadata.type`

## Comparison with dbt-spark / dbt-databricks

| Aspect | dbt-spark | dbt-databricks | dbt-fabric (T-SQL) | This PR (FabricSpark) |
|---|---|---|---|---|
| Implements `CatalogRelationTypes` test | No | No | Yes | Yes |
| Catalog source | Python (`relation.type`) | Python (similar) | SQL macro (`sys.tables`/`sys.views`) | Python (`parse_describe_extended`) |
| `table_type` for tables | `"table"` (lowercase) | `"table"` (lowercase) | `'BASE TABLE'` (SQL literal) | `"table"` (lowercase) |
| `table_type` for views | `"view"` (lowercase) | `"view"` (lowercase) | `'VIEW'` (SQL literal) | N/A (no views) |
| Supports views | Yes | Yes | Yes | No (only tables + materialized lake views) |

**Key insight:** dbt-spark and dbt-databricks both skip this test entirely. Both would face the same lowercase mismatch if they implemented it. The base test's docstring explicitly says adapters should customize the parametrize values if they "use different strings to describe the node."

## Issues fixed

- [x] `TestCatalogIntegrationValidationFabricSpark` verified present (was not actually removed)
- [x] Removed redundant `MY_MATERIALIZED_VIEW_FROM_SEED` — was identical to `files.MY_MATERIALIZED_VIEW`, simplified to 3 test cases matching the Fabric DW pattern
- [x] Run `uv run pytest -k "TestCatalog" --de -v` — all 3 tests pass
- [x] Confirmed `node.metadata.type` values match `"table"` and `"materialized_view"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)