### PR TITLE
Split DW and DE workflows into separate files

### DIFF
--- a/.github/agents/test-runner.agent.md
+++ b/.github/agents/test-runner.agent.md
@@ -16,7 +16,7 @@ You help developers run FabricSpark (DE) integration tests on pull requests. Whe
 Use `gh workflow run` with the PR number and filter:
 
 ```shell
-gh workflow run test-de-on-demand.yml -f pytest_filter="<FILTER>" -f pr_number="<PR_NUMBER>"
+gh workflow run integration-tests-de.yml -f pytest_filter="<FILTER>" -f pr_number="<PR_NUMBER>"
 ```
 
 Get the PR number from the current context (the PR you're working on, or ask the user).

--- a/.github/workflows/integration-tests-de.yml
+++ b/.github/workflows/integration-tests-de.yml
@@ -1,6 +1,8 @@
 ---
-name: "DE integration tests (on-demand)"
+name: "DE integration tests"
 on:
+  schedule:
+    - cron: '0 1 * * 0'
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -11,9 +13,10 @@ on:
         type: string
         default: ""
       pr_number:
-        description: "PR number to test"
-        required: true
+        description: "PR number to test (leave empty for current branch)"
+        required: false
         type: string
+        default: ""
 
 permissions:
   contents: read
@@ -22,14 +25,55 @@ permissions:
   id-token: write
 
 concurrency:
-  group: de-on-demand-${{ github.event.issue.number || github.event.inputs.pr_number }}
+  group: de-${{ github.event.issue.number || github.event.inputs.pr_number || 'main' }}
   cancel-in-progress: true
 
 jobs:
-  run-de-tests:
-    name: DE tests
+  scheduled-de-tests:
+    name: DE tests (scheduled)
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    environment: azure
+    container:
+      image: ghcr.io/${{ github.repository }}:CI-3.13-mssql-python
+    timeout-minutes: 60
+    steps:
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Run DE integration tests
+        env:
+          FABRIC_TEST_WORKSPACE_NAME: adapter-ci
+          FABRIC_TEST_LAKEHOUSE_NAME: cilh
+          FABRIC_TEST_THREADS: 2
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
+        run: uv run pytest -ra -v --de
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-de-scheduled
+          path: logs/
+
+  on-demand-de-tests:
+    name: DE tests (on-demand)
     if: >-
-      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '') ||
       (github.event_name == 'issue_comment'
        && github.event.issue.pull_request
        && (github.event.comment.body == '/test-de' || startsWith(github.event.comment.body, '/test-de '))
@@ -176,3 +220,50 @@ jobs:
               issue_number: prNumber,
               body,
             });
+
+  dispatch-de-tests:
+    name: DE tests (dispatch, no PR)
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number == ''
+    runs-on: ubuntu-latest
+    environment: azure
+    container:
+      image: ghcr.io/${{ github.repository }}:CI-3.13-mssql-python
+    timeout-minutes: 60
+    steps:
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Run DE integration tests
+        env:
+          FABRIC_TEST_WORKSPACE_NAME: adapter-ci
+          FABRIC_TEST_LAKEHOUSE_NAME: cilh
+          FABRIC_TEST_THREADS: 2
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
+          PYTEST_FILTER: ${{ github.event.inputs.pytest_filter }}
+        run: |
+          if [ -n "$PYTEST_FILTER" ]; then
+            uv run pytest -ra -v --de -k "$PYTEST_FILTER"
+          else
+            uv run pytest -ra -v --de
+          fi
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-de-dispatch
+          path: logs/

--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -1,9 +1,7 @@
 ---
-name: Integration tests on Fabric
+name: "DW integration tests"
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 1 * * 0'
   pull_request:
     branches:
       - main
@@ -14,7 +12,7 @@ on:
       - 'tests/conftest.py'
       - 'pyproject.toml'
       - 'uv.lock'
-      - '.github/workflows/integration-tests.yml'
+      - '.github/workflows/integration-tests-dw.yml'
   push:
     branches:
       - main
@@ -25,7 +23,7 @@ on:
       - 'tests/conftest.py'
       - 'pyproject.toml'
       - 'uv.lock'
-      - '.github/workflows/integration-tests.yml'
+      - '.github/workflows/integration-tests-dw.yml'
 
 permissions:
   contents: read
@@ -38,7 +36,7 @@ concurrency:
 
 jobs:
   integration-tests-fabric-dw:
-    name: Integration tests on Fabric DW
+    name: DW tests (Python ${{ matrix.python_version }})
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +50,7 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: azure
-    container: 
+    container:
       image: ghcr.io/${{ github.repository }}:CI-${{ matrix.python_version }}-mssql-python
     steps:
       - name: Azure CLI Login
@@ -61,7 +59,7 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
-      
+
       - uses: actions/checkout@v6
 
       - name: Install uv
