### PR TITLE
Use FabricCredentials instead of FabricSparkCredentials in Livy session fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,11 +138,11 @@ def livy_session_lifecycle():
 
     from dbt.adapters.fabric.base_connection_manager import BaseFabricConnectionManager
     from dbt.adapters.fabric.fabric_livy_session import LivySession
-    from dbt.adapters.fabricspark.fabricspark_credentials import FabricSparkCredentials
 
-    creds = FabricSparkCredentials(
+    creds = FabricCredentials(
         database=lakehouse_name,
         schema="dbo",
+        lakehouse=lakehouse_name,
         workspace_name=workspace_name,
         workspace_id=workspace_id,
         livy_session_name=session_name,


### PR DESCRIPTION
## Summary

- The `livy_session_lifecycle` fixture used `FabricSparkCredentials` to set up the shared Livy session, requiring the `[spark]` extra even for DW-only or unit test runs
- Replaced with `FabricCredentials` (always available), which has the same base fields needed by `FabricApiClient` and `LivySession`
- Sets `lakehouse=lakehouse_name` so `FabricCredentials.lakehouse_name` resolves correctly

## Test plan

- [x] All 152 unit tests pass without `[spark]` extra installed
- [x] Ruff format and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)