### PR TITLE
Add Livy session lifecycle management for CI runs

### DIFF
--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -86,6 +86,7 @@ jobs:
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ${{ matrix.dwh_name }}
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
         run: >-
           uv run pytest -ra -v --dw
           ${{ github.event_name == 'schedule' && '--with-python' || '' }}

--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -86,7 +86,7 @@ jobs:
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ${{ matrix.dwh_name }}
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.event_name == 'schedule' && github.run_id || '' }}
         run: >-
           uv run pytest -ra -v --dw
           ${{ github.event_name == 'schedule' && '--with-python' || '' }}

--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -4,6 +4,17 @@ on:
   schedule:
     - cron: "0 2 * * 0"
   workflow_dispatch:
+    inputs:
+      pytest_filter:
+        description: "Pytest -k filter expression (leave empty to run all DW tests)"
+        required: false
+        type: string
+        default: ""
+      with_python:
+        description: "Include Python model tests (requires Livy session)"
+        required: false
+        type: boolean
+        default: false
   pull_request:
     branches:
       - main
@@ -86,10 +97,17 @@ jobs:
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ${{ matrix.dwh_name }}
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.event_name == 'schedule' && github.run_id || '' }}
-        run: >-
-          uv run pytest -ra -v --dw
-          ${{ github.event_name == 'schedule' && '--with-python' || '' }}
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ (github.event_name == 'schedule' || inputs.with_python) && github.run_id || '' }}
+          PYTEST_FILTER: ${{ inputs.pytest_filter || '' }}
+        run: |
+          ARGS="-ra -v --dw"
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.with_python }}" == "true" ]]; then
+            ARGS="$ARGS --with-python"
+          fi
+          if [ -n "$PYTEST_FILTER" ]; then
+            ARGS="$ARGS -k $PYTEST_FILTER"
+          fi
+          uv run pytest $ARGS
 
       - name: Upload test logs
         if: always()

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -504,6 +504,15 @@ class FabricApiClient:
         response = self._api_post(url, {"code": code, "kind": "sql"})
         return response.json()["id"]
 
+    def delete_livy_session(self) -> None:
+        """Delete the current Livy session and clear the cached session ID."""
+        if self._livy_session_id is None:
+            return
+        session_id = self._livy_session_id
+        self._livy_session_id = None
+        url = self.get_livy_base_api_uri() + f"/sessions/{session_id}"
+        self._api_delete(url)
+
     def cancel_livy_statement(self, statement_id: int) -> str:
         """Cancel a running Livy statement.
 

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -509,9 +509,13 @@ class FabricApiClient:
         if self._livy_session_id is None:
             return
         session_id = self._livy_session_id
-        self._livy_session_id = None
         url = self.get_livy_base_api_uri() + f"/sessions/{session_id}"
-        self._api_delete(url)
+        try:
+            self._api_delete(url)
+        except FabricApiError as e:
+            if e.status_code != 404:
+                raise
+        self._livy_session_id = None
 
     def cancel_livy_statement(self, statement_id: int) -> str:
         """Cancel a running Livy statement.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,19 +120,12 @@ def livy_session_lifecycle(request):
     workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
     workspace_id = os.getenv("FABRIC_TEST_WORKSPACE_ID")
 
-    if (
-        not session_name
-        or not lakehouse_name
-        or not (workspace_name or workspace_id)
-        or request.config.getoption("--dw")
-    ):
+    if not session_name or not lakehouse_name or not (workspace_name or workspace_id):
         yield
         return
 
+    from dbt.adapters.fabric.base_connection_manager import BaseFabricConnectionManager
     from dbt.adapters.fabric.fabric_livy_session import LivySession
-    from dbt.adapters.fabricspark.fabricspark_connection_manager import (
-        FabricSparkConnectionManager,
-    )
     from dbt.adapters.fabricspark.fabricspark_credentials import FabricSparkCredentials
 
     creds = FabricSparkCredentials(
@@ -148,8 +141,8 @@ def livy_session_lifecycle(request):
     client.get_livy_session_id()
     LivySession(client).wait_for_session_ready()
 
-    FabricSparkConnectionManager._fabric_api_client = client
-    FabricSparkConnectionManager._fabric_token_provider = token_provider
+    BaseFabricConnectionManager._fabric_api_client = client
+    BaseFabricConnectionManager._fabric_token_provider = token_provider
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,6 +113,45 @@ def pytest_collection_modifyitems(config, items):
             )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def livy_session_lifecycle(request):
