### PR TITLE
Fix FabricSpark escape_single_quotes test

### DIFF
--- a/tests/fabricspark/adapter/utils/test_escape_single_quotes.py
+++ b/tests/fabricspark/adapter/utils/test_escape_single_quotes.py
@@ -1,5 +1,10 @@
+import pytest
+
 from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesQuote
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark escape_single_quotes macro needs Spark-compatible implementation"
+)
 class TestEscapeSingleQuotesQuoteFabricSpark(BaseEscapeSingleQuotesQuote):
     pass

--- a/tests/fabricspark/adapter/utils/test_escape_single_quotes.py
+++ b/tests/fabricspark/adapter/utils/test_escape_single_quotes.py
@@ -1,10 +1,5 @@
-import pytest
-
-from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesQuote
+from dbt.tests.adapter.utils.test_escape_single_quotes import BaseEscapeSingleQuotesBackslash
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark escape_single_quotes macro needs Spark-compatible implementation"
-)
-class TestEscapeSingleQuotesQuoteFabricSpark(BaseEscapeSingleQuotesQuote):
+class TestEscapeSingleQuotesBackslashFabricSpark(BaseEscapeSingleQuotesBackslash):
     pass


### PR DESCRIPTION
## Summary
- Switch from `BaseEscapeSingleQuotesQuote` to `BaseEscapeSingleQuotesBackslash` — Spark uses backslash escaping, not SQL-standard doubled quotes
- The `spark__escape_single_quotes` macro (backslash-based) is already available via the `dependencies=["spark"]` chain

## Comparison with dbt-spark / dbt-databricks

| Adapter | Status | Implementation |
|---|---|---|
| **dbt-spark** | ✅ Implements | Uses `BaseEscapeSingleQuotesBackslash`, macro: `spark__escape_single_quotes` replaces `'` with `\'` |
| **dbt-databricks** | ✅ Implements | Same as dbt-spark (inherits backslash macro) |
| **dbt-fabric (before)** | ❌ Wrong base class | Tests `BaseEscapeSingleQuotesQuote` (expects doubled quotes `''`), but Spark uses backslash escaping |

**Root cause**: The test was using the wrong base class variant. Spark SQL escapes single quotes with a backslash (`\'`), not by doubling (`''`). Switching to `BaseEscapeSingleQuotesBackslash` and relying on the inherited `spark__escape_single_quotes` macro fixes this.

## Test plan
- [x] Run `uv run pytest -k "TestEscapeSingleQuotes" --de -v` to verify the test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)