### PR TITLE
Fix Purview API risks and optimize metadata sync

### DIFF
--- a/src/dbt/adapters/fabric/base_fabric_adapter.py
+++ b/src/dbt/adapters/fabric/base_fabric_adapter.py
@@ -80,12 +80,16 @@ class BaseFabricAdapter(SQLAdapter, metaclass=abc.ABCMeta):
             logger.warning("Purview sync: no models could be matched to Purview entities")
             return ""
 
-        if sync_descriptions:
-            sync.push_descriptions(models, resolved)
-        if sync_metadata:
-            sync.push_business_metadata(models, resolved, results)
+        if sync_descriptions or sync_metadata:
+            sync.push_metadata(
+                models,
+                resolved,
+                results,
+                sync_descriptions=sync_descriptions,
+                sync_metadata=sync_metadata,
+            )
         if sync_lineage:
-            sync.push_lineage(models, resolved)
+            sync.push_lineage(models, resolved, is_full_sync=(results is None))
 
         logger.info("Purview sync completed")
         return ""

--- a/src/dbt/adapters/fabric/base_fabric_adapter.py
+++ b/src/dbt/adapters/fabric/base_fabric_adapter.py
@@ -60,7 +60,13 @@ class BaseFabricAdapter(SQLAdapter, metaclass=abc.ABCMeta):
         sync = PurviewSync(client, fabric_client, graph)
 
         if sync_metadata or sync_lineage:
-            client.ensure_type_definitions()
+            if not client.ensure_type_definitions():
+                logger.warning(
+                    "Purview sync: type definitions could not be registered, "
+                    "skipping metadata and lineage"
+                )
+                sync_metadata = False
+                sync_lineage = False
 
         models = extract_syncable_models(graph, results)
         if not models:

--- a/src/dbt/adapters/fabric/purview_client.py
+++ b/src/dbt/adapters/fabric/purview_client.py
@@ -21,6 +21,13 @@ _BUSINESS_METADATA_API = (
     "/datamap/api/atlas/v2/entity/guid/{guid}/businessmetadata/{bm_name}?isOverwrite=true"
 )
 
+
+def _qualifiedname_matches(qualified_name: str, identifiers: list[str]) -> bool:
+    """Check if any identifier matches a path segment in the qualifiedName."""
+    segments = [s.lower() for s in qualified_name.split("/") if s]
+    return any(i in segments for i in identifiers)
+
+
 _BM_APPLICABLE_TYPES = {"DataSet"}
 
 _BM_ATTRIBUTES = [
@@ -170,9 +177,7 @@ class PurviewClient:
         if database_identifiers:
             lower_ids = [i.lower() for i in database_identifiers]
             filtered = [
-                r
-                for r in results
-                if any(i in r.get("qualifiedName", "").lower() for i in lower_ids)
+                r for r in results if _qualifiedname_matches(r.get("qualifiedName", ""), lower_ids)
             ]
             if filtered:
                 return filtered
@@ -199,6 +204,13 @@ class PurviewClient:
             body["continuationToken"] = data["continuationToken"]
 
         return results
+
+    def search_process_entities(self, qualified_name_prefix: str) -> list[dict]:
+        """Search for process entities with a given qualifiedName prefix."""
+        url = f"{self._endpoint}{_SEARCH_API}"
+        filters = [{"objectType": "Process"}]
+        results = self._run_search(url, filters)
+        return [r for r in results if r.get("qualifiedName", "").startswith(qualified_name_prefix)]
 
     def get_entity_by_guid(self, guid: str) -> dict:
         """Fetch a single entity and its referred entities (e.g. columns) by GUID."""

--- a/src/dbt/adapters/fabric/purview_client.py
+++ b/src/dbt/adapters/fabric/purview_client.py
@@ -1,5 +1,6 @@
 import json
 import time
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import dbt_common.exceptions
 import requests
@@ -9,13 +10,16 @@ from dbt.adapters.fabric.fabric_token_provider import FabricTokenProvider
 
 logger = AdapterLogger("fabric")
 
+_API_VERSION = "2023-09-01"
 _PURVIEW_SCOPE = "https://purview.azure.net/.default"
 _SEARCH_API = "/datamap/api/search/query"
 _ENTITY_API = "/datamap/api/atlas/v2/entity"
 _ENTITY_BULK_API = "/datamap/api/atlas/v2/entity/bulk"
 _RELATIONSHIP_API = "/datamap/api/atlas/v2/relationship"
 _TYPEDEF_API = "/datamap/api/atlas/v2/types/typedefs"
-_BUSINESS_METADATA_API = "/datamap/api/atlas/v2/entity/guid/{guid}/businessmetadata/{bm_name}"
+_BUSINESS_METADATA_API = (
+    "/datamap/api/atlas/v2/entity/guid/{guid}/businessmetadata/{bm_name}?isOverwrite=true"
+)
 
 _BM_APPLICABLE_TYPES = {"DataSet"}
 
@@ -111,22 +115,24 @@ class PurviewClient:
         self, url: str, method: str = "get", body: dict | list | None = None
     ) -> requests.Response:
         """Send an HTTP request with auth headers, automatic 429 retry, and error handling."""
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        params["api-version"] = [_API_VERSION]
+        url = urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
+
         response = requests.request(method, url, json=body, headers=self._get_auth_headers())
 
