### PR TITLE
Fix FabricSpark constraint tests and skip NOT NULL enforcement

### DIFF
--- a/src/dbt/include/fabricspark/macros/adapters/constraints.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/constraints.sql
@@ -1,0 +1,14 @@
+{% macro fabricspark__alter_column_set_constraints(relation, column_dict) %}
+  {# Fabric Lakehouse does not support ALTER TABLE CHANGE COLUMN SET NOT NULL on Delta tables #}
+  {% for column_name in column_dict %}
+    {% set constraints = column_dict[column_name]['constraints'] %}
+    {% for constraint in constraints %}
+      {% if constraint.type == 'not_null' %}
+        {{ exceptions.warn("Fabric Lakehouse does not support NOT NULL column constraints on Delta tables. "
+          "Skipping NOT NULL for column `" ~ column_name ~ "`.") }}
+      {% else %}
+        {{ exceptions.warn('Invalid constraint for column ' ~ column_name ~ '. Only `not_null` is supported.') }}
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+{% endmacro %}

--- a/tests/fabricspark/adapter/test_constraints.py
+++ b/tests/fabricspark/adapter/test_constraints.py
@@ -1,16 +1,25 @@
 import pytest
 
 from dbt.tests.adapter.constraints.fixtures import (
+    constrained_model_schema_yml,
+    foreign_key_model_sql,
+    model_fk_constraint_schema_yml,
+    model_schema_yml,
+    my_incremental_model_sql,
     my_model_incremental_wrong_name_sql,
+    my_model_incremental_wrong_order_depends_on_fk_sql,
     my_model_incremental_wrong_order_sql,
+    my_model_sql,
     my_model_wrong_name_sql,
+    my_model_wrong_order_depends_on_fk_sql,
     my_model_wrong_order_sql,
 )
 from dbt.tests.adapter.constraints.test_constraints import (
-    BaseConstraintsColumnsEqual,
     BaseConstraintsRollback,
     BaseConstraintsRuntimeDdlEnforcement,
     BaseIncrementalConstraintsColumnsEqual,
+    BaseIncrementalConstraintsRollback,
+    BaseIncrementalConstraintsRuntimeDdlEnforcement,
     BaseModelConstraintsRuntimeEnforcement,
     BaseTableConstraintsColumnsEqual,
 )
@@ -98,6 +107,30 @@ models:
         data_type: string
 """
 
+fabricspark_constraints_yml = model_schema_yml.replace("text", "string").replace("primary key", "")
+fabricspark_model_fk_constraint_schema_yml = model_fk_constraint_schema_yml.replace(
+    "text", "string"
+).replace("primary key", "")
+fabricspark_model_constraints_yml = constrained_model_schema_yml.replace("text", "string")
+
+_expected_sql_fabricspark = """
+create or replace table <model_identifier>
+    using delta
+    as
+select
+  id,
+  color,
+  date_day
+from
+
+(
+    -- depends_on: <foreign_key_model_identifier>
+    select
+    'blue' as color,
+    1 as id,
+    '2019-01-01' as date_day ) as model_subq
+"""
+
 
 class FabricSparkConstraintsTypesMixin:
     @pytest.fixture
@@ -127,8 +160,8 @@ class FabricSparkConstraintsTypesMixin:
         ]
 
 
-class TestViewConstraintsColumnsEqualFabricSpark(
-    FabricSparkConstraintsTypesMixin, BaseConstraintsColumnsEqual
+class TestTableConstraintsColumnsEqualFabricSpark(
+    FabricSparkConstraintsTypesMixin, BaseTableConstraintsColumnsEqual
 ):
     @pytest.fixture(scope="class")
     def models(self):
@@ -138,12 +171,12 @@ class TestViewConstraintsColumnsEqualFabricSpark(
             "constraints_schema.yml": spark_model_schema_yml,
         }
 
-    @pytest.mark.skip("TODO: Delta Lake does not support NOT NULL constraints in CTAS")
+    @pytest.mark.skip("Delta Lake does not support NOT NULL constraints in CTAS")
     def test__constraints_wrong_column_order(self, project):
         pass
 
     @pytest.mark.skip(
-        "TODO: Delta Lake does not support NOT NULL constraints in CTAS,"
+        "Delta Lake does not support NOT NULL constraints in CTAS,"
         " preventing data type mismatch detection"
     )
     def test__constraints_wrong_column_data_types(
@@ -163,12 +196,12 @@ class TestIncrementalConstraintsColumnsEqualFabricSpark(
             "constraints_schema.yml": spark_model_schema_yml,
         }
 
-    @pytest.mark.skip("TODO: Delta Lake does not support NOT NULL constraints in CTAS")
+    @pytest.mark.skip("Delta Lake does not support NOT NULL constraints in CTAS")
     def test__constraints_wrong_column_order(self, project):
         pass
 
     @pytest.mark.skip(
-        "TODO: Delta Lake does not support NOT NULL constraints in CTAS,"
+        "Delta Lake does not support NOT NULL constraints in CTAS,"
         " preventing data type mismatch detection"
     )
     def test__constraints_wrong_column_data_types(
@@ -177,63 +210,102 @@ class TestIncrementalConstraintsColumnsEqualFabricSpark(
         pass
 
 
-class TestTableConstraintsColumnsEqualFabricSpark(
-    FabricSparkConstraintsTypesMixin, BaseTableConstraintsColumnsEqual
+class FabricSparkConstraintsDdlEnforcementSetup:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+file_format": "delta",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return _expected_sql_fabricspark
+
+
+class TestTableConstraintsRuntimeDdlEnforcementFabricSpark(
+    FabricSparkConstraintsDdlEnforcementSetup, BaseConstraintsRuntimeDdlEnforcement
 ):
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "my_model_wrong_order.sql": my_model_wrong_order_sql,
-            "my_model_wrong_name.sql": my_model_wrong_name_sql,
-            "constraints_schema.yml": spark_model_schema_yml,
+            "my_model.sql": my_model_wrong_order_depends_on_fk_sql,
+            "foreign_key_model.sql": foreign_key_model_sql,
+            "constraints_schema.yml": fabricspark_model_fk_constraint_schema_yml,
         }
 
-    @pytest.mark.skip("TODO: Delta Lake does not support NOT NULL constraints in CTAS")
-    def test__constraints_wrong_column_order(self, project):
-        pass
 
-    @pytest.mark.skip(
-        "TODO: Delta Lake does not support NOT NULL constraints in CTAS,"
-        " preventing data type mismatch detection"
-    )
-    def test__constraints_wrong_column_data_types(
-        self, project, string_type, int_type, schema_string_type, schema_int_type, data_types
-    ):
-        pass
-
-
-@pytest.mark.skip(
-    "TODO: FabricSpark DDL constraint syntax differs from default, needs expected_sql override"
-)
-class TestTableConstraintsRuntimeDdlEnforcementFabricSpark(BaseConstraintsRuntimeDdlEnforcement):
-    pass
-
-
-@pytest.mark.skip(
-    "TODO: FabricSpark DDL constraint syntax differs from default, needs expected_sql override"
-)
 class TestIncrementalConstraintsRuntimeDdlEnforcementFabricSpark(
-    BaseConstraintsRuntimeDdlEnforcement
+    FabricSparkConstraintsDdlEnforcementSetup, BaseIncrementalConstraintsRuntimeDdlEnforcement
 ):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_incremental_wrong_order_depends_on_fk_sql,
+            "foreign_key_model.sql": foreign_key_model_sql,
+            "constraints_schema.yml": fabricspark_model_fk_constraint_schema_yml,
+        }
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark DDL constraint syntax differs from default, needs expected_sql override"
-)
-class TestModelConstraintsRuntimeEnforcementFabricSpark(BaseModelConstraintsRuntimeEnforcement):
-    pass
+class TestModelConstraintsRuntimeEnforcementFabricSpark(
+    FabricSparkConstraintsDdlEnforcementSetup, BaseModelConstraintsRuntimeEnforcement
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_wrong_order_depends_on_fk_sql,
+            "foreign_key_model.sql": foreign_key_model_sql,
+            "constraints_schema.yml": fabricspark_model_constraints_yml,
+        }
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark does not enforce NOT NULL constraints at runtime for rollback testing"
-)
-class TestTableConstraintsRollbackFabricSpark(BaseConstraintsRollback):
-    pass
+class FabricSparkConstraintsRollbackSetup:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+file_format": "delta",
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_error_messages(self):
+        return [
+            "violate the new CHECK constraint",
+            "DELTA_NEW_CHECK_CONSTRAINT_VIOLATION",
+            "DELTA_NEW_NOT_NULL_VIOLATION",
+            "violate the new NOT NULL constraint",
+            "(id > 0) violated by row with values:",
+            "DELTA_VIOLATE_CONSTRAINT_WITH_VALUES",
+            "NOT NULL constraint violated for col",
+        ]
+
+    def assert_expected_error_messages(self, error_message, expected_error_messages):
+        assert any(msg in error_message for msg in expected_error_messages)
 
 
-@pytest.mark.skip(
-    "TODO: FabricSpark does not enforce NOT NULL constraints at runtime for rollback testing"
-)
-class TestIncrementalConstraintsRollbackFabricSpark(BaseConstraintsRollback):
-    pass
+class TestTableConstraintsRollbackFabricSpark(
+    FabricSparkConstraintsRollbackSetup, BaseConstraintsRollback
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "constraints_schema.yml": fabricspark_constraints_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_color(self):
+        return "red"
+
+
+class TestIncrementalConstraintsRollbackFabricSpark(
+    FabricSparkConstraintsRollbackSetup, BaseIncrementalConstraintsRollback
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_incremental_model_sql,
+            "constraints_schema.yml": fabricspark_constraints_yml,
+        }

--- a/tests/fabricspark/adapter/test_constraints.py
+++ b/tests/fabricspark/adapter/test_constraints.py
@@ -1,40 +1,239 @@
+import pytest
+
+from dbt.tests.adapter.constraints.fixtures import (
+    my_model_incremental_wrong_name_sql,
+    my_model_incremental_wrong_order_sql,
+    my_model_wrong_name_sql,
+    my_model_wrong_order_sql,
+)
 from dbt.tests.adapter.constraints.test_constraints import (
     BaseConstraintsColumnsEqual,
     BaseConstraintsRollback,
     BaseConstraintsRuntimeDdlEnforcement,
+    BaseIncrementalConstraintsColumnsEqual,
     BaseModelConstraintsRuntimeEnforcement,
+    BaseTableConstraintsColumnsEqual,
 )
 
+spark_model_schema_yml = """
+version: 2
+models:
+  - name: my_model
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+        description: hello
+        constraints:
+          - type: not_null
+          - type: primary_key
+          - type: check
+            expression: (id > 0)
+          - type: check
+            expression: id >= 1
+        data_tests:
+          - unique
+      - name: color
+        data_type: string
+      - name: date_day
+        data_type: string
+  - name: my_model_error
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+        description: hello
+        constraints:
+          - type: not_null
+          - type: primary_key
+          - type: check
+            expression: (id > 0)
+        data_tests:
+          - unique
+      - name: color
+        data_type: string
+      - name: date_day
+        data_type: string
+  - name: my_model_wrong_order
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+        description: hello
+        constraints:
+          - type: not_null
+          - type: primary_key
+          - type: check
+            expression: (id > 0)
+        data_tests:
+          - unique
+      - name: color
+        data_type: string
+      - name: date_day
+        data_type: string
+  - name: my_model_wrong_name
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: int
+        description: hello
+        constraints:
+          - type: not_null
+          - type: primary_key
+          - type: check
+            expression: (id > 0)
+        data_tests:
+          - unique
+      - name: color
+        data_type: string
+      - name: date_day
+        data_type: string
+"""
 
-class TestViewConstraintsColumnsEqualFabricSpark(BaseConstraintsColumnsEqual):
-    pass
+
+class FabricSparkConstraintsTypesMixin:
+    @pytest.fixture
+    def string_type(self):
+        return "string"
+
+    @pytest.fixture
+    def int_type(self):
+        return "INT"
+
+    @pytest.fixture
+    def schema_string_type(self, string_type):
+        return string_type
+
+    @pytest.fixture
+    def schema_int_type(self, int_type):
+        return int_type
+
+    @pytest.fixture
+    def data_types(self, schema_int_type, int_type, string_type):
+        return [
+            ["1", schema_int_type, int_type],
+            ["'1'", string_type, string_type],
+            ["true", "boolean", "BOOLEAN"],
+            ["cast('2013-11-03 00:00:00' as timestamp)", "timestamp", "TIMESTAMP"],
+            ["cast(1.0 as decimal(10,2))", "decimal(10,2)", "DECIMAL(10,2)"],
+        ]
 
 
-class TestIncrementalConstraintsColumnsEqualFabricSpark(BaseConstraintsColumnsEqual):
-    pass
+class TestViewConstraintsColumnsEqualFabricSpark(
+    FabricSparkConstraintsTypesMixin, BaseConstraintsColumnsEqual
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_wrong_name_sql,
+            "constraints_schema.yml": spark_model_schema_yml,
+        }
+
+    @pytest.mark.skip("TODO: Delta Lake does not support NOT NULL constraints in CTAS")
+    def test__constraints_wrong_column_order(self, project):
+        pass
+
+    @pytest.mark.skip(
+        "TODO: Delta Lake does not support NOT NULL constraints in CTAS,"
+        " preventing data type mismatch detection"
+    )
+    def test__constraints_wrong_column_data_types(
+        self, project, string_type, int_type, schema_string_type, schema_int_type, data_types
+    ):
+        pass
 
 
-class TestTableConstraintsColumnsEqualFabricSpark(BaseConstraintsColumnsEqual):
-    pass
+class TestIncrementalConstraintsColumnsEqualFabricSpark(
+    FabricSparkConstraintsTypesMixin, BaseIncrementalConstraintsColumnsEqual
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_incremental_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_incremental_wrong_name_sql,
+            "constraints_schema.yml": spark_model_schema_yml,
+        }
+
+    @pytest.mark.skip("TODO: Delta Lake does not support NOT NULL constraints in CTAS")
+    def test__constraints_wrong_column_order(self, project):
+        pass
+
+    @pytest.mark.skip(
+        "TODO: Delta Lake does not support NOT NULL constraints in CTAS,"
+        " preventing data type mismatch detection"
+    )
+    def test__constraints_wrong_column_data_types(
+        self, project, string_type, int_type, schema_string_type, schema_int_type, data_types
+    ):
+        pass
 
 
+class TestTableConstraintsColumnsEqualFabricSpark(
+    FabricSparkConstraintsTypesMixin, BaseTableConstraintsColumnsEqual
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_wrong_name_sql,
+            "constraints_schema.yml": spark_model_schema_yml,
+        }
+
+    @pytest.mark.skip("TODO: Delta Lake does not support NOT NULL constraints in CTAS")
+    def test__constraints_wrong_column_order(self, project):
+        pass
+
+    @pytest.mark.skip(
+        "TODO: Delta Lake does not support NOT NULL constraints in CTAS,"
+        " preventing data type mismatch detection"
+    )
+    def test__constraints_wrong_column_data_types(
+        self, project, string_type, int_type, schema_string_type, schema_int_type, data_types
+    ):
+        pass
+
+
+@pytest.mark.skip(
+    "TODO: FabricSpark DDL constraint syntax differs from default, needs expected_sql override"
+)
 class TestTableConstraintsRuntimeDdlEnforcementFabricSpark(BaseConstraintsRuntimeDdlEnforcement):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark DDL constraint syntax differs from default, needs expected_sql override"
+)
 class TestIncrementalConstraintsRuntimeDdlEnforcementFabricSpark(
     BaseConstraintsRuntimeDdlEnforcement
 ):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark DDL constraint syntax differs from default, needs expected_sql override"
+)
 class TestModelConstraintsRuntimeEnforcementFabricSpark(BaseModelConstraintsRuntimeEnforcement):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark does not enforce NOT NULL constraints at runtime for rollback testing"
+)
 class TestTableConstraintsRollbackFabricSpark(BaseConstraintsRollback):
     pass
 
 
+@pytest.mark.skip(
+    "TODO: FabricSpark does not enforce NOT NULL constraints at runtime for rollback testing"
+)
 class TestIncrementalConstraintsRollbackFabricSpark(BaseConstraintsRollback):
     pass

--- a/tests/fabricspark/adapter/test_constraints.py
+++ b/tests/fabricspark/adapter/test_constraints.py
@@ -4,12 +4,9 @@ from dbt.tests.adapter.constraints.fixtures import (
     constrained_model_schema_yml,
     foreign_key_model_sql,
     model_fk_constraint_schema_yml,
-    model_schema_yml,
-    my_incremental_model_sql,
     my_model_incremental_wrong_name_sql,
     my_model_incremental_wrong_order_depends_on_fk_sql,
     my_model_incremental_wrong_order_sql,
-    my_model_sql,
     my_model_wrong_name_sql,
     my_model_wrong_order_depends_on_fk_sql,
     my_model_wrong_order_sql,
@@ -107,7 +104,6 @@ models:
         data_type: string
 """
 
-fabricspark_constraints_yml = model_schema_yml.replace("text", "string").replace("primary key", "")
 fabricspark_model_fk_constraint_schema_yml = model_fk_constraint_schema_yml.replace(
     "text", "string"
 ).replace("primary key", "")
@@ -260,52 +256,17 @@ class TestModelConstraintsRuntimeEnforcementFabricSpark(
         }
 
 
-class FabricSparkConstraintsRollbackSetup:
-    @pytest.fixture(scope="class")
-    def project_config_update(self):
-        return {
-            "models": {
-                "+file_format": "delta",
-            }
-        }
-
-    @pytest.fixture(scope="class")
-    def expected_error_messages(self):
-        return [
-            "violate the new CHECK constraint",
-            "DELTA_NEW_CHECK_CONSTRAINT_VIOLATION",
-            "DELTA_NEW_NOT_NULL_VIOLATION",
-            "violate the new NOT NULL constraint",
-            "(id > 0) violated by row with values:",
-            "DELTA_VIOLATE_CONSTRAINT_WITH_VALUES",
-            "NOT NULL constraint violated for col",
-        ]
-
-    def assert_expected_error_messages(self, error_message, expected_error_messages):
-        assert any(msg in error_message for msg in expected_error_messages)
+@pytest.mark.skip(
+    "Fabric Lakehouse does not support ALTER TABLE CHANGE COLUMN SET NOT NULL on Delta tables,"
+    " so constraint violations are not triggered for null data"
+)
+class TestTableConstraintsRollbackFabricSpark(BaseConstraintsRollback):
+    pass
 
 
-class TestTableConstraintsRollbackFabricSpark(
-    FabricSparkConstraintsRollbackSetup, BaseConstraintsRollback
-):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": my_model_sql,
-            "constraints_schema.yml": fabricspark_constraints_yml,
-        }
-
-    @pytest.fixture(scope="class")
-    def expected_color(self):
-        return "red"
-
-
-class TestIncrementalConstraintsRollbackFabricSpark(
-    FabricSparkConstraintsRollbackSetup, BaseIncrementalConstraintsRollback
-):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "my_model.sql": my_incremental_model_sql,
-            "constraints_schema.yml": fabricspark_constraints_yml,
-        }
+@pytest.mark.skip(
+    "Fabric Lakehouse does not support ALTER TABLE CHANGE COLUMN SET NOT NULL on Delta tables,"
+    " so constraint violations are not triggered for null data"
+)
+class TestIncrementalConstraintsRollbackFabricSpark(BaseIncrementalConstraintsRollback):
+    pass


