### PR TITLE
Fix FabricSpark seed tests

### DIFF
--- a/tests/fabricspark/adapter/test_simple_seed.py
+++ b/tests/fabricspark/adapter/test_simple_seed.py
@@ -19,7 +19,7 @@ from dbt.tests.adapter.simple_seed.test_seed import (
     BaseTestEmptySeed,
 )
 from dbt.tests.adapter.simple_seed.test_seed_type_override import BaseSimpleSeedColumnOverride
-from dbt.tests.util import copy_file, run_dbt
+from dbt.tests.util import copy_file, read_file, rm_dir, run_dbt
 
 fixed_seeds__expected_sql = (
     seeds.seeds__expected_sql.replace("TIMESTAMP WITHOUT TIME ZONE", "TIMESTAMP")
@@ -67,22 +67,29 @@ class TestSeedConfigFullRefreshOnFabricSpark(FixedSeedSetup, BaseSeedConfigFullR
 
 
 class TestSeedCustomSchemaFabricSpark(FixedSeedSetup, BaseSeedCustomSchema):
-    @pytest.mark.skip("TODO: FabricSpark cannot drop and recreate schemas during seed operations")
-    def test_simple_seed_with_drop_and_schema(self, project, custom_schema):
-        pass
+    pass
 
 
-@pytest.mark.skip("TODO: FabricSpark seed parsing test encounters runtime errors")
 class TestSeedParsingFabricSpark(FixedSeedSetup, BaseSeedParsing):
     pass
 
 
-@pytest.mark.skip("Spark SQL interprets dots in seed names as schema separators")
 class TestSeedSpecificFormatsFabricSpark(BaseSeedSpecificFormats):
-    pass
+    @pytest.fixture(scope="class")
+    def seeds(self, test_data_dir):
+        big_seed_path = self._make_big_seed(test_data_dir)
+        big_seed = read_file(big_seed_path)
+        yield {
+            "big_seed.csv": big_seed,
+            "seed_unicode.csv": seeds.seed__unicode_csv,
+        }
+        rm_dir(test_data_dir)
+
+    def test_simple_seed(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 2
 
 
-@pytest.mark.skip("TODO: FabricSpark seed with empty delimiter encounters runtime errors")
 class TestSeedWithEmptyDelimiterFabricSpark(FixedSeedSetup, BaseSeedWithEmptyDelimiter):
     pass
 
@@ -118,46 +125,12 @@ class TestSimpleSeedColumnOverrideFabricSpark(BaseSimpleSeedColumnOverride):
         }
 
 
-class BaseSimpleSeedEnabledViaConfigFabricSpark(BaseSimpleSeedEnabledViaConfig):
+class TestSimpleSeedEnabledViaConfigFabricSpark(BaseSimpleSeedEnabledViaConfig):
     @pytest.fixture(scope="function")
-    def clear_test_schema(self):
-        pass
-
-
-class TestSimpleSeedEnabledViaConfigFabricSparkDisabled(
-    BaseSimpleSeedEnabledViaConfigFabricSpark,
-):
-    @pytest.mark.skip("Tests have to be split up into multiple classes")
-    def test_simple_seed_selection(self, clear_test_schema, project):
-        super().test_simple_seed_selection(clear_test_schema, project)
-
-    @pytest.mark.skip("Tests have to be split up into multiple classes")
-    def test_simple_seed_exclude(self, clear_test_schema, project):
-        super().test_simple_seed_exclude(clear_test_schema, project)
-
-
-class TestSimpleSeedEnabledViaConfigFabricSparkSelection(
-    BaseSimpleSeedEnabledViaConfigFabricSpark,
-):
-    @pytest.mark.skip("Tests have to be split up into multiple classes")
-    def test_simple_seed_with_disabled(self, clear_test_schema, project):
-        super().test_simple_seed_with_disabled(clear_test_schema, project)
-
-    @pytest.mark.skip("Tests have to be split up into multiple classes")
-    def test_simple_seed_exclude(self, clear_test_schema, project):
-        super().test_simple_seed_exclude(clear_test_schema, project)
-
-
-class TestSimpleSeedEnabledViaConfigFabricSparkExclude(
-    BaseSimpleSeedEnabledViaConfigFabricSpark,
-):
-    @pytest.mark.skip("Tests have to be split up into multiple classes")
-    def test_simple_seed_with_disabled(self, clear_test_schema, project):
-        super().test_simple_seed_with_disabled(clear_test_schema, project)
-
-    @pytest.mark.skip("Tests have to be split up into multiple classes")
-    def test_simple_seed_selection(self, clear_test_schema, project):
-        super().test_simple_seed_selection(clear_test_schema, project)
+    def clear_test_schema(self, project):
+        yield
+        for table in ["seed_enabled", "seed_disabled", "seed_tricky"]:
+            project.run_sql(f"DROP TABLE IF EXISTS {project.test_schema}.{table}")
 
 
 class TestSimpleSeedWithBOMFabricSpark(FixedSeedSetup, BaseSimpleSeedWithBOM):

--- a/tests/fabricspark/adapter/test_simple_seed.py
+++ b/tests/fabricspark/adapter/test_simple_seed.py
@@ -133,7 +133,7 @@ class TestSimpleSeedEnabledViaConfigFabricSpark(BaseSimpleSeedEnabledViaConfig):
             project.run_sql(f"DROP TABLE IF EXISTS {project.test_schema}.{table}")
 
 
-class TestSimpleSeedWithBOMFabricSpark(FixedSeedSetup, BaseSimpleSeedWithBOM):
+class TestSimpleSeedWithBOMFabricSpark(BaseSimpleSeedWithBOM):
     @pytest.fixture(scope="class", autouse=True)
     def setUp(self, project):
         run_sql_statements(project, fixed_seeds__expected_sql)

--- a/tests/fabricspark/adapter/test_simple_seed.py
+++ b/tests/fabricspark/adapter/test_simple_seed.py
@@ -1,3 +1,9 @@
+import inspect
+from pathlib import Path
+
+import pytest
+
+from dbt.tests.adapter.simple_seed import fixtures, seeds
 from dbt.tests.adapter.simple_seed.test_seed import (
     BaseBasicSeedTests,
     BaseSeedConfigFullRefreshOff,
@@ -13,55 +19,154 @@ from dbt.tests.adapter.simple_seed.test_seed import (
     BaseTestEmptySeed,
 )
 from dbt.tests.adapter.simple_seed.test_seed_type_override import BaseSimpleSeedColumnOverride
+from dbt.tests.util import copy_file, run_dbt
+
+fixed_seeds__expected_sql = (
+    seeds.seeds__expected_sql.replace("TIMESTAMP WITHOUT TIME ZONE", "TIMESTAMP")
+    .replace("TEXT", "STRING")
+    .replace("INTEGER", "INT")
+    .replace('"', "")
+)
+
+fixed_properties__schema_yml = (
+    fixtures.properties__schema_yml.replace("type: timestamp without time zone", "type: timestamp")
+    .replace("type: text", "type: string")
+    .replace("type: integer", "type: bigint")
+)
 
 
-class TestBasicSeedTestsFabricSpark(BaseBasicSeedTests):
-    pass
+def run_sql_statements(project, sql):
+    for stmt in sql.split(";"):
+        stmt = stmt.strip()
+        if stmt:
+            project.run_sql(stmt)
+
+
+class FixedSeedSetup:
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        run_sql_statements(project, fixed_seeds__expected_sql)
+
+
+class TestBasicSeedTestsFabricSpark(FixedSeedSetup, BaseBasicSeedTests):
+    def test_simple_seed_full_refresh_flag(self, project):
+        pytest.skip("Dropping a seed table does not cascade to materialized views in Fabric")
 
 
 class TestEmptySeedFabricSpark(BaseTestEmptySeed):
     pass
 
 
-class TestSeedConfigFullRefreshOffFabricSpark(BaseSeedConfigFullRefreshOff):
+class TestSeedConfigFullRefreshOffFabricSpark(FixedSeedSetup, BaseSeedConfigFullRefreshOff):
     pass
 
 
-class TestSeedConfigFullRefreshOnFabricSpark(BaseSeedConfigFullRefreshOn):
+@pytest.mark.skip("Dropping a seed table does not cascade to materialized views in Fabric")
+class TestSeedConfigFullRefreshOnFabricSpark(FixedSeedSetup, BaseSeedConfigFullRefreshOn):
     pass
 
 
-class TestSeedCustomSchemaFabricSpark(BaseSeedCustomSchema):
+class TestSeedCustomSchemaFabricSpark(FixedSeedSetup, BaseSeedCustomSchema):
+    @pytest.mark.skip("TODO: FabricSpark cannot drop and recreate schemas during seed operations")
+    def test_simple_seed_with_drop_and_schema(self, project, custom_schema):
+        pass
+
+
+@pytest.mark.skip("TODO: FabricSpark seed parsing test encounters runtime errors")
+class TestSeedParsingFabricSpark(FixedSeedSetup, BaseSeedParsing):
     pass
 
 
-class TestSeedParsingFabricSpark(BaseSeedParsing):
-    pass
-
-
+@pytest.mark.skip("Spark SQL interprets dots in seed names as schema separators")
 class TestSeedSpecificFormatsFabricSpark(BaseSeedSpecificFormats):
     pass
 
 
-class TestSeedWithEmptyDelimiterFabricSpark(BaseSeedWithEmptyDelimiter):
+@pytest.mark.skip("TODO: FabricSpark seed with empty delimiter encounters runtime errors")
+class TestSeedWithEmptyDelimiterFabricSpark(FixedSeedSetup, BaseSeedWithEmptyDelimiter):
     pass
 
 
-class TestSeedWithUniqueDelimiterFabricSpark(BaseSeedWithUniqueDelimiter):
+class TestSeedWithUniqueDelimiterFabricSpark(FixedSeedSetup, BaseSeedWithUniqueDelimiter):
     pass
 
 
-class TestSeedWithWrongDelimiterFabricSpark(BaseSeedWithWrongDelimiter):
+class TestSeedWithWrongDelimiterFabricSpark(FixedSeedSetup, BaseSeedWithWrongDelimiter):
     pass
 
 
 class TestSimpleSeedColumnOverrideFabricSpark(BaseSimpleSeedColumnOverride):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "schema.yml": fixed_properties__schema_yml,
+        }
+
+    @staticmethod
+    def seed_enabled_types():
+        return {
+            "seed_id": "string",
+            "birthday": "date",
+        }
+
+    @staticmethod
+    def seed_tricky_types():
+        return {
+            "seed_id_str": "string",
+            "looks_like_a_bool": "string",
+            "looks_like_a_date": "string",
+        }
 
 
-class TestSimpleSeedEnabledViaConfigFabricSpark(BaseSimpleSeedEnabledViaConfig):
-    pass
+class BaseSimpleSeedEnabledViaConfigFabricSpark(BaseSimpleSeedEnabledViaConfig):
+    @pytest.fixture(scope="function")
+    def clear_test_schema(self):
+        pass
 
 
-class TestSimpleSeedWithBOMFabricSpark(BaseSimpleSeedWithBOM):
-    pass
+class TestSimpleSeedEnabledViaConfigFabricSparkDisabled(
+    BaseSimpleSeedEnabledViaConfigFabricSpark,
+):
+    @pytest.mark.skip("Tests have to be split up into multiple classes")
+    def test_simple_seed_selection(self, clear_test_schema, project):
+        super().test_simple_seed_selection(clear_test_schema, project)
+
+    @pytest.mark.skip("Tests have to be split up into multiple classes")
+    def test_simple_seed_exclude(self, clear_test_schema, project):
+        super().test_simple_seed_exclude(clear_test_schema, project)
+
+
+class TestSimpleSeedEnabledViaConfigFabricSparkSelection(
+    BaseSimpleSeedEnabledViaConfigFabricSpark,
+):
+    @pytest.mark.skip("Tests have to be split up into multiple classes")
+    def test_simple_seed_with_disabled(self, clear_test_schema, project):
+        super().test_simple_seed_with_disabled(clear_test_schema, project)
+
+    @pytest.mark.skip("Tests have to be split up into multiple classes")
+    def test_simple_seed_exclude(self, clear_test_schema, project):
+        super().test_simple_seed_exclude(clear_test_schema, project)
+
+
+class TestSimpleSeedEnabledViaConfigFabricSparkExclude(
+    BaseSimpleSeedEnabledViaConfigFabricSpark,
+):
+    @pytest.mark.skip("Tests have to be split up into multiple classes")
+    def test_simple_seed_with_disabled(self, clear_test_schema, project):
+        super().test_simple_seed_with_disabled(clear_test_schema, project)
+
+    @pytest.mark.skip("Tests have to be split up into multiple classes")
+    def test_simple_seed_selection(self, clear_test_schema, project):
+        super().test_simple_seed_selection(clear_test_schema, project)
+
+
+class TestSimpleSeedWithBOMFabricSpark(FixedSeedSetup, BaseSimpleSeedWithBOM):
+    @pytest.fixture(scope="class", autouse=True)
+    def setUp(self, project):
+        run_sql_statements(project, fixed_seeds__expected_sql)
+        copy_file(
+            Path(inspect.getfile(BaseSimpleSeedWithBOM)).parent,
+            "seed_bom.csv",
+            project.project_root / Path("seeds") / "seed_bom.csv",
+            "",
+        )


### PR DESCRIPTION
## Summary

Adapt all FabricSpark seed tests to work with Spark SQL. On `main` these were bare `pass` subclasses that fail because the base fixtures use PostgreSQL syntax.

Changes:
- Add `FixedSeedSetup` mixin: replace PG types (`TEXT`→`STRING`, `TIMESTAMP WITHOUT TIME ZONE`→`TIMESTAMP`, `INTEGER`→`INT`), remove double-quote identifiers, split multi-statement SQL for Livy
- Skip full-refresh tests (`test_simple_seed_full_refresh_flag`, `BaseSeedConfigFullRefreshOn`) — dropping a seed table does not cascade to dependent materialized views in Fabric
- Exclude `seed.with.dots.csv` from `BaseSeedSpecificFormats` — Spark interprets dots in seed names as schema separators
- Override `clear_test_schema` in `BaseSimpleSeedEnabledViaConfig` with per-table `DROP TABLE IF EXISTS` instead of `DROP SCHEMA ... CASCADE` (which Spark doesn't support)
- Add Spark type overrides for `BaseSimpleSeedColumnOverride` (`string`, `date`, `bigint`)
- Add `setUp` override for `BaseSimpleSeedWithBOM` to split SQL and copy BOM seed file

Split from #65.

## Comparison across adapters

| Base test class | dbt-adapters (base) | Fabric DW | FabricSpark (this PR) | dbt-databricks |
|---|---|---|---|---|
| `BaseBasicSeedTests` | PG types in setUp SQL | FixedSeedSetup + skip full-refresh | FixedSeedSetup + skip full-refresh | Skip full-refresh |
| `BaseTestEmptySeed` | Pass | Pass | Pass | Pass |
| `BaseSeedConfigFullRefreshOff` | PG types in setUp SQL | FixedSeedSetup | FixedSeedSetup | DatabricksSetup |
| `BaseSeedConfigFullRefreshOn` | PG types in setUp SQL | Skipped (cascade drop) | Skipped (cascade drop) | Omitted |
| `BaseSeedCustomSchema` | PG types in setUp SQL | FixedSeedSetup, both tests pass | FixedSeedSetup, both tests pass | Pass with teardown cleanup |
| `BaseSeedParsing` | PG types in setUp SQL | FixedSeedSetup | FixedSeedSetup | DatabricksSetup |
| `BaseSeedSpecificFormats` | Includes `seed.with.dots.csv` | Pass (dots seed works in T-SQL) | Dots seed excluded (Spark schema separator) | Dots seed excluded |
| `BaseSeedWithEmptyDelimiter` | PG types in setUp SQL | FixedSeedSetup | FixedSeedSetup | DatabricksSetup |
| `BaseSeedWithUniqueDelimiter` | PG types in setUp SQL | FixedSeedSetup | FixedSeedSetup | DatabricksSetup |
| `BaseSeedWithWrongDelimiter` | Asserts "compilation error" | Custom assertion ("Incorrect syntax near") | Pass (base assertion works) | DatabricksSetup |
| `BaseSimpleSeedColumnOverride` | PG types (`text`, `integer`) | T-SQL types (`varchar`, `int`) + custom macro | Spark types (`string`, `bigint`) | Not tested |
| `BaseSimpleSeedEnabledViaConfig` | `DROP SCHEMA ... CASCADE` cleanup | 3-class split, no-op cleanup | Single class, per-table DROP TABLE cleanup | Pass as-is |
| `BaseSimpleSeedWithBOM` | PG types in setUp SQL | setUp override | FixedSeedSetup + BOM file copy | Split setUp |

Key patterns shared with Fabric DW: `FixedSeedSetup` mixin for PG→dialect type replacement, skip cascade-dependent full-refresh tests.

Key difference from Fabric DW: `BaseSimpleSeedEnabledViaConfig` uses per-table cleanup (single class) instead of the 3-class split that Fabric DW uses. `BaseSeedSpecificFormats` excludes dots seed (T-SQL handles dots fine, Spark doesn't).

dbt-spark does not test any of these base classes.

## Test plan
- [x] Run `uv run pytest -k "Seed" --de -v` — 18 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)