### PR TITLE
Extract community package tests into skill, shorten test architecture

### DIFF
--- a/.claude/skills/community-package-tests/SKILL.md
+++ b/.claude/skills/community-package-tests/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: community-package-tests
+description: Use when adding or modifying integration tests for community dbt packages (dbt-utils, dbt-date, dbt-expectations, dbt-audit-helper, dbt-external-tables). Covers the BaseDbtPackageTests base class, fixture wiring, and patterns for git-based and PyPI packages.
+user-invocable: true
+---
+
+Integration tests for community dbt packages live in `tests/fabric/packages/`. They use the `BaseDbtPackageTests` base class from `base_package_test.py`, which provides shared fixture wiring and dispatch configuration.
+
+**Base class fixtures:**
+
+| Fixture | Purpose |
+|---|---|
+| `package_name` | dbt macro namespace (e.g., `dbt_utils`, `dbt_external_tables`) |
+| `package_repo` | Git URL to the package repository (e.g., `https://github.com/dbt-labs/dbt-utils`) |
+| `package_revision` | Git revision or tag (e.g., `1.3.0`) |
+| `packages` | Installs via git + `integration_tests` subdirectory, using `package_repo`/`package_revision` |
+| `project_config_update` | Sets up dispatch with `search_order: [test_dbt_package, dbt, <package_name>]` |
+| `test_package` | Default flow: `dbt deps` -> `dbt seed` -> `dbt run` |
+
+Subclasses must provide `package_name`, `package_repo`, and `package_revision`.
+
+**Git packages** (have integration_tests subdirectory, e.g., dbt-utils) -- inherit directly from `BaseDbtPackageTests`:
+
+```python
+class TestDbtUtils(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "dbt_utils"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "https://github.com/dbt-labs/dbt-utils"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "1.3.0"
+```
+
+**PyPI packages** (e.g., dbt-external-tables) -- create an intermediate base class that overrides `packages` (for PyPI format) and `test_package` (for the package-specific workflow). Concrete test classes then only provide `models` and `verify_data`:
+
+```python
+class BaseExternalTableTest(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "dbt_external_tables"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "dbt-labs/dbt_external_tables"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "0.11.0"
+
+    @pytest.fixture(scope="class")
+    def packages(self, package_repo: str, package_revision: str):
+        return {"packages": [{"package": package_repo, "version": package_revision}]}
+
+    def test_package(self, project, dbt_core_bug_workaround):
+        run_dbt(["deps"])
+        run_dbt(["run-operation", "stage_external_sources"])
+        results = run_dbt(["run"])
+        for r in results:
+            assert r.status == "success"
+        self.verify_data(project)
+
+    def verify_data(self, project):
+        raise NotImplementedError
+
+class TestExternalTableCSV(BaseExternalTableTest):
+    @pytest.fixture(scope="class")
+    def models(self):
+        ...  # sources.yml + model SQL for CSV
+
+    def verify_data(self, project):
+        ...  # assert row counts and data values
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,25 +236,7 @@ For coordinating parallel agents to fix multiple test failures, use the `multi-a
 
 ### Test architecture
 
