### PR TITLE
Add path filters to DW integration test triggers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,9 +7,25 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/dbt/adapters/fabric/**'
+      - 'src/dbt/include/fabric/**'
+      - 'tests/fabric/**'
+      - 'tests/conftest.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/integration-tests.yml'
   push:
     branches:
       - main
+    paths:
+      - 'src/dbt/adapters/fabric/**'
+      - 'src/dbt/include/fabric/**'
+      - 'tests/fabric/**'
+      - 'tests/conftest.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/integration-tests.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `paths` filters to the `pull_request` and `push` triggers in the integration tests workflow so DW integration tests only run when relevant files change
- Filtered paths: `src/dbt/adapters/fabric/**`, `src/dbt/include/fabric/**`, `tests/fabric/**`, `tests/conftest.py`, `pyproject.toml`, `uv.lock`, and the workflow file itself
- `schedule` and `workflow_dispatch` triggers are unchanged (they always run the full suite)

## Test plan
- [ ] Verify the workflow still triggers on PRs that touch DW adapter code
- [ ] Verify the workflow does not trigger on PRs that only touch docs or FabricSpark code
- [ ] Verify scheduled runs and manual dispatch are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)