### PR TITLE
Run DW tests on Python 3.13 only by default

### DIFF
--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -1,6 +1,8 @@
 ---
 name: "DW integration tests"
 on:
+  schedule:
+    - cron: "0 2 * * 0"
   workflow_dispatch:
   pull_request:
     branches:
@@ -35,18 +37,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-matrix:
+    name: Resolve Python matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo 'matrix=[{"python_version":"3.11","dwh_name":"ci02"},{"python_version":"3.12","dwh_name":"ci03"},{"python_version":"3.13","dwh_name":"ci04"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix=[{"python_version":"3.13","dwh_name":"ci04"}]' >> "$GITHUB_OUTPUT"
+          fi
+
   integration-tests-fabric-dw:
     name: DW tests (Python ${{ matrix.python_version }})
+    needs: resolve-matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - python_version: "3.11"
-            dwh_name: "ci02"
-          - python_version: "3.12"
-            dwh_name: "ci03"
-          - python_version: "3.13"
-            dwh_name: "ci04"
+        include: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
 
     runs-on: ubuntu-latest
     environment: azure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ GitHub Actions workflows in `.github/workflows/`:
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `lint-format.yml` | PR, push | `ruff format --check` + `ruff check` |
-| `integration-tests-dw.yml` | PR, push, manual | DW tests: Python 3.11/3.12/3.13 matrix |
+| `integration-tests-dw.yml` | PR, push, manual, weekly (Sun 02:00 UTC) | DW tests: Python 3.13 only on PR/push/manual, full matrix (3.11/3.12/3.13) on weekly schedule |
 | `integration-tests-de.yml` | Weekly (Sun 01:00 UTC), PR comment (`/test-de`), manual | DE tests: weekly full run on main + on-demand per PR via `/test-de <filter>` or `gh workflow run` |
 | `publish-docker.yml` | Manual | Build CI Docker image (`.github/CI.Dockerfile`) → ghcr.io |
 | `release-version.yml` | Tag `v*` | Update version, build, publish to PyPI |


### PR DESCRIPTION
## Summary
- DW integration tests now run only Python 3.13 on PR, push, and manual triggers
- The full matrix (3.11/3.12/3.13) runs on the weekly Sunday schedule (02:00 UTC)
- Reduces CI cost and wait time for everyday development

## Test plan
- [ ] Verify the `resolve-matrix` job outputs the correct single-version matrix on a PR trigger
- [ ] Verify the weekly schedule still runs all three Python versions (check next Sunday run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)