### PR TITLE
Fix test collection failure when spark extra is not installed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,15 @@ def _requires_spark(collection_path, tests_root):
     return False
 
 
+def _spark_extra_available():
+    try:
+        import dbt.adapters.spark  # noqa: F401
+
+        return True
+    except ModuleNotFoundError:
+        return False
+
+
 def pytest_ignore_collect(collection_path, config):
     tests_root = Path(__file__).parent
     try:
@@ -120,11 +129,14 @@ def pytest_ignore_collect(collection_path, config):
     if config.getoption("--de", default=False) and top_dir == "fabric":
         return True
 
-    if _requires_spark(collection_path, tests_root):
-        try:
-            import dbt.adapters.spark  # noqa: F401
-        except ImportError:
-            return True
+    if _requires_spark(collection_path, tests_root) and not _spark_extra_available():
+        if config.getoption("--de", default=False):
+            pytest.exit(
+                "The spark extra is required for FabricSpark tests. "
+                "Install with: uv sync --extra spark",
+                returncode=4,
+            )
+        return True
 
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import functools
 import os
 from pathlib import Path
 
@@ -101,6 +102,7 @@ def _requires_spark(collection_path, tests_root):
     return False
 
 
+@functools.lru_cache(maxsize=1)
 def _spark_extra_available():
     try:
         import dbt.adapters.spark  # noqa: F401
@@ -124,7 +126,7 @@ def pytest_ignore_collect(collection_path, config):
     top_dir = parts[0]
 
     if config.getoption("--dw", default=False):
-        if top_dir == "fabricspark" or "fabricspark" in collection_path.name:
+        if _requires_spark(collection_path, tests_root):
             return True
     if config.getoption("--de", default=False) and top_dir == "fabric":
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,33 @@ def pytest_configure(config):
     )
 
 
+def pytest_ignore_collect(collection_path, config):
+    tests_root = Path(__file__).parent
+    try:
+        rel = collection_path.relative_to(tests_root)
+    except ValueError:
+        return None
+
+    parts = rel.parts
+    if not parts:
+        return None
+
+    top_dir = parts[0]
+
+    if config.getoption("--dw", default=False) and top_dir == "fabricspark":
+        return True
+    if config.getoption("--de", default=False) and top_dir == "fabric":
+        return True
+
+    if top_dir == "fabricspark":
+        try:
+            import dbt.adapters.spark  # noqa: F401
+        except ImportError:
+            return True
+
+    return None
+
+
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--de") and config.getoption("--dw"):
         raise ValueError("Cannot specify both --de and --dw options")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,18 @@ def pytest_configure(config):
     )
 
 
+def _requires_spark(collection_path, tests_root):
+    rel = collection_path.relative_to(tests_root)
+    parts = rel.parts
+    if not parts:
+        return False
+    if parts[0] == "fabricspark":
+        return True
+    if "fabricspark" in collection_path.name:
+        return True
+    return False
+
+
 def pytest_ignore_collect(collection_path, config):
     tests_root = Path(__file__).parent
     try:
@@ -102,12 +114,13 @@ def pytest_ignore_collect(collection_path, config):
 
     top_dir = parts[0]
 
-    if config.getoption("--dw", default=False) and top_dir == "fabricspark":
-        return True
+    if config.getoption("--dw", default=False):
+        if top_dir == "fabricspark" or "fabricspark" in collection_path.name:
+            return True
     if config.getoption("--de", default=False) and top_dir == "fabric":
         return True
 
-    if top_dir == "fabricspark":
+    if _requires_spark(collection_path, tests_root):
         try:
             import dbt.adapters.spark  # noqa: F401
         except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import functools
+import importlib.util
 import os
 from pathlib import Path
 
@@ -104,12 +105,7 @@ def _requires_spark(collection_path, tests_root):
 
 @functools.lru_cache(maxsize=1)
 def _spark_extra_available():
-    try:
-        import dbt.adapters.spark  # noqa: F401
-
-        return True
-    except ModuleNotFoundError:
-        return False
+    return importlib.util.find_spec("dbt.adapters.spark") is not None
 
 
 def pytest_ignore_collect(collection_path, config):


### PR DESCRIPTION
## Summary

- Add `pytest_ignore_collect` hook to `tests/conftest.py` that prevents `tests/fabricspark/` from being imported during collection when `--dw` is passed or when `dbt-spark` is not installed
- Similarly skips `tests/fabric/` when `--de` is passed
- Also skips unit test files with "fabricspark" in the name when spark is unavailable

## Test plan

- [x] Run `uv run pytest --dw --collect-only` without spark extra installed — should collect only fabric tests without import errors
- [x] Run `uv run pytest --de --collect-only` — should collect only fabricspark tests
- [x] Run `uv run pytest --collect-only` with spark installed — should collect both

🤖 Generated with [Claude Code](https://claude.com/claude-code)