-        if response.status_code == 429:
+        retries = 0
+        while response.status_code == 429 and retries < 10:
             retry_after = int(response.headers.get("Retry-After", 5))
-            for attempt in range(10):
-                time.sleep(retry_after)
-                response = requests.request(
-                    method, url, json=body, headers=self._get_auth_headers()
-                )
-                if response.status_code != 429:
-                    break
-                retry_after = int(response.headers.get("Retry-After", 5))
-            else:
-                raise dbt_common.exceptions.DbtRuntimeError(
-                    f"Purview {method.upper()} {url} rate limited after 10 retries"
-                )
+            time.sleep(retry_after)
+            response = requests.request(method, url, json=body, headers=self._get_auth_headers())
+            retries += 1
+
+        if response.status_code == 429:
+            raise dbt_common.exceptions.DbtRuntimeError(
+                f"Purview {method.upper()} {url} rate limited after {retries} retries"
+            )
 
         if not (200 <= response.status_code < 300):
             raise dbt_common.exceptions.DbtRuntimeError(
@@ -226,15 +232,17 @@ class PurviewClient:
         url = f"{self._endpoint}{_BUSINESS_METADATA_API.format(guid=guid, bm_name=bm_name)}"
         self._api_post(url, attrs)
 
-    def ensure_type_definitions(self) -> None:
+    def ensure_type_definitions(self) -> bool:
         """Register or update the dbt_metadata business metadata type and dbt_transformation
         entity type in Purview.
 
         Uses PUT (idempotent create-or-update) so that definition changes in future adapter
         versions are always applied. Only runs once per client instance.
+
+        Returns True if both type definitions were registered successfully.
         """
         if self._types_ensured:
-            return
+            return True
 
         url = f"{self._endpoint}{_TYPEDEF_API}"
 
@@ -253,6 +261,7 @@ class PurviewClient:
             logger.warning("Failed to register dbt_transformation entity type in Purview")
 
         self._types_ensured = bm_ok and entity_ok
+        return self._types_ensured
 
     def delete_business_metadata(self, guid: str, bm_name: str) -> None:
         """Remove all attributes of a business metadata type from an entity."""

--- a/src/dbt/adapters/fabric/purview_client.py
+++ b/src/dbt/adapters/fabric/purview_client.py
@@ -20,6 +20,7 @@ _TYPEDEF_API = "/datamap/api/atlas/v2/types/typedefs"
 _BUSINESS_METADATA_API = (
     "/datamap/api/atlas/v2/entity/guid/{guid}/businessmetadata/{bm_name}?isOverwrite=true"
 )
+_LABELS_API = "/datamap/api/atlas/v2/entity/guid/{guid}/labels"
 
 
 def _qualifiedname_matches(qualified_name: str, identifiers: list[str]) -> bool:
@@ -218,9 +219,17 @@ class PurviewClient:
         response = self._api_get(url)
         return response.json()
 
-    def bulk_create_or_update(self, entities: list[dict]) -> dict:
-        """Create or update entities in batches of 50 (Purview API limit)."""
+    def bulk_create_or_update(
+        self, entities: list[dict], merge_business_attrs: bool = False
+    ) -> dict:
+        """Create or update entities in batches of 50 (Purview API limit).
+
+        When merge_business_attrs is True, includes businessAttributeUpdateBehavior=merge
+        so that businessAttributes on entities are merged into existing values.
+        """
         url = f"{self._endpoint}{_ENTITY_BULK_API}"
+        if merge_business_attrs:
+            url += "?businessAttributeUpdateBehavior=merge"
         all_results: dict = {"mutatedEntities": {}, "guidAssignments": {}}
 
         for i in range(0, len(entities), 50):
@@ -243,6 +252,11 @@ class PurviewClient:
         """Set business metadata attributes on an entity (e.g. dbt_metadata)."""
         url = f"{self._endpoint}{_BUSINESS_METADATA_API.format(guid=guid, bm_name=bm_name)}"
         self._api_post(url, attrs)
+
+    def set_labels(self, guid: str, labels: list[str]) -> None:
+        """Set labels (free-text tags) on a Purview entity, replacing existing labels."""
+        url = f"{self._endpoint}{_LABELS_API.format(guid=guid)}"
+        self._api_post(url, labels)
 
     def ensure_type_definitions(self) -> bool:
         """Register or update the dbt_metadata business metadata type and dbt_transformation

--- a/src/dbt/adapters/fabric/purview_sync.py
+++ b/src/dbt/adapters/fabric/purview_sync.py
@@ -267,13 +267,25 @@ class PurviewSync:
         )
         return resolved.get(cache_key)
 
-    def push_descriptions(self, models: list, resolved: dict) -> None:
-        """Sync model and column descriptions from dbt to Purview userDescription fields.
+    def push_metadata(
+        self,
+        models: list,
+        resolved: dict,
+        results: list | None = None,
+        sync_descriptions: bool = True,
+        sync_metadata: bool = True,
+    ) -> None:
+        """Push descriptions, business metadata, and labels to Purview in a single bulk call.
 
-        Respects the persist_docs config: only pushes model descriptions when
-        persist_docs.relation is true, and column descriptions when persist_docs.columns
-        is true.
+        Combines model descriptions (userDescription), business metadata (dbt_metadata),
+        and labels (dbt tags) into one entity update per model, then sends them all in a
+        single bulk API call. Column descriptions still require separate calls since they
+        need to fetch referred entities first.
         """
+        test_results = self._collect_test_results(models, results) if sync_metadata else {}
+        entity_updates: list[dict] = []
+        column_work: list[tuple] = []
+
         for model in models:
             entity = self._resolve_entity_for_node(model, resolved)
             if entity is None:
@@ -292,84 +304,105 @@ class PurviewSync:
                 persist_relation = _get_attr(persist_docs, "relation", False)
                 persist_columns = _get_attr(persist_docs, "columns", False)
 
-            if persist_relation:
+            update: dict = {
+                "typeName": entity["entityType"],
+                "guid": entity["id"],
+                "attributes": {
+                    "qualifiedName": entity["qualifiedName"],
+                    "name": entity.get("name", _get_node_name(model)),
+                },
+            }
+
+            if sync_descriptions and persist_relation:
                 description = _get_attr(model, "description", "")
                 if description:
-                    self._client.update_entity_description(
-                        guid=entity["id"],
-                        type_name=entity["entityType"],
-                        qualified_name=entity["qualifiedName"],
-                        name=entity.get("name", _get_node_name(model)),
-                        description=description,
-                    )
+                    update["attributes"]["userDescription"] = description
 
-            if persist_columns:
-                columns = _get_attr(model, "columns", {})
-                if hasattr(columns, "values"):
-                    col_iter = columns.values()
-                elif isinstance(columns, dict):
-                    col_iter = columns.values()
-                else:
-                    col_iter = columns if isinstance(columns, list) else []
+            if sync_metadata:
+                unique_id = _get_attr(model, "unique_id", "")
+                bm_attrs = self._build_business_metadata_attrs(model, unique_id, test_results)
+                update["businessAttributes"] = {"dbt_metadata": bm_attrs}
 
-                col_descriptions: dict[str, str] = {}
-                for col in col_iter:
-                    col_name = _get_attr(col, "name", "")
-                    col_desc = _get_attr(col, "description", "")
-                    if col_name and col_desc:
-                        col_descriptions[col_name] = col_desc
+                tags = _get_attr(model, "tags", [])
+                if tags:
+                    update["labels"] = list(tags) if isinstance(tags, list) else [str(tags)]
 
-                if col_descriptions:
-                    self._client.update_column_descriptions(entity["id"], col_descriptions)
-
-    def push_business_metadata(
-        self, models: list, resolved: dict, results: list | None = None
-    ) -> None:
-        """Sync dbt model metadata (tags, materialization, tests, etc.) as Purview business metadata."""
-        test_results = self._collect_test_results(models, results)
-
-        for model in models:
-            entity = self._resolve_entity_for_node(model, resolved)
-            if entity is None:
-                continue
-
-            unique_id = _get_attr(model, "unique_id", "")
-            tags = _get_attr(model, "tags", [])
-            config = _get_attr(model, "config", {})
-            materialization = (
-                _get_attr(config, "materialized", "")
-                if not isinstance(config, dict)
-                else config.get("materialized", "")
+            has_content = (
+                "userDescription" in update["attributes"]
+                or "businessAttributes" in update
+                or "labels" in update
             )
-            meta = _get_attr(model, "meta", {})
-            if isinstance(meta, dict) and not meta:
-                meta_str = ""
-            else:
-                meta_str = json.dumps(meta) if meta else ""
+            if has_content:
+                entity_updates.append(update)
 
-            test_names = self._get_test_names_for_model(unique_id)
+            if sync_descriptions and persist_columns:
+                column_work.append((model, entity))
 
-            model_test_results = test_results.get(unique_id, {})
-            test_status = self._format_test_status(model_test_results)
+        has_bm = any("businessAttributes" in u for u in entity_updates)
+        if entity_updates:
+            self._client.bulk_create_or_update(entity_updates, merge_business_attrs=has_bm)
 
-            attrs: dict[str, str] = {
-                "dbt_model_id": unique_id,
-                "dbt_last_sync": datetime.now(timezone.utc).isoformat(),
-            }
-            if tags:
-                attrs["dbt_tags"] = ",".join(tags) if isinstance(tags, list) else str(tags)
-            if materialization:
-                attrs["dbt_materialization"] = str(materialization)
-            if meta_str:
-                attrs["dbt_meta"] = meta_str
-            if test_names:
-                attrs["dbt_tests"] = (
-                    ",".join(test_names) if isinstance(test_names, list) else str(test_names)
-                )
-            if test_status:
-                attrs["dbt_test_status"] = test_status
+        for model, entity in column_work:
+            col_descriptions = self._extract_column_descriptions(model)
+            if col_descriptions:
+                self._client.update_column_descriptions(entity["id"], col_descriptions)
 
-            self._client.set_business_metadata(entity["id"], "dbt_metadata", attrs)
+    def _extract_column_descriptions(self, model) -> dict[str, str]:
+        """Extract column name → description mapping from a dbt model node."""
+        columns = _get_attr(model, "columns", {})
+        if hasattr(columns, "values"):
+            col_iter = columns.values()
+        elif isinstance(columns, dict):
+            col_iter = columns.values()
+        else:
+            col_iter = columns if isinstance(columns, list) else []
+
+        col_descriptions: dict[str, str] = {}
+        for col in col_iter:
+            col_name = _get_attr(col, "name", "")
+            col_desc = _get_attr(col, "description", "")
+            if col_name and col_desc:
+                col_descriptions[col_name] = col_desc
+        return col_descriptions
+
+    def _build_business_metadata_attrs(
+        self, model, unique_id: str, test_results: dict[str, dict[str, str]]
+    ) -> dict[str, str]:
+        """Build the dbt_metadata business metadata attributes dict for a model."""
+        tags = _get_attr(model, "tags", [])
+        config = _get_attr(model, "config", {})
+        materialization = (
+            _get_attr(config, "materialized", "")
+            if not isinstance(config, dict)
+            else config.get("materialized", "")
+        )
+        meta = _get_attr(model, "meta", {})
+        if isinstance(meta, dict) and not meta:
+            meta_str = ""
+        else:
+            meta_str = json.dumps(meta) if meta else ""
+
+        test_names = self._get_test_names_for_model(unique_id)
+        model_test_results = test_results.get(unique_id, {})
+        test_status = self._format_test_status(model_test_results)
+
+        attrs: dict[str, str] = {
+            "dbt_model_id": unique_id,
+            "dbt_last_sync": datetime.now(timezone.utc).isoformat(),
+        }
+        if tags:
+            attrs["dbt_tags"] = ",".join(tags) if isinstance(tags, list) else str(tags)
+        if materialization:
+            attrs["dbt_materialization"] = str(materialization)
+        if meta_str:
+            attrs["dbt_meta"] = meta_str
+        if test_names:
+            attrs["dbt_tests"] = (
+                ",".join(test_names) if isinstance(test_names, list) else str(test_names)
+            )
+        if test_status:
+            attrs["dbt_test_status"] = test_status
+        return attrs
 
     def push_lineage(self, models: list, resolved: dict, is_full_sync: bool = False) -> None:
         """Create dbt_transformation process entities in Purview to represent data lineage.

--- a/src/dbt/adapters/fabric/purview_sync.py
+++ b/src/dbt/adapters/fabric/purview_sync.py
@@ -74,8 +74,10 @@ def _has_persist_docs_enabled(node) -> bool:
     if not persist_docs:
         return True
     if isinstance(persist_docs, dict):
-        return any(persist_docs.values())
-    return getattr(persist_docs, "relation", False) or getattr(persist_docs, "columns", False)
+        relation = persist_docs.get("relation", True)
+        columns = persist_docs.get("columns", True)
+        return relation or columns
+    return getattr(persist_docs, "relation", True) or getattr(persist_docs, "columns", True)
 
 
 def _get_attr(node: object, key: str, default=None):
@@ -134,6 +136,8 @@ class PurviewSync:
         self._graph = graph
         self._entity_cache: dict[str, dict] = {}
         self._item_id_cache: dict[str, str] = {}
+        self._lakehouses: list[dict] | None = None
+        self._warehouses: list[dict] | None = None
         self._test_mapping = self._build_test_mapping()
 
     def _resolve_item_id(self, database: str) -> str | None:
@@ -141,12 +145,16 @@ class PurviewSync:
         if database in self._item_id_cache:
             return self._item_id_cache[database]
 
-        for lh in self._fabric_client.get_lakehouses():
+        if self._lakehouses is None:
+            self._lakehouses = self._fabric_client.get_lakehouses()
+        for lh in self._lakehouses:
             if lh["displayName"] == database:
                 self._item_id_cache[database] = lh["id"]
                 return lh["id"]
 
-        for wh in self._fabric_client.get_warehouses():
+        if self._warehouses is None:
+            self._warehouses = self._fabric_client.get_warehouses()
+        for wh in self._warehouses:
             if wh["displayName"] == database:
                 self._item_id_cache[database] = wh["id"]
                 return wh["id"]
@@ -363,7 +371,7 @@ class PurviewSync:
 
             self._client.set_business_metadata(entity["id"], "dbt_metadata", attrs)
 
-    def push_lineage(self, models: list, resolved: dict) -> None:
+    def push_lineage(self, models: list, resolved: dict, is_full_sync: bool = False) -> None:
         """Create dbt_transformation process entities in Purview to represent data lineage.
 
         For each model with upstream dependencies (ref/source), creates a Process entity
@@ -395,13 +403,15 @@ class PurviewSync:
                 else config.get("materialized", "")
             )
 
-            upstream_guids = []
+            upstream_refs = []
             for dep_id in dep_nodes:
                 dep_entity = self._resolve_dependency_entity(dep_id, resolved)
                 if dep_entity is not None:
-                    upstream_guids.append(dep_entity["id"])
+                    upstream_refs.append(
+                        (dep_entity["id"], dep_entity.get("entityType", "DataSet"))
+                    )
 
-            if not upstream_guids:
+            if not upstream_refs:
                 continue
 
             process_qn = f"dbt://{unique_id}"
@@ -412,14 +422,29 @@ class PurviewSync:
                     "name": _get_node_name(model),
                     "dbt_model_id": unique_id,
                     "dbt_materialization": str(materialization) if materialization else "",
-                    "inputs": [{"guid": guid, "typeName": "DataSet"} for guid in upstream_guids],
-                    "outputs": [{"guid": entity["id"], "typeName": "DataSet"}],
+                    "inputs": [
+                        {"guid": guid, "typeName": type_name} for guid, type_name in upstream_refs
+                    ],
+                    "outputs": [
+                        {
+                            "guid": entity["id"],
+                            "typeName": entity.get("entityType", "DataSet"),
+                        }
+                    ],
                 },
             }
             process_entities.append(process_entity)
 
         if process_entities:
             self._client.bulk_create_or_update(process_entities)
