### PR TITLE
Fix FabricSpark get_intervals_between test

### DIFF
--- a/tests/fabricspark/adapter/utils/test_get_intervals_between.py
+++ b/tests/fabricspark/adapter/utils/test_get_intervals_between.py
@@ -1,10 +1,23 @@
 import pytest
 
+from dbt.tests.adapter.utils.fixture_get_intervals_between import (
+    models__test_get_intervals_between_yml,
+)
 from dbt.tests.adapter.utils.test_get_intervals_between import BaseGetIntervalsBetween
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark get_intervals_between macro needs Spark-compatible implementation"
-)
 class TestGetIntervalsBetweenFabricSpark(BaseGetIntervalsBetween):
-    pass
+    model_sql = """
+        SELECT
+            {{ get_intervals_between("'2023-09-01'", "'2023-09-12'", "day") }} as intervals,
+            11 as expected
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_get_intervals_between.yml": models__test_get_intervals_between_yml,
+            "test_get_intervals_between.sql": self.interpolate_macro_namespace(
+                self.model_sql, "get_intervals_between"
+            ),
+        }

--- a/tests/fabricspark/adapter/utils/test_get_intervals_between.py
+++ b/tests/fabricspark/adapter/utils/test_get_intervals_between.py
@@ -1,5 +1,10 @@
+import pytest
+
 from dbt.tests.adapter.utils.test_get_intervals_between import BaseGetIntervalsBetween
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark get_intervals_between macro needs Spark-compatible implementation"
+)
 class TestGetIntervalsBetweenFabricSpark(BaseGetIntervalsBetween):
     pass


### PR DESCRIPTION
## Summary
- Override the model fixture to use ISO date format (`'2023-09-01'`) instead of MM/DD/YYYY (`'09/01/2023'`), which Spark SQL can't parse

## Test plan
- [x] Run `uv run pytest -k "TestGetIntervalsBetween" --de -v` to verify the test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)