### PR DESCRIPTION
## Summary
- Add `fabricspark__alter_column_set_constraints` macro that warns and skips NOT NULL — Fabric Lakehouse does not support `ALTER TABLE CHANGE COLUMN SET NOT NULL` on Delta tables (unlike Databricks)
- Add `FabricSparkConstraintsTypesMixin` with Spark-compatible data types (`string`, `INT`, `boolean`, `timestamp`, `decimal`)
- Implement DDL enforcement, model constraints, and ColumnsEqual tests with Spark-specific fixture overrides
- Skip rollback tests — without NOT NULL enforcement, null data passes through CHECK constraints (NULL > 0 = NULL, which Delta treats as not-violated)
- Remove old `TestViewConstraintsColumnsEqualFabricSpark` (FabricSpark doesn't support views)

## Comparison with dbt-spark / dbt-databricks

| Test group | dbt-spark | dbt-databricks | FabricSpark (this PR) |
|---|---|---|---|
| **ColumnsEqual** | ✅ Passes (Pyodbc/HTTP mixins) | ✅ Passes | ✅ 2 pass, 2 skip (wrong_order, wrong_data_types — CTAS has no inline NOT NULL) |
| **DDL enforcement** (3 classes) | ✅ `expected_sql` = CTAS using delta | ✅ Same | ✅ Same pattern, macro skips NOT NULL |
| **Model constraints** | ✅ `expected_sql` = CTAS using delta | ✅ Same | ✅ Same pattern |
| **Rollback** (2 classes) | ✅ `expected_color="red"`, `any()` | ✅ Same | ⏭️ Skipped — ALTER TABLE SET NOT NULL unsupported |

The key difference from dbt-spark/dbt-databricks: Fabric Lakehouse rejects `ALTER TABLE CHANGE COLUMN SET NOT NULL` entirely (not just when data violates the constraint). This requires the `fabricspark__alter_column_set_constraints` macro override and makes rollback tests untestable.

## Test plan
- [x] Run `uv run pytest tests/fabricspark/adapter/test_constraints.py --de -v`
- [x] Verify DDL enforcement tests pass with expected_sql fixture override
- [x] Verify model constraints runtime enforcement passes
- [x] Verify rollback tests are correctly skipped
- [x] Result: 7 passed, 6 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)