### PR TITLE
Fix FabricSpark simple copy tests

### DIFF
--- a/tests/fabricspark/adapter/test_simple_copy.py
+++ b/tests/fabricspark/adapter/test_simple_copy.py
@@ -3,7 +3,7 @@ import pytest
 from dbt.tests.adapter.simple_copy import fixtures
 from dbt.tests.adapter.simple_copy.test_copy_uppercase import BaseSimpleCopyUppercase
 from dbt.tests.adapter.simple_copy.test_simple_copy import EmptyModelsArentRunBase, SimpleCopyBase
-from dbt.tests.util import check_relations_equal, run_dbt
+from dbt.tests.util import check_relations_equal, rm_file, run_dbt, write_file
 
 _FABRICSPARK_VIEW_MODEL = """
 {{
@@ -26,17 +26,54 @@ _FABRICSPARK_DISABLED = """
 select * from {{ ref('seed') }}
 """
 
+_FABRICSPARK_INCREMENTAL = """
+{{
+  config(
+    materialized = "incremental",
+    incremental_strategy = "merge",
+    file_format = "delta"
+  )
+}}
+
+select * from {{ ref('seed') }}
+
+{% if is_incremental() %}
+    where id > (select max(id) from {{this}})
+{% endif %}
+"""
+
+_FABRICSPARK_ADVANCED_INCREMENTAL = """
+{{
+  config(
+    materialized = "incremental",
+    unique_key = "id",
+    incremental_strategy = "merge",
+    file_format = "delta",
+    persist_docs = {"relation": true}
+  )
+}}
+
+select *
+from {{ ref('seed') }}
+
+{% if is_incremental() %}
+
+    where id > (select max(id) from {{this}})
+
+{% endif %}
+"""
+
 
 class FabricSparkSimpleCopySetup:
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "advanced_incremental.sql": fixtures._MODELS__ADVANCED_INCREMENTAL,
+            "advanced_incremental.sql": _FABRICSPARK_ADVANCED_INCREMENTAL,
             "compound_sort.sql": fixtures._MODELS__COMPOUND_SORT,
             "disabled.sql": _FABRICSPARK_DISABLED,
             "empty.sql": fixtures._MODELS__EMPTY,
             "get_and_ref.sql": fixtures._MODELS__GET_AND_REF,
-            "incremental.sql": fixtures._MODELS__INCREMENTAL,
+            "incremental.sql": _FABRICSPARK_INCREMENTAL,
             "interleaved_sort.sql": fixtures._MODELS__INTERLEAVED_SORT,
             "materialized.sql": fixtures._MODELS__MATERIALIZED,
             "view_model.sql": _FABRICSPARK_VIEW_MODEL,
@@ -83,6 +120,17 @@ class TestSimpleCopyBaseFabricSpark(FabricSparkSimpleCopySetup, SimpleCopyBase):
             project.adapter, ["seed", "view_model", "incremental", "materialized", "get_and_ref"]
         )
 
+        main_seed_file = project.project_root / "seeds" / "seed.csv"
+        rm_file(main_seed_file)
+        write_file(fixtures._SEEDS__SEED_UPDATE, main_seed_file)
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt(["run", "--full-refresh"])
+        assert len(results) == 7
+        check_relations_equal(
+            project.adapter, ["seed", "view_model", "incremental", "materialized", "get_and_ref"]
+        )
+
     @pytest.mark.skip(
         "FabricSpark does not support CREATE VIEW or CREATE MATERIALIZED VIEW via raw SQL"
     )
@@ -98,12 +146,12 @@ class TestSimpleCopyUppercaseFabricSpark(BaseSimpleCopyUppercase):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "ADVANCED_INCREMENTAL.sql": fixtures._MODELS__ADVANCED_INCREMENTAL,
+            "ADVANCED_INCREMENTAL.sql": _FABRICSPARK_ADVANCED_INCREMENTAL,
             "COMPOUND_SORT.sql": fixtures._MODELS__COMPOUND_SORT,
             "DISABLED.sql": _FABRICSPARK_DISABLED,
             "EMPTY.sql": fixtures._MODELS__EMPTY,
             "GET_AND_REF.sql": fixtures._MODELS_GET_AND_REF_UPPERCASE,
-            "INCREMENTAL.sql": fixtures._MODELS__INCREMENTAL,
+            "INCREMENTAL.sql": _FABRICSPARK_INCREMENTAL,
             "INTERLEAVED_SORT.sql": fixtures._MODELS__INTERLEAVED_SORT,
             "MATERIALIZED.sql": fixtures._MODELS__MATERIALIZED,
             "VIEW_MODEL.sql": _FABRICSPARK_VIEW_MODEL,

--- a/tests/fabricspark/adapter/test_simple_copy.py
+++ b/tests/fabricspark/adapter/test_simple_copy.py
@@ -1,14 +1,122 @@
+import pytest
+
+from dbt.tests.adapter.simple_copy import fixtures
 from dbt.tests.adapter.simple_copy.test_copy_uppercase import BaseSimpleCopyUppercase
 from dbt.tests.adapter.simple_copy.test_simple_copy import EmptyModelsArentRunBase, SimpleCopyBase
+from dbt.tests.util import check_relations_equal, run_dbt
+
+_FABRICSPARK_VIEW_MODEL = """
+{{
+  config(
+    materialized = "materialized_view"
+  )
+}}
+
+select * from {{ ref('seed') }}
+"""
+
+_FABRICSPARK_DISABLED = """
+{{
+  config(
+    materialized = "table",
+    enabled = False
+  )
+}}
+
+select * from {{ ref('seed') }}
+"""
 
 
-class TestEmptyModelsArentRunFabricSpark(EmptyModelsArentRunBase):
-    pass
+class FabricSparkSimpleCopySetup:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "advanced_incremental.sql": fixtures._MODELS__ADVANCED_INCREMENTAL,
+            "compound_sort.sql": fixtures._MODELS__COMPOUND_SORT,
+            "disabled.sql": _FABRICSPARK_DISABLED,
+            "empty.sql": fixtures._MODELS__EMPTY,
+            "get_and_ref.sql": fixtures._MODELS__GET_AND_REF,
+            "incremental.sql": fixtures._MODELS__INCREMENTAL,
+            "interleaved_sort.sql": fixtures._MODELS__INTERLEAVED_SORT,
+            "materialized.sql": fixtures._MODELS__MATERIALIZED,
+            "view_model.sql": _FABRICSPARK_VIEW_MODEL,
+        }
+
+    @pytest.fixture(scope="class")
+    def properties(self):
+        return {
+            "schema.yml": fixtures._PROPERTIES__SCHEMA_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": fixtures._SEEDS__SEED_INITIAL}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"seeds": {"quote_columns": False}}
 
 
-class TestSimpleCopyBaseFabricSpark(SimpleCopyBase):
-    pass
+class TestEmptyModelsArentRunFabricSpark(FabricSparkSimpleCopySetup, EmptyModelsArentRunBase):
+    def test_dbt_doesnt_run_empty_models(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        results = run_dbt()
+        assert len(results) == 7
+
+        sql = f"SHOW TABLES IN `{project.test_schema}`"
+        result = project.run_sql(sql, fetch="all")
+        table_names = {row[1].lower() for row in result}
+
+        assert "empty" not in table_names
+        assert "disabled" not in table_names
+
+
+class TestSimpleCopyBaseFabricSpark(FabricSparkSimpleCopySetup, SimpleCopyBase):
+    def test_simple_copy(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        results = run_dbt()
+        assert len(results) == 7
+        check_relations_equal(
+            project.adapter, ["seed", "view_model", "incremental", "materialized", "get_and_ref"]
+        )
+
+    @pytest.mark.skip(
+        "FabricSpark does not support CREATE VIEW or CREATE MATERIALIZED VIEW via raw SQL"
+    )
+    def test_simple_copy_with_materialized_views(self, project):
+        pass
 
 
 class TestSimpleCopyUppercaseFabricSpark(BaseSimpleCopyUppercase):
-    pass
+    @pytest.fixture(scope="class")
+    def dbt_profile_target(self, dbt_profile_target):
+        return dbt_profile_target
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "ADVANCED_INCREMENTAL.sql": fixtures._MODELS__ADVANCED_INCREMENTAL,
+            "COMPOUND_SORT.sql": fixtures._MODELS__COMPOUND_SORT,
+            "DISABLED.sql": _FABRICSPARK_DISABLED,
+            "EMPTY.sql": fixtures._MODELS__EMPTY,
+            "GET_AND_REF.sql": fixtures._MODELS_GET_AND_REF_UPPERCASE,
+            "INCREMENTAL.sql": fixtures._MODELS__INCREMENTAL,
+            "INTERLEAVED_SORT.sql": fixtures._MODELS__INTERLEAVED_SORT,
+            "MATERIALIZED.sql": fixtures._MODELS__MATERIALIZED,
+            "VIEW_MODEL.sql": _FABRICSPARK_VIEW_MODEL,
+        }
+
+    def test_simple_copy_uppercase(self, project):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+
+        results = run_dbt()
+        assert len(results) == 7
+
+        check_relations_equal(
+            project.adapter,
+            ["seed", "VIEW_MODEL", "INCREMENTAL", "MATERIALIZED", "GET_AND_REF"],
+        )


### PR DESCRIPTION
## Summary

Adapt the three `simple_copy` base test classes (`SimpleCopyBase`, `EmptyModelsArentRunBase`, `BaseSimpleCopyUppercase`) for FabricSpark. The base classes assume PostgreSQL and views; FabricSpark supports neither.

Split from #65.

## What changed

- **Materialization overrides** — `view_model.sql` uses `materialized_view` instead of `view`; `disabled.sql` uses `table` instead of `view`. FabricSpark has no `View` relation type.
- **Incremental strategy** — `incremental.sql` and `advanced_incremental.sql` use `merge` strategy with `file_format='delta'` instead of the default `append`. The `append` strategy generates `INSERT INTO TABLE` which fails with 3-part names on FabricSpark (`REQUIRES_SINGLE_PART_NAMESPACE`).
- **`test_dbt_doesnt_run_empty_models`** — Replaced `project.get_tables_in_schema()` (uses T-SQL `sys.tables`/`sys.views`) with `SHOW TABLES IN` (Spark SQL).
- **`test_simple_copy`** — Added seed-update-and-rerun phase to match the base class. Uses `--full-refresh` in phase 2 because normal incremental runs trigger `REQUIRES_SINGLE_PART_NAMESPACE` when temp views exist in the Livy session.
- **`test_simple_copy_with_materialized_views`** — Skipped. The base test creates objects via raw SQL (`CREATE TABLE`, `CREATE MATERIALIZED VIEW`, `CREATE VIEW`), and FabricSpark doesn't support raw `CREATE VIEW` or `CREATE MATERIALIZED VIEW`.
- **`BaseSimpleCopyUppercase` profile fix** — Re-overrides `dbt_profile_target` to pass through the conftest fixture instead of the base class's hardcoded PostgreSQL credentials.

## Comparison with other adapters

| Aspect | Base (dbt-adapters) | dbt-spark | dbt-databricks | Fabric DW | This PR (FabricSpark) |
|---|---|---|---|---|---|
| **SimpleCopyBase** | Views, append incremental, 2-phase seed+update | Not implemented | `pass` (views work) | Skips `test_simple_copy_with_materialized_views` only | `materialized_view` fixtures, `merge` incremental, `--full-refresh` in phase 2, skips `test_simple_copy_with_materialized_views` |
| **EmptyModelsArentRunBase** | `project.get_tables_in_schema()` (T-SQL) | Not implemented | `pass`, skips on cluster profiles (no `information_schema` in HMS) | `pass` (T-SQL works) | `SHOW TABLES IN` (Spark SQL) |
| **BaseSimpleCopyUppercase** | Hardcodes PostgreSQL `dbt_profile_target` | Not implemented | Not implemented | Passes through conftest fixture | Passes through conftest fixture + overrides model fixtures |

Key difference vs dbt-databricks: Databricks supports views and can use the base fixtures as-is. FabricSpark (Fabric Lakehouse) has no view support, requiring materialization overrides for every model fixture.

## Test plan
- [x] `uv run pytest -k "TestSimpleCopy or TestEmptyModelsArentRun" --de -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)