### PR TITLE
Add test.env copy step to worktree workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ Workflow for every change:
 1. Create a worktree on a new branch:
    ```shell
    git worktree add ../dbt-fabric-<short-name> -b <branch-name>
+   cp test.env ../dbt-fabric-<short-name>/
    ```
 2. Make changes, run ruff, commit.
 3. Push and create a PR:


### PR DESCRIPTION
## Summary

- Add `cp test.env` command to the worktree creation step in CLAUDE.md, since `test.env` is in `.gitignore` and won't be included in new worktrees automatically

## Test plan

- [x] Verify the updated instructions render correctly in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)