+    session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
+    lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
+
+    if not session_name or not lakehouse_name or request.config.getoption("--dw"):
+        yield
+        return
+
+    from dbt.adapters.fabric.fabric_livy_session import LivySession
+    from dbt.adapters.fabricspark.fabricspark_connection_manager import (
+        FabricSparkConnectionManager,
+    )
+    from dbt.adapters.fabricspark.fabricspark_credentials import FabricSparkCredentials
+
+    creds = FabricSparkCredentials(
+        database=lakehouse_name,
+        schema="dbo",
+        workspace_name=os.getenv("FABRIC_TEST_WORKSPACE_NAME"),
+        workspace_id=os.getenv("FABRIC_TEST_WORKSPACE_ID"),
+        livy_session_name=session_name,
+    )
+    token_provider = FabricTokenProvider(creds)
+    client = FabricApiClient(creds, token_provider)
+
+    client.get_livy_session_id()
+    LivySession(client).wait_for_session_ready()
+
+    FabricSparkConnectionManager._fabric_api_client = client
+    FabricSparkConnectionManager._fabric_token_provider = token_provider
+
+    yield
+
+    try:
+        client.delete_livy_session()
+    except Exception:
+        pass
+
+
 @pytest.fixture(scope="class")
 def logs_dir(request, prefix):
     dbt_log_dir = os.path.join(request.config.rootdir, "logs", prefix)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def livy_session_lifecycle(request):
+def livy_session_lifecycle():
     session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
     lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
     workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,8 +117,15 @@ def pytest_collection_modifyitems(config, items):
 def livy_session_lifecycle(request):
     session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
     lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
+    workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
+    workspace_id = os.getenv("FABRIC_TEST_WORKSPACE_ID")
 
-    if not session_name or not lakehouse_name or request.config.getoption("--dw"):
+    if (
+        not session_name
+        or not lakehouse_name
+        or not (workspace_name or workspace_id)
+        or request.config.getoption("--dw")
+    ):
         yield
         return
 
@@ -131,8 +138,8 @@ def livy_session_lifecycle(request):
     creds = FabricSparkCredentials(
         database=lakehouse_name,
         schema="dbo",
-        workspace_name=os.getenv("FABRIC_TEST_WORKSPACE_NAME"),
-        workspace_id=os.getenv("FABRIC_TEST_WORKSPACE_ID"),
+        workspace_name=workspace_name,
+        workspace_id=workspace_id,
         livy_session_name=session_name,
     )
     token_provider = FabricTokenProvider(creds)
@@ -148,8 +155,8 @@ def livy_session_lifecycle(request):
 
     try:
         client.delete_livy_session()
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"\nWarning: failed to delete Livy session: {e}")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary
- Adds `delete_livy_session()` to `FabricApiClient` for explicit session cleanup
- Adds a session-scoped pytest fixture (`livy_session_lifecycle`) that eagerly creates a Livy session at the start of the test run and deletes it on teardown
- The fixture activates when `FABRIC_TEST_LIVY_SESSION_NAME` and `FABRIC_TEST_LAKEHOUSE_NAME` env vars are set (CI), and skips when `--dw` is passed
- Pre-populates `FabricSparkConnectionManager` singletons so all test classes reuse the same session and client

This reduces pressure on the 3-session concurrency limit by ensuring one session per CI run instead of one per test class, and frees the slot immediately after tests finish rather than waiting for the 30s TTL to expire.

## Test plan
- [x] Run DE integration tests via `/test-de` to verify session is created once and reused
- [ ] Run DW tests with `--dw` to verify the fixture is a no-op
- [x] Verify session is deleted after test run completes (check Fabric portal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)