@@ -72,56 +70,16 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --all-groups
 
-      - name: Run integration tests
+      - name: Run DW integration tests
         env:
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ${{ matrix.dwh_name }}
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
         run: uv run pytest -ra -v --dw
-      
-      - name: Upload test logs
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: logs-${{ matrix.python_version }}-${{ matrix.dwh_name }}
-          path: logs/
-
-  integration-tests-fabric-de:
-    name: Integration tests on Fabric DE
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment: azure
-    container:
-      image: ghcr.io/${{ github.repository }}:CI-3.13-mssql-python
-    steps:
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - uses: actions/checkout@v6
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: uv sync --all-extras --all-groups
-
-      - name: Run integration tests
-        env:
-          FABRIC_TEST_WORKSPACE_NAME: adapter-ci
-          FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_THREADS: 2
-          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
-        run: uv run pytest -ra -v --de
 
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: logs-fs
+          name: logs-dw-${{ matrix.python_version }}-${{ matrix.dwh_name }}
           path: logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,8 +313,8 @@ GitHub Actions workflows in `.github/workflows/`:
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `lint-format.yml` | PR, push | `ruff format --check` + `ruff check` |
-| `integration-tests.yml` | PR, push, weekly (Sun 01:00 UTC) | DW: Python 3.11/3.12/3.13 on every trigger. DE: Python 3.13 only on schedule + manual dispatch |
-| `test-de-on-demand.yml` | PR comment (`/test-de`), workflow_dispatch | On-demand DE tests on a PR branch. Comment `/test-de <filter>` or use `gh workflow run` with `pytest_filter` + `pr_number` inputs |
+| `integration-tests-dw.yml` | PR, push, manual | DW tests: Python 3.11/3.12/3.13 matrix |
+| `integration-tests-de.yml` | Weekly (Sun 01:00 UTC), PR comment (`/test-de`), manual | DE tests: weekly full run on main + on-demand per PR via `/test-de <filter>` or `gh workflow run` |
 | `publish-docker.yml` | Manual | Build CI Docker image (`.github/CI.Dockerfile`) → ghcr.io |
 | `release-version.yml` | Tag `v*` | Update version, build, publish to PyPI |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,8 +191,8 @@ GitHub Actions workflows in `.github/workflows/`:
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `lint-format.yml` | PR, push | `ruff format --check` + `ruff check` |
-| `integration-tests.yml` | PR, push, weekly | DW: Python 3.11/3.12/3.13 on every trigger. DE: Python 3.13 on schedule + manual dispatch only |
-| `test-de-on-demand.yml` | PR comment, manual | On-demand DE tests — see below |
+| `integration-tests-dw.yml` | PR, push, manual | DW tests: Python 3.11/3.12/3.13 matrix |
+| `integration-tests-de.yml` | Weekly, PR comment, manual | DE tests: weekly on main, on-demand per PR — see below |
 | `publish-docker.yml` | Manual | Build CI Docker image (`.github/CI.Dockerfile`) → ghcr.io |
 | `release-version.yml` | Tag `v*` | Update version, build, publish to PyPI |
 
@@ -215,7 +215,7 @@ The workflow checks out the PR branch, runs the matching tests, and comments bac
 **From the CLI:**
 
 ```shell
-gh workflow run test-de-on-demand.yml -f pytest_filter="TestDebugFabricSpark" -f pr_number="94"
+gh workflow run integration-tests-de.yml -f pytest_filter="TestDebugFabricSpark" -f pr_number="94"
 ```
 
 **Via Copilot:** mention `@test-runner` in a PR comment with a natural language description of which tests to run. The agent translates it to the right pytest filter and triggers the workflow.


### PR DESCRIPTION
## Summary

- Renames `integration-tests.yml` → `integration-tests-dw.yml` (DW tests only: PR, push, manual dispatch)
- Renames `test-de-on-demand.yml` → `integration-tests-de.yml` (all DE tests: weekly schedule, on-demand via PR comments, manual dispatch)
- The DE workflow now has 3 jobs:
  - **scheduled**: weekly Sunday 01:00 UTC run of all DE tests on main
  - **on-demand**: triggered via `/test-de` PR comments or `workflow_dispatch` with a `pr_number`
  - **dispatch without PR**: manual `workflow_dispatch` without a PR number (runs on current branch)
- Updates all references in CLAUDE.md, CONTRIBUTING.md, and the Copilot agent file

## Test plan

- [ ] Verify lint workflow still runs on PR
- [ ] Verify DW tests trigger correctly (check workflow tab after merge)
- [ ] Comment `/test-de TestDebugFabricSpark` on a PR to verify on-demand still works
- [ ] Wait for Sunday to verify scheduled DE run, or trigger manually via dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)