-Tests use [dbt-tests-adapter](https://github.com/dbt-labs/dbt-adapters), dbt's official adapter test harness. It provides base test classes for standard adapter behavior. Our tests inherit from these base classes and override fixtures where Fabric's SQL dialect differs.
-
-Typical test pattern:
-
-```python
-from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
-
-class TestSimpleMaterializations(BaseSimpleMaterializations):
-    pass  # Inherits all test methods, uses Fabric adapter automatically
-```
-
-When Fabric-specific SQL is needed, override fixtures:
-
-```python
-class TestIncrementalFabric(BaseIncrementalOnSchemaChange):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {"model.sql": fabric_specific_sql}
-```
+Tests use [dbt-tests-adapter](https://github.com/dbt-labs/dbt-adapters), dbt's official adapter test harness. It provides base test classes for standard adapter behavior. Our tests inherit from these base classes and override fixtures where Fabric's SQL dialect differs. See any test file in `tests/fabric/adapter/` or `tests/fabricspark/adapter/` for the pattern.
 
 Common fixture overrides:
 - `models` — SQL model files (when T-SQL syntax differs from default)
@@ -322,77 +304,7 @@ class TestGetCatalogForSingleRelation(BaseGetCatalogForSingleRelation):
 
 ### Community package integration tests
 
-Integration tests for community dbt packages live in `tests/fabric/packages/`. They use the `BaseDbtPackageTests` base class from `base_package_test.py`, which provides shared fixture wiring and dispatch configuration.
-
-**Base class fixtures:**
-
-| Fixture | Purpose |
-|---|---|
-| `package_name` | dbt macro namespace (e.g., `dbt_utils`, `dbt_external_tables`) |
-| `package_repo` | Git URL to the package repository (e.g., `https://github.com/dbt-labs/dbt-utils`) |
-| `package_revision` | Git revision or tag (e.g., `1.3.0`) |
-| `packages` | Installs via git + `integration_tests` subdirectory, using `package_repo`/`package_revision` |
-| `project_config_update` | Sets up dispatch with `search_order: [test_dbt_package, dbt, <package_name>]` |
-| `test_package` | Default flow: `dbt deps` → `dbt seed` → `dbt run` |
-
-Subclasses must provide `package_name`, `package_repo`, and `package_revision`.
-
-**Git packages** (have integration_tests subdirectory, e.g., dbt-utils) — inherit directly from `BaseDbtPackageTests`:
-
-```python
-class TestDbtUtils(BaseDbtPackageTests):
-    @pytest.fixture(scope="class")
-    def package_name(self) -> str:
-        return "dbt_utils"
-
-    @pytest.fixture(scope="class")
-    def package_repo(self) -> str:
-        return "https://github.com/dbt-labs/dbt-utils"
-
-    @pytest.fixture(scope="class")
-    def package_revision(self) -> str:
-        return "1.3.0"
-```
-
-**PyPI packages** (e.g., dbt-external-tables) — create an intermediate base class that overrides `packages` (for PyPI format) and `test_package` (for the package-specific workflow). Concrete test classes then only provide `models` and `verify_data`:
-
-```python
-class BaseExternalTableTest(BaseDbtPackageTests):
-    @pytest.fixture(scope="class")
-    def package_name(self) -> str:
-        return "dbt_external_tables"
-
-    @pytest.fixture(scope="class")
-    def package_repo(self) -> str:
-        return "dbt-labs/dbt_external_tables"
-
-    @pytest.fixture(scope="class")
-    def package_revision(self) -> str:
-        return "0.11.0"
-
-    @pytest.fixture(scope="class")
-    def packages(self, package_repo: str, package_revision: str):
-        return {"packages": [{"package": package_repo, "version": package_revision}]}
-
-    def test_package(self, project, dbt_core_bug_workaround):
-        run_dbt(["deps"])
-        run_dbt(["run-operation", "stage_external_sources"])
-        results = run_dbt(["run"])
-        for r in results:
-            assert r.status == "success"
-        self.verify_data(project)
-
-    def verify_data(self, project):
-        raise NotImplementedError
-
-class TestExternalTableCSV(BaseExternalTableTest):
-    @pytest.fixture(scope="class")
-    def models(self):
-        ...  # sources.yml + model SQL for CSV
-
-    def verify_data(self, project):
-        ...  # assert row counts and data values
-```
+For adding integration tests for community dbt packages, use the `community-package-tests` skill. See `tests/fabric/packages/base_package_test.py` for the `BaseDbtPackageTests` base class and existing tests in the same directory for examples.
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary
- Extracted the "Community package integration tests" subsection from CLAUDE.md into a new skill at `.claude/skills/community-package-tests/SKILL.md`, replacing the subsection with a pointer to the skill
- Shortened the "Test architecture" subsection by removing the two Python code blocks and replacing them with a reference to existing test files

## Test plan
- [x] Verify CLAUDE.md reads coherently after both edits
- [x] Verify the skill file contains the full extracted content
- [x] Verify `wc -l` and `wc -c` show reduced CLAUDE.md size (392 lines, 27962 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)