### PR TITLE
Fix FabricSpark listagg test

### DIFF
--- a/tests/fabricspark/adapter/utils/test_listagg.py
+++ b/tests/fabricspark/adapter/utils/test_listagg.py
@@ -62,6 +62,7 @@ and calculate.version = data_output.version
 """
 
 
+@pytest.mark.skip("TODO: FabricSpark listagg macro needs Spark-compatible implementation")
 class TestListaggFabricSpark(BaseListagg):
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/fabricspark/adapter/utils/test_listagg.py
+++ b/tests/fabricspark/adapter/utils/test_listagg.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dbt.tests.adapter.utils import fixture_listagg
 from dbt.tests.adapter.utils.test_listagg import BaseListagg
 
 models__test_listagg_no_order_by_sql = """
@@ -62,12 +63,11 @@ and calculate.version = data_output.version
 """
 
 
-@pytest.mark.skip("TODO: FabricSpark listagg macro needs Spark-compatible implementation")
 class TestListaggFabricSpark(BaseListagg):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "test_listagg.yml": models__test_listagg_no_order_by_sql,
+            "test_listagg.yml": fixture_listagg.models__test_listagg_yml,
             "test_listagg.sql": self.interpolate_macro_namespace(
                 models__test_listagg_no_order_by_sql, "listagg"
             ),


### PR DESCRIPTION
## Summary
- Fix `test_listagg.yml` fixture reference — was incorrectly set to SQL model content (`models__test_listagg_no_order_by_sql`) instead of the YAML schema (`fixture_listagg.models__test_listagg_yml`)
- The `spark__listagg` macro (collect_list + array_join) is inherited via `dependencies=["spark"]`, no custom macro needed

## Comparison with dbt-spark / dbt-databricks

| Adapter | Status | Implementation |
|---|---|---|
| **dbt-spark** | ✅ Implements | `spark__listagg` macro: `array_join(collect_list(...), delimiter)`. ORDER BY is not supported (warns and ignores). Test fixture comments out ordered variants. |
| **dbt-databricks** | ✅ Inherits | Same as dbt-spark — inherits the macro, same fixture workaround |
| **dbt-fabric FabricSpark** | ✅ Inherits | Same as dbt-spark via `dependencies=["spark"]`. Test fixture already excluded ORDER BY variants, but YAML schema fixture was broken. |

## Test plan
- [x] Run `uv run pytest -k "TestListagg" --de -v` to verify the test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)