### PR TITLE
Add on-demand DE tests via PR comments and Copilot agent

### DIFF
--- a/.github/agents/test-runner.agent.md
+++ b/.github/agents/test-runner.agent.md
@@ -1,0 +1,288 @@
+---
+name: test-runner
+description: Triggers on-demand FabricSpark (DE) integration tests for dbt-fabric PRs
+tools:
+  - shell
+---
+
+You help developers run FabricSpark (DE) integration tests on pull requests. When asked to run tests, you:
+
+1. Determine which test classes match the user's request using the catalog below
+2. Build a pytest `-k` filter expression
+3. Trigger the test workflow
+
+## How to trigger tests
+
+Use `gh workflow run` with the PR number and filter:
+
+```shell
+gh workflow run test-de-on-demand.yml -f pytest_filter="<FILTER>" -f pr_number="<PR_NUMBER>"
+```
+
+Get the PR number from the current context (the PR you're working on, or ask the user).
+
+If the user wants ALL DE tests (no filter), warn them: this is a long run (30-60 min) that consumes Spark session capacity. Suggest narrowing to the relevant area if possible.
+
+## Building `-k` filter expressions
+
+pytest's `-k` flag matches test class and method names. Use `and`, `or`, `not`, and parentheses:
+
+- Single class: `TestDebugFabricSpark`
+- Multiple classes: `TestDebugFabricSpark or TestConcurrencyFabricSpark`
+- By area keyword: `Incremental and FabricSpark`
+- Exclude: `Seed and FabricSpark and not Delimiter`
+
+## Test catalog
+
+### Core materializations (`test_basic.py`)
+| Class | Tests |
+|---|---|
+| `TestSimpleMaterializationsSpark` | Basic table + materialized_view creation |
+| `TestSingularTestsSpark` | Singular test execution |
+| `TestSingularTestsEphemeralSpark` | Singular tests with ephemeral models |
+| `TestEmptySpark` | Empty model handling |
+| `TestEphemeralSpark` | Ephemeral (CTE) materialization |
+| `TestIncrementalSpark` | Basic incremental materialization |
+| `TestIncrementalNotSchemaChangeFabric` | Incremental without schema changes |
+| `TestIncrementalBadStrategySpark` | Invalid incremental strategy error |
+| `TestGenericTestsSpark` | Generic test execution |
+| `TestSnapshotCheckColsSpark` | Snapshot with check_cols strategy |
+| `TestSnapshotTimestampSpark` | Snapshot with timestamp strategy |
+| `TestBaseCachingSpark` | Basic relation caching |
+| `TestValidateConnectionSpark` | Connection validation |
+| `TestDocsGenerateSpark` | `dbt docs generate` |
+| `TestDocsGenReferencesSpark` | Docs generation with refs |
+| `TestTableMaterializationSpark` | Table materialization |
+| `TestGetCatalogForSingleRelationSpark` | Single-relation catalog (skipped) |
+
+**Shorthand:** `Spark and test_basic` or specific class name
+
+### Seeds (`test_simple_seed.py`)
+| Class | Tests |
+|---|---|
+| `TestBasicSeedTestsFabricSpark` | Basic seed loading |
+| `TestEmptySeedFabricSpark` | Empty seed files |
+| `TestSeedConfigFullRefreshOffFabricSpark` | Seed with full_refresh=false |
+| `TestSeedConfigFullRefreshOnFabricSpark` | Seed with full_refresh=true |
+| `TestSeedCustomSchemaFabricSpark` | Seeds in custom schemas |
+| `TestSeedParsingFabricSpark` | Seed CSV parsing |
+| `TestSeedSpecificFormatsFabricSpark` | Special format seeds |
+| `TestSeedWithEmptyDelimiterFabricSpark` | Empty delimiter handling |
+| `TestSeedWithUniqueDelimiterFabricSpark` | Custom delimiter |
+| `TestSeedWithWrongDelimiterFabricSpark` | Wrong delimiter error |
+| `TestSimpleSeedColumnOverrideFabricSpark` | Column type overrides in seeds |
+| `TestSimpleSeedEnabledViaConfigFabricSpark` | Seed enabled via config |
+| `TestSimpleSeedWithBOMFabricSpark` | UTF-8 BOM handling |
+
+**Shorthand:** `Seed and FabricSpark`
+
+### Snapshots (`test_simple_snapshot.py`)
+| Class | Tests |
+|---|---|
+| `TestSimpleSnapshotFabricSpark` | Basic snapshot |
+| `TestSnapshotCheckFabricSpark` | Snapshot check strategy |
+
+**Shorthand:** `Snapshot and (FabricSpark or Spark)`
+
+### Incremental (`test_incremental.py`)
+| Class | Tests |
+|---|---|
+| `TestBaseIncrementalUniqueKeyFabricSpark` | Unique key incremental |
+| `TestIncrementalOnSchemaChangeFabricSpark` | Schema change handling |
+| `TestIncrementalPredicatesDeleteInsertFabricSpark` | Delete+insert with predicates |
+| `TestPredicatesDeleteInsertFabricSpark` | Predicates delete+insert |
+| `TestMergeExcludeColumnsFabricSpark` | Merge with excluded columns |
+| `TestFabricSparkMicrobatch` | Microbatch incremental |
+
+**Shorthand:** `(Incremental or Predicates or Merge or Microbatch) and (FabricSpark or Spark)`
+
+### Constraints (`test_constraints.py`)
+| Class | Tests |
+|---|---|
+| `TestViewConstraintsColumnsEqualFabricSpark` | View constraint column equality |
+| `TestIncrementalConstraintsColumnsEqualFabricSpark` | Incremental constraint columns |
+| `TestTableConstraintsColumnsEqualFabricSpark` | Table constraint columns |
+| `TestTableConstraintsRuntimeDdlEnforcementFabricSpark` | Table DDL enforcement |
+| `TestIncrementalConstraintsRuntimeDdlEnforcementFabricSpark` | Incremental DDL enforcement |
+| `TestModelConstraintsRuntimeEnforcementFabricSpark` | Model runtime enforcement |
+| `TestTableConstraintsRollbackFabricSpark` | Table constraint rollback |
+| `TestIncrementalConstraintsRollbackFabricSpark` | Incremental constraint rollback |
+
+**Shorthand:** `Constraints and FabricSpark`
+
+### Python models (`test_python_model.py`)
+| Class | Tests |
+|---|---|
+| `TestPythonModelTestsFabricSpark` | Basic Python model |
+| `TestPythonIncrementalTestsFabricSpark` | Incremental Python model |
+| `TestPySparkTestsFabricSpark` | PySpark DataFrame model |
+| `TestPythonEmptyTestsFabricSpark` | Empty Python model |
+| `TestPythonSampleTestsFabricSpark` | Sample Python model |
+
+**Shorthand:** `(PythonModel or PythonIncremental or PySpark or PythonEmpty or PythonSample) and FabricSpark`
+
+### Hooks (`test_hooks.py`)
+| Class | Tests |
+|---|---|
+| `TestPrePostModelHooksFabricSpark` | Pre/post model hooks |
+| `TestPrePostModelHooksInConfigFabricSpark` | Hooks in config |
+| `TestPrePostModelHooksInConfigKwargsFabricSpark` | Hooks with kwargs |
+| `TestPrePostModelHooksInConfigWithCountFabricSpark` | Hooks with count |
+| `TestPrePostModelHooksOnSeedsFabricSpark` | Hooks on seeds |
+| `TestPrePostModelHooksOnSeedsPlusPrefixedFabricSpark` | Prefixed seed hooks |
+| `TestPrePostModelHooksOnSeedsPlusPrefixedWhitespaceFabricSpark` | Whitespace prefixed |
+| `TestPrePostModelHooksOnSnapshotsFabricSpark` | Hooks on snapshots |
+| `TestPrePostSnapshotHooksInConfigKwargsFabricSpark` | Snapshot hook kwargs |
+| `TestPrePostRunHooksFabricSpark` | Pre/post run hooks |
+| `TestAfterRunHooksFabricSpark` | After-run hooks |
+| `TestDuplicateHooksInConfigsFabricSpark` | Duplicate hook handling |
+| `TestHookRefsFabricSpark` | Hook refs |
+| `TestHooksRefsOnSeedsFabricSpark` | Hook refs on seeds |
+
+**Shorthand:** `Hook and FabricSpark`
+
+### Caching (`test_caching.py`)
+| Class | Tests |
+|---|---|
+| `TestCachingLowerCaseModelFabricSpark` | Lowercase model caching |
+| `TestCachingUppercaseModelFabricSpark` | Uppercase model caching |
+| `TestCachingSelectedSchemaOnlyFabricSpark` | Schema-scoped caching |
+| `TestNoPopulateCacheFabricSpark` | No-cache mode |
+
+**Shorthand:** `Cach and FabricSpark`
+
+### Aliases (`test_aliases.py`)
+| Class | Tests |
+|---|---|
+| `TestAliasesFabricSpark` | Basic aliasing |
+| `TestAliasErrorsFabricSpark` | Alias error handling |
+| `TestSameAliasDifferentSchemasFabricSpark` | Cross-schema aliases |
+| `TestSameAliasDifferentDatabasesFabricSpark` | Cross-database aliases |
+
+**Shorthand:** `Alias and FabricSpark`
+
+### Functions / UDFs (`test_functions.py`)
+| Class | Tests |
+|---|---|
+| `TestUDFsBasicFabricSpark` | Basic UDF (skipped) |
+| `TestErrorForUnsupportedTypeFabricSpark` | Unsupported type error |
+| `TestPythonUDFNotSupportedFabricSpark` | Python UDF not supported |
+| `TestSqlUDFDefaultArgSupportFabricSpark` | SQL UDF default args (skipped) |
+| `TestBasicSQLUDAFFabricSpark` | Basic SQL UDAF (skipped) |
+| `TestDeterministicUDFFabricSpark` | Deterministic UDF (skipped) |
+| `TestStableUDFFabricSpark` | Stable UDF (skipped) |
+| `TestNonDeterministicUDFFabricSpark` | Non-deterministic UDF (skipped) |
+| `TestPythonUDFSupportedFabricSpark` | Python UDF support (skipped) |
+| `TestPythonUDFRuntimeVersionRequiredFabricSpark` | Runtime version required |
+| `TestPythonUDFEntryPointRequiredFabricSpark` | Entry point required |
+| `TestPythonUDFDefaultArgSupportFabricSpark` | Python UDF default args (skipped) |
+| `TestPythonUDFVolatilitySupportFabricSpark` | UDF volatility (skipped) |
+| `TestBasicPythonUDAFFabricSpark` | Basic Python UDAF (skipped) |
+| `TestPythonUDAFDefaultArgSupportFabricSpark` | Python UDAF args (skipped) |
+
+**Shorthand:** `UDF and FabricSpark` or `UDAF and FabricSpark`
+
+### Store test failures (`test_store_test_failures.py`)
+| Class | Tests |
+|---|---|
+| `TestFabricSparkStoreTestFailures` | Basic store failures |
+| `TestFabricSparkStoreTestFailuresAsGeneric` | Generic store failures |
+| `TestFabricSparkStoreTestFailuresAsExceptions` | Exception store failures |
+| `TestFabricSparkStoreTestFailuresAsInteractions` | Interaction store failures |
+| `TestFabricSparkStoreTestFailuresAsProjectLevelEphemeral` | Ephemeral project-level |
+| `TestFabricSparkStoreTestFailuresAsProjectLevelOff` | Off project-level |
+| `TestFabricSparkStoreTestFailuresAsProjectLevelView` | View project-level |
+| `TestFabricSparkStoreTestFailuresLimit` | Store failures limit |
+
+**Shorthand:** `StoreTestFailures and FabricSpark`
+
+### Unit testing (`test_unit_testing.py`)
+| Class | Tests |
+|---|---|
+| `TestFabricSparkUnitTestingTypes` | Unit test data types |
+| `TestFabricSparkUnitTestCaseInsensivity` | Case insensitivity |
+| `TestFabricSparkUnitTestInvalidInput` | Invalid input |
+| `TestFabricSparkUnitTestQuotedReservedWordColumnNames` | Quoted reserved words |
+
+**Shorthand:** `UnitTest and FabricSpark`
+
+### Clone (`test_dbt_clone.py`)
+| Class | Tests |
+|---|---|
+| `TestFabricSparkCloneNotPossible` | Clone not possible |
+| `TestFabricSparkClonePossible` | Clone possible |
+| `TestFabricSparkCloneSameTargetAndState` | Clone same target+state |
+| `TestFabricSparkCloneSameSourceAndTarget` | Clone same source+target |
+
+**Shorthand:** `Clone and FabricSpark`
+
+### Ephemeral (`test_ephemeral.py`)
+| Class | Tests |
+|---|---|
+| `TestEphemeralFabricSpark` | Basic ephemeral |
+| `TestEphemeralNestedFabricSpark` | Nested ephemeral |
+| `TestEphemeralErrorHandlingFabricSpark` | Ephemeral error handling |
+
+**Shorthand:** `Ephemeral and FabricSpark`
+
+### Other test files
+| Class | Area | Shorthand |
+|---|---|---|
+| `TestCatalogRelationTypesFabricSpark` | Catalog relation types | `CatalogRelation and FabricSpark` |
+| `TestFabricSparkColumnTypes` | Column types | `ColumnTypes and FabricSpark` |
+| `TestConcurrencyFabricSpark` | Concurrency | `Concurrency and FabricSpark` |
+| `TestSampleModeTestFabricSpark` | Sample mode | `SampleMode and FabricSpark` |
+| `TestListRelationsWithoutCachingSchemaNotFound` | List relations | `ListRelationsWithoutCaching` |
+| `TestFabricSparkEmpty` | Empty model | `FabricSparkEmpty` |
+| `TestFabricSparkEmptyInlineSourceRef` | Empty inline source ref | `FabricSparkEmptyInline` |
+| `TestFabricSparkShowLimit` | dbt show limit | `ShowLimit and FabricSpark` |
+| `TestFabricSparkShowSqlHeader` | dbt show SQL header | `ShowSqlHeader and FabricSpark` |
+| `TestChangeRelationTypesFabricSpark` | Relation type changes | `ChangeRelationType and FabricSpark` |
+| `TestDropSchemaNamedFabricSpark` | Drop named schema | `DropSchemaNamed and FabricSpark` |
+| `TestCalculateFreshnessMethodFabricSpark` | Source freshness | `Freshness and FabricSpark` |
+| `TestValidateSqlMethodFabricSpark` | Validate SQL | `ValidateSql and FabricSpark` |
+
+### Grants (`test_grants.py`) — all skipped
+| Class | Tests |
+|---|---|
+| `TestModelGrantsFabricSpark` | Model grants (skipped) |
+| `TestSeedGrantsFabricSpark` | Seed grants (skipped) |
+| `TestSnapshotGrantsFabricSpark` | Snapshot grants (skipped) |
+| `TestIncrementalGrantsFabricSpark` | Incremental grants (skipped) |
+| `TestInvalidGrantsFabricSpark` | Invalid grants (skipped) |
+
+### Persist docs (`test_persist_docs.py`)
+| Class | Tests |
+|---|---|
+| `TestPersistDocsFabricSpark` | Basic persist docs |
+| `TestPersistDocsColumnMissingFabricSpark` | Missing column docs |
+| `TestPersistDocsCommentOnQuotedColumnFabricSpark` | Quoted column docs |
+
+**Shorthand:** `PersistDocs and FabricSpark`
+
+### Query comments (`test_query_comment.py`)
+| Class | Tests |
+|---|---|
+| `TestQueryCommentsFabricSpark` | Basic query comments |
+| `TestMacroQueryCommentsFabricSpark` | Macro query comments |
+| `TestMacroArgsQueryCommentsFabricSpark` | Macro args query comments |
+| `TestMacroInvalidQueryCommentsFabricSpark` | Invalid macro comments |
+| `TestNullQueryCommentsFabricSpark` | Null query comments |
+| `TestEmptyQueryCommentsFabricSpark` | Empty query comments |
+
+**Shorthand:** `QueryComment and FabricSpark`
+
+### Utility functions (`utils/`)
+All utility test classes follow the pattern `Test<Function>FabricSpark`:
+
+`TestAnyValueFabricSpark`, `TestArrayAppendFabricSpark`, `TestArrayConcatFabricSpark`, `TestArrayConstructFabricSpark`, `TestBoolOrFabricSpark`, `TestCastFabricSpark`, `TestCastBoolToTextFabricSpark`, `TestSafeCastFabricSpark`, `TestConcatFabricSpark`, `TestCurrentTimestampNaiveFabricSpark`, `TestDateFabricSpark`, `TestDateSpineFabricSpark`, `TestDateTruncFabricSpark`, `TestDateAddFabricSpark`, `TestDateDiffFabricSpark`, `TestEqualsFabricSpark`, `TestEscapeSingleQuotesQuoteFabricSpark`, `TestExceptFabricSpark`, `TestGenerateSeriesFabricSpark`, `TestGetIntervalsBetweenFabricSpark`, `TestGetPowersOfTwoFabricSpark`, `TestHashFabricSpark`, `TestIntersectFabricSpark`, `TestLastDayFabricSpark`, `TestLengthFabricSpark`, `TestListaggFabricSpark`, `TestMixedNullCompareFabricSpark`, `TestNullCompareFabricSpark`, `TestPositionFabricSpark`, `TestReplaceFabricSpark`, `TestRightFabricSpark`, `TestSplitPartFabricSpark`, `TestStringLiteralFabricSpark`, `TestCurrentTimestampsFabricSpark`, `TestTypeBigIntFabricSpark`, `TestTypeFloatFabricSpark`, `TestTypeIntFabricSpark`, `TestTypeNumericFabricSpark`, `TestTypeStringFabricSpark`, `TestTypeTimestampFabricSpark`, `TestTypeBooleanFabricSpark`
+
+**Shorthand for all utils:** running all of them is expensive — suggest specific function names like `DateAdd and FabricSpark` or `Hash and FabricSpark`.
+
+## Humans can also trigger tests directly
+
+Users can comment `/test-de <filter>` on a PR without using this agent. Examples:
+
+- `/test-de TestDebugFabricSpark` — run a single test class
+- `/test-de Seed and FabricSpark` — run all seed tests
+- `/test-de` — run all DE tests (slow, 30-60 min)

--- a/.github/agents/test-runner.agent.md
+++ b/.github/agents/test-runner.agent.md
@@ -149,7 +149,7 @@ pytest's `-k` flag matches test class and method names. Use `and`, `or`, `not`, 
 | `TestCachingSelectedSchemaOnlyFabricSpark` | Schema-scoped caching |
 | `TestNoPopulateCacheFabricSpark` | No-cache mode |
 
-**Shorthand:** `Cach and FabricSpark`
+**Shorthand:** `Caching and FabricSpark`
 
 ### Aliases (`test_aliases.py`)
 | Class | Tests |

--- a/.github/workflows/test-de-on-demand.yml
+++ b/.github/workflows/test-de-on-demand.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pull-requests: write
   id-token: write
 
@@ -31,7 +32,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'issue_comment'
        && github.event.issue.pull_request
-       && startsWith(github.event.comment.body, '/test-de')
+       && (github.event.comment.body == '/test-de' || startsWith(github.event.comment.body, '/test-de '))
        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     environment: azure
@@ -43,11 +44,13 @@ jobs:
       - name: Resolve PR metadata
         id: pr
         uses: actions/github-script@v7
+        env:
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
           script: |
             const prNumber = context.eventName === 'issue_comment'
               ? context.issue.number
-              : parseInt('${{ github.event.inputs.pr_number }}');
+              : parseInt(process.env.INPUT_PR_NUMBER);
 
             if (!prNumber) {
               core.setFailed('No PR number provided');
@@ -72,6 +75,8 @@ jobs:
       - name: Parse pytest filter
         id: filter
         uses: actions/github-script@v7
+        env:
+          INPUT_PYTEST_FILTER: ${{ github.event.inputs.pytest_filter }}
         with:
           script: |
             let rawFilter = '';
@@ -80,10 +85,10 @@ jobs:
               const match = body.match(/^\/test-de\s+(.*)/);
               rawFilter = match ? match[1].split('\n')[0].trim() : '';
             } else {
-              rawFilter = `${{ github.event.inputs.pytest_filter }}`;
+              rawFilter = process.env.INPUT_PYTEST_FILTER || '';
             }
 
-            const sanitized = rawFilter.replace(/[^a-zA-Z0-9 _\-()]/g, '');
+            const sanitized = rawFilter.replace(/[^a-zA-Z0-9 _()]/g, '');
             core.setOutput('expression', sanitized);
             core.setOutput('has_filter', sanitized.length > 0 ? 'true' : 'false');
             core.info(`Pytest filter: ${sanitized || '(none — running all DE tests)'}`);

--- a/.github/workflows/test-de-on-demand.yml
+++ b/.github/workflows/test-de-on-demand.yml
@@ -60,6 +60,11 @@ jobs:
               pull_number: prNumber,
             });
 
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed('Cannot run tests on PRs from forks');
+              return;
+            }
+
             core.setOutput('number', prNumber);
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('head_sha', pr.head.sha);
@@ -105,6 +110,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test-de-on-demand.yml
+++ b/.github/workflows/test-de-on-demand.yml
@@ -1,0 +1,167 @@
+---
+name: "DE integration tests (on-demand)"
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pytest_filter:
+        description: "Pytest -k filter expression (leave empty to run all DE tests)"
+        required: false
+        type: string
+        default: ""
+      pr_number:
+        description: "PR number to test"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: de-on-demand-${{ github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  run-de-tests:
+    name: DE tests
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'issue_comment'
+       && github.event.issue.pull_request
+       && startsWith(github.event.comment.body, '/test-de')
+       && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    runs-on: ubuntu-latest
+    environment: azure
+    container:
+      image: ghcr.io/${{ github.repository }}:CI-3.13-mssql-python
+    timeout-minutes: 60
+
+    steps:
+      - name: Resolve PR metadata
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.eventName === 'issue_comment'
+              ? context.issue.number
+              : parseInt('${{ github.event.inputs.pr_number }}');
+
+            if (!prNumber) {
+              core.setFailed('No PR number provided');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            core.setOutput('number', prNumber);
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Parse pytest filter
+        id: filter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let rawFilter = '';
+            if (context.eventName === 'issue_comment') {
+              const body = context.payload.comment.body;
+              const match = body.match(/^\/test-de\s+(.*)/);
+              rawFilter = match ? match[1].split('\n')[0].trim() : '';
+            } else {
+              rawFilter = `${{ github.event.inputs.pytest_filter }}`;
+            }
+
+            const sanitized = rawFilter.replace(/[^a-zA-Z0-9 _\-()]/g, '');
+            core.setOutput('expression', sanitized);
+            core.setOutput('has_filter', sanitized.length > 0 ? 'true' : 'false');
+            core.info(`Pytest filter: ${sanitized || '(none — running all DE tests)'}`);
+
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Run DE integration tests
+        id: tests
+        env:
+          FABRIC_TEST_WORKSPACE_NAME: adapter-ci
+          FABRIC_TEST_LAKEHOUSE_NAME: cilh
+          FABRIC_TEST_THREADS: 2
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
+          PYTEST_FILTER: ${{ steps.filter.outputs.expression }}
+        run: |
+          if [ -n "$PYTEST_FILTER" ]; then
+            uv run pytest -ra -v --de -k "$PYTEST_FILTER"
+          else
+            uv run pytest -ra -v --de
+          fi
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-de-on-demand-${{ steps.pr.outputs.number }}
+          path: logs/
+
+      - name: Report results
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          FILTER_EXPR: ${{ steps.filter.outputs.expression }}
+          TEST_OUTCOME: ${{ steps.tests.outcome }}
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const success = process.env.TEST_OUTCOME === 'success';
+            const filter = process.env.FILTER_EXPR || '(all DE tests)';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            const emoji = success ? ':white_check_mark:' : ':x:';
+            const status = success ? 'passed' : 'failed';
+
+            const body = [
+              `${emoji} **DE integration tests ${status}**`,
+              ``,
+              `**Filter:** \`${filter}\``,
+              `**Run:** ${runUrl}`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ GitHub Actions workflows in `.github/workflows/`:
 |---|---|---|
 | `lint-format.yml` | PR, push | `ruff format --check` + `ruff check` |
 | `integration-tests.yml` | PR, push, weekly (Sun 01:00 UTC) | DW: Python 3.11/3.12/3.13 on every trigger. DE: Python 3.13 only on schedule + manual dispatch |
+| `test-de-on-demand.yml` | PR comment (`/test-de`), workflow_dispatch | On-demand DE tests on a PR branch. Comment `/test-de <filter>` or use `gh workflow run` with `pytest_filter` + `pr_number` inputs |
 | `publish-docker.yml` | Manual | Build CI Docker image (`.github/CI.Dockerfile`) → ghcr.io |
 | `release-version.yml` | Tag `v*` | Update version, build, publish to PyPI |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,11 +191,34 @@ GitHub Actions workflows in `.github/workflows/`:
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `lint-format.yml` | PR, push | `ruff format --check` + `ruff check` |
-| `integration-tests.yml` | PR, push, weekly | Matrix: Python 3.11/3.12/3.13 x {DW, DE} |
+| `integration-tests.yml` | PR, push, weekly | DW: Python 3.11/3.12/3.13 on every trigger. DE: Python 3.13 on schedule + manual dispatch only |
+| `test-de-on-demand.yml` | PR comment, manual | On-demand DE tests — see below |
 | `publish-docker.yml` | Manual | Build CI Docker image (`.github/CI.Dockerfile`) → ghcr.io |
 | `release-version.yml` | Tag `v*` | Update version, build, publish to PyPI |
 
 CI authenticates to Azure via OIDC (federated credentials, no secrets stored). Tests run inside Docker containers with pre-installed `mssql-python` dependencies.
+
+### On-demand DE tests
+
+FabricSpark (DE) tests use Livy sessions and are too slow/expensive to run on every PR. Instead, they run weekly and can be triggered on-demand for specific PRs.
+
+**From a PR comment:**
+
+```
+/test-de TestDebugFabricSpark           # Run a single test class
+/test-de Seed and FabricSpark           # Run all seed tests
+/test-de                                # Run all DE tests (slow, 30-60 min)
+```
+
+The workflow checks out the PR branch, runs the matching tests, and comments back with results. Only repository members and collaborators can trigger tests.
+
+**From the CLI:**
+
+```shell
+gh workflow run test-de-on-demand.yml -f pytest_filter="TestDebugFabricSpark" -f pr_number="94"
+```
+
+**Via Copilot:** mention `@test-runner` in a PR comment with a natural language description of which tests to run. The agent translates it to the right pytest filter and triggers the workflow.
 
 ## Releasing
 


### PR DESCRIPTION
## Summary
- New workflow **test-de-on-demand.yml**: triggers FabricSpark (DE) integration tests from PR comments or workflow_dispatch
- New Copilot agent **test-runner**: translates natural language test requests to pytest `-k` filters

## How it works

### For humans: `/test-de` comment command
Comment on any PR:
```
/test-de TestDebugFabricSpark
/test-de Seed and FabricSpark
/test-de
```
The workflow checks out the PR branch, runs the matching DE tests, and comments back with results.

### For Copilot: `@test-runner` agent
Mention `@test-runner run the incremental tests` in a PR. The agent maps natural language to the right pytest filter and triggers the workflow.

### Manual: workflow_dispatch
```bash
gh workflow run test-de-on-demand.yml -f pytest_filter="TestDebugFabricSpark" -f pr_number="94"
```

## Security
- Only OWNER, MEMBER, and COLLABORATOR can trigger via comments
- Filter is sanitized (alphanumeric + spaces/underscores/parens only) and passed via env var, never `${{ }}` interpolation
- PR head SHA pinned at trigger time (TOCTOU-safe)
- Concurrency: one run per PR, re-trigger cancels previous

## Test plan
- [ ] Verify workflow appears in Actions tab
- [ ] Test `/test-de TestDebugFabricSpark` comment on this PR after merge
- [ ] Test `gh workflow run` with filter and pr_number inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)