+
+        if is_full_sync:
+            created_qns = {e["attributes"]["qualifiedName"] for e in process_entities}
+            existing = self._client.search_process_entities("dbt://")
+            for proc in existing:
+                if proc.get("qualifiedName", "") not in created_qns:
+                    self._client.delete_entity_by_guid(proc["id"])
+                    logger.info(f"Purview: removed stale lineage {proc.get('qualifiedName', '')}")
 
     def _resolve_dependency_entity(self, dep_id: str, resolved: dict) -> dict | None:
         """Resolve a dependency to a Purview entity.

--- a/tests/unit/test_purview_client.py
+++ b/tests/unit/test_purview_client.py
@@ -287,6 +287,57 @@ class TestDeleteEntity:
         assert "guid-1" in call_args[0][1]
 
 
+class TestLabels:
+    @patch("dbt.adapters.fabric.purview_client.requests.request")
+    def test_set_labels(self, mock_request, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
+
+        client.set_labels("guid-1", ["finance", "daily"])
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "post"
+        call_url = call_args[0][1]
+        assert "guid-1" in call_url
+        assert "labels" in call_url
+        assert call_args[1]["json"] == ["finance", "daily"]
+
+
+class TestBulkMergeBusinessAttrs:
+    @patch("dbt.adapters.fabric.purview_client.requests.request")
+    def test_merge_business_attrs_adds_query_param(self, mock_request, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "mutatedEntities": {},
+            "guidAssignments": {},
+        }
+        mock_request.return_value = mock_response
+
+        entities = [{"typeName": "t", "attributes": {"qualifiedName": "q"}}]
+        client.bulk_create_or_update(entities, merge_business_attrs=True)
+
+        call_url = mock_request.call_args[0][1]
+        assert "businessAttributeUpdateBehavior=merge" in call_url
+
+    @patch("dbt.adapters.fabric.purview_client.requests.request")
+    def test_no_merge_by_default(self, mock_request, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "mutatedEntities": {},
+            "guidAssignments": {},
+        }
+        mock_request.return_value = mock_response
+
+        entities = [{"typeName": "t", "attributes": {"qualifiedName": "q"}}]
+        client.bulk_create_or_update(entities)
+
+        call_url = mock_request.call_args[0][1]
+        assert "businessAttributeUpdateBehavior" not in call_url
+
+
 class TestUpdateColumnDescriptions:
     @patch("dbt.adapters.fabric.purview_client.requests.request")
     def test_updates_matching_columns(self, mock_request, client):

--- a/tests/unit/test_purview_client.py
+++ b/tests/unit/test_purview_client.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dbt.adapters.fabric.purview_client import (
+    _API_VERSION,
     _DBT_BUSINESS_METADATA_DEF,
     _DBT_TRANSFORMATION_TYPE_DEF,
     _PURVIEW_SCOPE,
@@ -31,6 +32,20 @@ class TestPurviewClientAuth:
     def test_endpoint_trailing_slash_stripped(self, token_provider):
         c = PurviewClient("https://test.purview.azure.com/", token_provider)
         assert c._endpoint == "https://test.purview.azure.com"
+
+
+class TestApiVersion:
+    @patch("dbt.adapters.fabric.purview_client.requests.request")
+    def test_api_version_appended_to_urls(self, mock_request, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"value": [], "@search.count": 0}
+        mock_request.return_value = mock_response
+
+        client.search_entities(name="test")
+
+        call_url = mock_request.call_args[0][1]
+        assert f"api-version={_API_VERSION}" in call_url
 
 
 class TestSearchEntities:
@@ -197,9 +212,11 @@ class TestEnsureTypeDefinitions:
         mock_response.json.return_value = {}
         mock_request.return_value = mock_response
 
-        client.ensure_type_definitions()
-        client.ensure_type_definitions()
+        result1 = client.ensure_type_definitions()
+        result2 = client.ensure_type_definitions()
 
+        assert result1 is True
+        assert result2 is True
         assert mock_request.call_count == 2  # one PUT for BM def, one PUT for entity def
 
     @patch("dbt.adapters.fabric.purview_client.requests.request")
@@ -214,6 +231,16 @@ class TestEnsureTypeDefinitions:
         for call in mock_request.call_args_list:
             assert call[0][0] == "put"
 
+    @patch("dbt.adapters.fabric.purview_client.requests.request")
+    def test_returns_false_when_registration_fails(self, mock_request, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        mock_request.return_value = mock_response
+
+        result = client.ensure_type_definitions()
+        assert result is False
+
 
 class TestBusinessMetadata:
     @patch("dbt.adapters.fabric.purview_client.requests.request")
@@ -225,8 +252,11 @@ class TestBusinessMetadata:
         client.set_business_metadata("guid-1", "dbt_metadata", {"dbt_model_id": "model.test.x"})
 
         call_args = mock_request.call_args
-        assert "guid-1" in call_args[0][1]
-        assert "dbt_metadata" in call_args[0][1]
+        call_url = call_args[0][1]
+        assert "guid-1" in call_url
+        assert "dbt_metadata" in call_url
+        assert "isOverwrite=true" in call_url
+        assert f"api-version={_API_VERSION}" in call_url
 
     @patch("dbt.adapters.fabric.purview_client.requests.request")
     def test_delete_business_metadata(self, mock_request, client):
@@ -238,8 +268,9 @@ class TestBusinessMetadata:
 
         call_args = mock_request.call_args
         assert call_args[0][0] == "delete"
-        assert "guid-1" in call_args[0][1]
-        assert "dbt_metadata" in call_args[0][1]
+        call_url = call_args[0][1]
+        assert "guid-1" in call_url
+        assert "dbt_metadata" in call_url
 
 
 class TestDeleteEntity:

--- a/tests/unit/test_purview_sync.py
+++ b/tests/unit/test_purview_sync.py
@@ -336,9 +336,10 @@ class TestResolveEntities:
         client.search_entities.assert_called_once()
 
 
-class TestPushDescriptions:
-    def test_pushes_model_description_when_persist_docs_relation(self):
+class TestPushMetadata:
+    def test_pushes_description_via_bulk_when_persist_docs_relation(self):
         client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
         sync = PurviewSync(client, _make_fabric_client(), _make_graph())
 
         entity = _make_purview_entity()
@@ -348,15 +349,13 @@ class TestPushDescriptions:
         )
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        sync.push_descriptions([node], resolved)
+        sync.push_metadata([node], resolved, sync_descriptions=True, sync_metadata=False)
 
-        client.update_entity_description.assert_called_once_with(
-            guid="guid-1",
-            type_name="fabric_lakehouse_table",
-            qualified_name="https://app.fabric.microsoft.com/groups/a1b2c3d4/lakehouses/b2c3d4e5/tables/my_model",
-            name="my_model",
-            description="This model tracks user events",
-        )
+        client.bulk_create_or_update.assert_called_once()
+        entities = client.bulk_create_or_update.call_args[0][0]
+        assert len(entities) == 1
+        assert entities[0]["attributes"]["userDescription"] == "This model tracks user events"
+        assert entities[0]["typeName"] == "fabric_lakehouse_table"
         client.update_column_descriptions.assert_not_called()
 
     def test_skips_description_when_persist_docs_not_set(self):
@@ -367,9 +366,9 @@ class TestPushDescriptions:
         node = _make_node(description="This model tracks user events")
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        sync.push_descriptions([node], resolved)
+        sync.push_metadata([node], resolved, sync_descriptions=True, sync_metadata=False)
 
-        client.update_entity_description.assert_not_called()
+        client.bulk_create_or_update.assert_not_called()
         client.update_column_descriptions.assert_not_called()
 
     def test_skips_description_when_persist_docs_relation_false(self):
@@ -383,11 +382,11 @@ class TestPushDescriptions:
         )
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        sync.push_descriptions([node], resolved)
+        sync.push_metadata([node], resolved, sync_descriptions=True, sync_metadata=False)
 
-        client.update_entity_description.assert_not_called()
+        client.bulk_create_or_update.assert_not_called()
 
-    def test_pushes_column_descriptions_when_persist_docs_columns(self):
+    def test_pushes_column_descriptions_separately(self):
         client = MagicMock()
         sync = PurviewSync(client, _make_fabric_client(), _make_graph())
 
@@ -404,37 +403,16 @@ class TestPushDescriptions:
         )
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        sync.push_descriptions([node], resolved)
+        sync.push_metadata([node], resolved, sync_descriptions=True, sync_metadata=False)
 
-        client.update_entity_description.assert_not_called()
+        client.bulk_create_or_update.assert_not_called()
         client.update_column_descriptions.assert_called_once_with(
             "guid-1", {"user_id": "Primary key"}
         )
 
-    def test_pushes_both_when_persist_docs_fully_enabled(self):
+    def test_pushes_business_metadata_via_bulk(self):
         client = MagicMock()
-        sync = PurviewSync(client, _make_fabric_client(), _make_graph())
-
-        entity = _make_purview_entity()
-        node = _make_node(
-            description="Full docs",
-            columns={"user_id": {"name": "user_id", "description": "Primary key"}},
-            config={
-                "materialized": "table",
-                "persist_docs": {"relation": True, "columns": True},
-            },
-        )
-        resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
-
-        sync.push_descriptions([node], resolved)
-
-        client.update_entity_description.assert_called_once()
-        client.update_column_descriptions.assert_called_once()
-
-
-class TestPushBusinessMetadata:
-    def test_pushes_metadata(self):
-        client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
         sync = PurviewSync(client, _make_fabric_client(), _make_graph())
 
         entity = _make_purview_entity()
@@ -445,20 +423,51 @@ class TestPushBusinessMetadata:
         )
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        sync.push_business_metadata([node], resolved)
+        sync.push_metadata([node], resolved, sync_descriptions=False, sync_metadata=True)
 
-        call_args = client.set_business_metadata.call_args
-        assert call_args[0][0] == "guid-1"
-        assert call_args[0][1] == "dbt_metadata"
-        attrs = call_args[0][2]
-        assert attrs["dbt_model_id"] == "model.test.my_model"
-        assert attrs.get("dbt_last_sync")
-        assert attrs["dbt_tags"] == "finance,daily"
-        assert attrs["dbt_materialization"] == "incremental"
-        assert "owner" in attrs["dbt_meta"]
+        client.bulk_create_or_update.assert_called_once()
+        assert client.bulk_create_or_update.call_args[1]["merge_business_attrs"] is True
 
-    def test_includes_test_results(self):
+        entities = client.bulk_create_or_update.call_args[0][0]
+        assert len(entities) == 1
+        bm = entities[0]["businessAttributes"]["dbt_metadata"]
+        assert bm["dbt_model_id"] == "model.test.my_model"
+        assert bm.get("dbt_last_sync")
+        assert bm["dbt_tags"] == "finance,daily"
+        assert bm["dbt_materialization"] == "incremental"
+        assert "owner" in bm["dbt_meta"]
+
+    def test_sets_labels_from_tags(self):
         client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
+        sync = PurviewSync(client, _make_fabric_client(), _make_graph())
+
+        entity = _make_purview_entity()
+        node = _make_node(tags=["finance", "daily"])
+        resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
+
+        sync.push_metadata([node], resolved, sync_descriptions=False, sync_metadata=True)
+
+        entities = client.bulk_create_or_update.call_args[0][0]
+        assert entities[0]["labels"] == ["finance", "daily"]
+
+    def test_no_labels_when_no_tags(self):
+        client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
+        sync = PurviewSync(client, _make_fabric_client(), _make_graph())
+
+        entity = _make_purview_entity()
+        node = _make_node(tags=[])
+        resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
+
+        sync.push_metadata([node], resolved, sync_descriptions=False, sync_metadata=True)
+
+        entities = client.bulk_create_or_update.call_args[0][0]
+        assert "labels" not in entities[0]
+
+    def test_includes_test_results_in_metadata(self):
+        client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
         sync = PurviewSync(client, _make_fabric_client(), _make_graph())
 
         entity = _make_purview_entity()
@@ -471,18 +480,18 @@ class TestPushBusinessMetadata:
             status="pass",
         )
         test_result["node"]["depends_on"] = {"nodes": ["model.test.my_model"]}
-
         model_result = _make_result(unique_id="model.test.my_model")
         results = [model_result, test_result]
 
-        sync.push_business_metadata([node], resolved, results)
+        sync.push_metadata([node], resolved, results, sync_descriptions=False, sync_metadata=True)
 
-        call_args = client.set_business_metadata.call_args
-        attrs = call_args[0][2]
-        assert attrs["dbt_test_status"] == "all_passed"
+        entities = client.bulk_create_or_update.call_args[0][0]
+        bm = entities[0]["businessAttributes"]["dbt_metadata"]
+        assert bm["dbt_test_status"] == "all_passed"
 
     def test_includes_test_names_from_graph(self):
         client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
         graph = _make_graph(
             nodes={
                 "model.test.my_model": _make_node(),
@@ -496,12 +505,54 @@ class TestPushBusinessMetadata:
         node = _make_node()
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        sync.push_business_metadata([node], resolved)
+        sync.push_metadata([node], resolved, sync_descriptions=False, sync_metadata=True)
 
-        call_args = client.set_business_metadata.call_args
-        attrs = call_args[0][2]
-        test_names = set(attrs["dbt_tests"].split(","))
+        entities = client.bulk_create_or_update.call_args[0][0]
+        bm = entities[0]["businessAttributes"]["dbt_metadata"]
+        test_names = set(bm["dbt_tests"].split(","))
         assert test_names == {"not_null_id", "unique_id"}
+
+    def test_combined_descriptions_and_metadata(self):
+        client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
+        sync = PurviewSync(client, _make_fabric_client(), _make_graph())
+
+        entity = _make_purview_entity()
+        node = _make_node(
+            description="Full docs",
+            columns={"user_id": {"name": "user_id", "description": "Primary key"}},
+            tags=["finance"],
+            config={
+                "materialized": "table",
+                "persist_docs": {"relation": True, "columns": True},
+            },
+        )
+        resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
+
+        sync.push_metadata([node], resolved, sync_descriptions=True, sync_metadata=True)
+
+        client.bulk_create_or_update.assert_called_once()
+        entities = client.bulk_create_or_update.call_args[0][0]
+        assert entities[0]["attributes"]["userDescription"] == "Full docs"
+        assert "dbt_metadata" in entities[0]["businessAttributes"]
+        assert entities[0]["labels"] == ["finance"]
+        client.update_column_descriptions.assert_called_once()
+
+    def test_no_merge_flag_when_descriptions_only(self):
+        client = MagicMock()
+        client.bulk_create_or_update.return_value = {"mutatedEntities": {}, "guidAssignments": {}}
+        sync = PurviewSync(client, _make_fabric_client(), _make_graph())
+
+        entity = _make_purview_entity()
+        node = _make_node(
+            description="Desc",
+            config={"materialized": "table", "persist_docs": {"relation": True}},
+        )
+        resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
+
+        sync.push_metadata([node], resolved, sync_descriptions=True, sync_metadata=False)
+
+        assert client.bulk_create_or_update.call_args[1]["merge_business_attrs"] is False
 
 
 class TestPushLineage:

--- a/tests/unit/test_purview_sync.py
+++ b/tests/unit/test_purview_sync.py
@@ -1,6 +1,4 @@
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 from dbt.adapters.fabric.purview_sync import (
     PurviewSync,
@@ -207,7 +205,7 @@ class TestHasPersistDocsEnabled:
 
     def test_relation_false_only(self):
         node = {"config": {"persist_docs": {"relation": False}}}
-        assert _has_persist_docs_enabled(node) is False
+        assert _has_persist_docs_enabled(node) is True
 
 
 class TestGetAttr:
@@ -447,16 +445,14 @@ class TestPushBusinessMetadata:
         )
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        with patch("dbt.adapters.fabric.purview_sync.datetime") as mock_dt:
-            mock_dt.now.return_value.isoformat.return_value = "2026-01-01T00:00:00+00:00"
-            mock_dt.side_effect = lambda *args, **kw: __import__("datetime").datetime(*args, **kw)
-            sync.push_business_metadata([node], resolved)
+        sync.push_business_metadata([node], resolved)
 
         call_args = client.set_business_metadata.call_args
         assert call_args[0][0] == "guid-1"
         assert call_args[0][1] == "dbt_metadata"
         attrs = call_args[0][2]
         assert attrs["dbt_model_id"] == "model.test.my_model"
+        assert attrs.get("dbt_last_sync")
         assert attrs["dbt_tags"] == "finance,daily"
         assert attrs["dbt_materialization"] == "incremental"
         assert "owner" in attrs["dbt_meta"]
@@ -500,10 +496,7 @@ class TestPushBusinessMetadata:
         node = _make_node()
         resolved = {"model.test.my_model": entity, "my_db.dbo.my_model": entity}
 
-        with patch("dbt.adapters.fabric.purview_sync.datetime") as mock_dt:
-            mock_dt.now.return_value.isoformat.return_value = "2026-01-01T00:00:00+00:00"
-            mock_dt.side_effect = lambda *args, **kw: __import__("datetime").datetime(*args, **kw)
-            sync.push_business_metadata([node], resolved)
+        sync.push_business_metadata([node], resolved)
 
         call_args = client.set_business_metadata.call_args
         attrs = call_args[0][2]
@@ -540,8 +533,10 @@ class TestPushLineage:
         assert process["attributes"]["qualifiedName"] == "dbt://model.test.my_model"
         assert len(process["attributes"]["inputs"]) == 1
         assert process["attributes"]["inputs"][0]["guid"] == "guid-upstream"
+        assert process["attributes"]["inputs"][0]["typeName"] == "fabric_lakehouse_table"
         assert len(process["attributes"]["outputs"]) == 1
         assert process["attributes"]["outputs"][0]["guid"] == "guid-downstream"
+        assert process["attributes"]["outputs"][0]["typeName"] == "fabric_lakehouse_table"
 
     def test_resolves_source_dependencies(self):
         client = MagicMock()


### PR DESCRIPTION
## Summary

Fixes identified during API documentation review of the Purview integration (#66). Addresses 10 risks, 3 problems, and 2 optimization opportunities.

**API correctness & stability:**
- Pin `api-version=2023-09-01` on all Purview Data Map API calls
- Add `?isOverwrite=true` on business metadata POST endpoint
- Use actual `entityType` from Purview search results in lineage refs instead of hardcoded `DataSet`
- Use path-segment matching for `qualifiedName` filtering (prevents substring false positives)
- `ensure_type_definitions()` returns `bool` — caller skips metadata/lineage when registration fails
- Simplify `_api_request` retry loop (single request + while-loop instead of do-while pattern)

**Sync correctness:**
- Fix `_has_persist_docs_enabled`: `{"relation": False}` without `columns` key now correctly defaults `columns` to `True` (sync enabled)
- Clean up stale lineage `dbt_transformation` entities during full sync
- Cache `get_lakehouses()` / `get_warehouses()` results per sync run

**Bulk optimization & labels (Opportunities 1 & 2):**
- Replace separate `push_descriptions()` + `push_business_metadata()` with single `push_metadata()` that combines `userDescription`, `businessAttributes`, and `labels` into one `bulk_create_or_update` call with `businessAttributeUpdateBehavior=merge`
- Sync dbt tags as Purview labels (searchable/filterable in the Purview UI)

**Tests:**
- Remove fragile `datetime.now()` mocking — assert `dbt_last_sync` exists instead of matching exact value
- Add tests for `api-version` injection, `set_labels`, `merge_business_attrs`, type-def failure path
- Rewrite description/metadata tests for the unified `push_metadata` method

## Test plan

- [x] All 67 Purview unit tests pass
- [x] Linting clean (`ruff format` + `ruff check`)
- [ ] Integration tests against real Fabric/Purview (CI)


🤖 Generated with [Claude Code](https://claude.com/claude-code)