### PR TITLE
Switch FabricSpark current_timestamp test to timezone-aware

### DIFF
--- a/tests/fabricspark/adapter/utils/test_current_timestamp.py
+++ b/tests/fabricspark/adapter/utils/test_current_timestamp.py
@@ -1,7 +1,7 @@
 from dbt.tests.adapter.utils.test_current_timestamp import (
-    BaseCurrentTimestampNaive,
+    BaseCurrentTimestampAware,
 )
 
 
-class TestCurrentTimestampNaiveFabricSpark(BaseCurrentTimestampNaive):
+class TestCurrentTimestampAwareFabricSpark(BaseCurrentTimestampAware):
     pass

--- a/tests/fabricspark/adapter/utils/test_current_timestamp.py
+++ b/tests/fabricspark/adapter/utils/test_current_timestamp.py
@@ -1,7 +1,11 @@
+import pytest
+
 from dbt.tests.adapter.utils.test_current_timestamp import (
     BaseCurrentTimestampNaive,
 )
 
 
 class TestCurrentTimestampNaiveFabricSpark(BaseCurrentTimestampNaive):
-    pass
+    @pytest.mark.skip("TODO: FabricSpark current_timestamp type differs from expected")
+    def test_current_timestamp_type(self, current_timestamp):
+        pass

--- a/tests/fabricspark/adapter/utils/test_current_timestamp.py
+++ b/tests/fabricspark/adapter/utils/test_current_timestamp.py
@@ -1,11 +1,7 @@
-import pytest
-
 from dbt.tests.adapter.utils.test_current_timestamp import (
     BaseCurrentTimestampNaive,
 )
 
 
 class TestCurrentTimestampNaiveFabricSpark(BaseCurrentTimestampNaive):
-    @pytest.mark.skip("TODO: FabricSpark current_timestamp type differs from expected")
-    def test_current_timestamp_type(self, current_timestamp):
-        pass
+    pass


### PR DESCRIPTION
## Summary
- Switch FabricSpark `current_timestamp` test from `BaseCurrentTimestampNaive` to `BaseCurrentTimestampAware`
- FabricSpark returns timezone-aware timestamps (with UTC tzinfo via Livy sessions), not naive ones

## Comparison with dbt-spark / dbt-databricks

| Adapter | Status | Implementation |
|---|---|---|
| **dbt-spark** | ✅ Implements | Uses `BaseCurrentTimestampNaive` — `spark__current_timestamp()` returns `current_timestamp()` (naive, no timezone) |
| **dbt-databricks** | ✅ Implements | Uses `BaseCurrentTimestampAware` — Databricks returns timezone-aware timestamps |
| **dbt-fabric (before)** | ❌ Used `BaseCurrentTimestampNaive` with `test_current_timestamp_type` skipped |
| **dbt-fabric (after)** | ✅ Uses `BaseCurrentTimestampAware` — FabricSpark returns timezone-aware timestamps, matching Databricks behavior |

**Root cause**: FabricSpark's Livy session returns timestamps with `tzinfo=datetime.timezone.utc`. This makes it timezone-aware, like Databricks, not naive like standard Spark. The original skip was correct — the test genuinely fails with `BaseCurrentTimestampNaive`. The fix is to use the right base class.

## Test plan
- [x] Run `uv run pytest -k "TestCurrentTimestampAwareFabricSpark" --de -v` to verify both test methods pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)