### PR TITLE
Fix singleton pollution causing TestWarehouseSnapshots to fail

### DIFF
--- a/src/dbt/adapters/fabric/base_connection_manager.py
+++ b/src/dbt/adapters/fabric/base_connection_manager.py
@@ -33,29 +33,12 @@ class BaseFabricConnectionManager(SQLConnectionManager, metaclass=abc.ABCMeta):
         return cls._fabric_token_provider
 
     @classmethod
-    def _credentials_match(cls, a: BaseFabricCredentials, b: BaseFabricCredentials) -> bool:
-        return (a.database, a.workspace_id, a.workspace_name) == (
-            b.database,
-            b.workspace_id,
-            b.workspace_name,
-        )
-
-    @classmethod
     def get_fabric_api_client(cls, credentials: BaseFabricCredentials) -> FabricApiClient:
         """Return a shared FabricApiClient, creating one on first call.
-
-        Recreates the client (and token provider) when the cached instance
-        targets a different database or workspace than the passed credentials.
 
         Args:
             credentials: Fabric connection credentials used to configure the client.
         """
-        if cls._fabric_api_client is not None and not cls._credentials_match(
-            cls._fabric_api_client._credentials, credentials
-        ):
-            cls._fabric_api_client = None
-            cls._fabric_token_provider = None
-
         if cls._fabric_api_client is None:
             cls._fabric_api_client = FabricApiClient(
                 credentials, cls.get_fabric_token_provider(credentials)

--- a/src/dbt/adapters/fabric/base_connection_manager.py
+++ b/src/dbt/adapters/fabric/base_connection_manager.py
@@ -33,20 +33,28 @@ class BaseFabricConnectionManager(SQLConnectionManager, metaclass=abc.ABCMeta):
         return cls._fabric_token_provider
 
     @classmethod
+    def _credentials_match(cls, a: BaseFabricCredentials, b: BaseFabricCredentials) -> bool:
+        return (a.database, a.workspace_id, a.workspace_name) == (
+            b.database,
+            b.workspace_id,
+            b.workspace_name,
+        )
+
+    @classmethod
     def get_fabric_api_client(cls, credentials: BaseFabricCredentials) -> FabricApiClient:
         """Return a shared FabricApiClient, creating one on first call.
 
-        Recreates the client if the cached instance targets a different database
-        than the passed credentials (prevents cross-adapter singleton pollution).
+        Recreates the client (and token provider) when the cached instance
+        targets a different database or workspace than the passed credentials.
 
         Args:
             credentials: Fabric connection credentials used to configure the client.
         """
-        if (
-            cls._fabric_api_client is not None
-            and cls._fabric_api_client._credentials.database != credentials.database
+        if cls._fabric_api_client is not None and not cls._credentials_match(
+            cls._fabric_api_client._credentials, credentials
         ):
             cls._fabric_api_client = None
+            cls._fabric_token_provider = None
 
         if cls._fabric_api_client is None:
             cls._fabric_api_client = FabricApiClient(

--- a/src/dbt/adapters/fabric/base_connection_manager.py
+++ b/src/dbt/adapters/fabric/base_connection_manager.py
@@ -36,9 +36,18 @@ class BaseFabricConnectionManager(SQLConnectionManager, metaclass=abc.ABCMeta):
     def get_fabric_api_client(cls, credentials: BaseFabricCredentials) -> FabricApiClient:
         """Return a shared FabricApiClient, creating one on first call.
 
+        Recreates the client if the cached instance targets a different database
+        than the passed credentials (prevents cross-adapter singleton pollution).
+
         Args:
             credentials: Fabric connection credentials used to configure the client.
         """
+        if (
+            cls._fabric_api_client is not None
+            and cls._fabric_api_client._credentials.database != credentials.database
+        ):
+            cls._fabric_api_client = None
+
         if cls._fabric_api_client is None:
             cls._fabric_api_client = FabricApiClient(
                 credentials, cls.get_fabric_token_provider(credentials)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,7 +153,10 @@ def livy_session_lifecycle():
     client.get_livy_session_id()
     LivySession(client).wait_for_session_ready()
 
-    BaseFabricConnectionManager._fabric_api_client = client
+    # Only cache the token provider (credential-agnostic). Don't cache the API
+    # client: it was created with lakehouse credentials and would pollute the
+    # singleton for DW tests. Each adapter creates its own client with the
+    # correct credentials and finds the pre-warmed Livy session by name.
     BaseFabricConnectionManager._fabric_token_provider = token_provider
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,7 +136,6 @@ def livy_session_lifecycle():
         yield
         return
 
-    from dbt.adapters.fabric.base_connection_manager import BaseFabricConnectionManager
     from dbt.adapters.fabric.fabric_livy_session import LivySession
 
     creds = FabricCredentials(
@@ -152,12 +151,6 @@ def livy_session_lifecycle():
 
     client.get_livy_session_id()
     LivySession(client).wait_for_session_ready()
-
-    # Only cache the token provider (credential-agnostic). Don't cache the API
-    # client: it was created with lakehouse credentials and would pollute the
-    # singleton for DW tests. Each adapter creates its own client with the
-    # correct credentials and finds the pre-warmed Livy session by name.
-    BaseFabricConnectionManager._fabric_token_provider = token_provider
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,11 +126,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def livy_session_lifecycle(request):
-    if request.config.getoption("--dw", default=False):
-        yield
-        return
-
+def livy_session_lifecycle():
     session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
     lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
     workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
@@ -140,10 +136,8 @@ def livy_session_lifecycle(request):
         yield
         return
 
+    from dbt.adapters.fabric.base_connection_manager import BaseFabricConnectionManager
     from dbt.adapters.fabric.fabric_livy_session import LivySession
-    from dbt.adapters.fabricspark.fabricspark_connection_manager import (
-        FabricSparkConnectionManager,
-    )
 
     creds = FabricCredentials(
         database=lakehouse_name,
@@ -159,8 +153,8 @@ def livy_session_lifecycle(request):
     client.get_livy_session_id()
     LivySession(client).wait_for_session_ready()
 
-    FabricSparkConnectionManager._fabric_api_client = client
-    FabricSparkConnectionManager._fabric_token_provider = token_provider
+    BaseFabricConnectionManager._fabric_api_client = client
+    BaseFabricConnectionManager._fabric_token_provider = token_provider
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,11 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def livy_session_lifecycle():
+def livy_session_lifecycle(request):
+    if request.config.getoption("--dw", default=False):
+        yield
+        return
+
     session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
     lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
     workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
@@ -136,8 +140,10 @@ def livy_session_lifecycle():
         yield
         return
 
-    from dbt.adapters.fabric.base_connection_manager import BaseFabricConnectionManager
     from dbt.adapters.fabric.fabric_livy_session import LivySession
+    from dbt.adapters.fabricspark.fabricspark_connection_manager import (
+        FabricSparkConnectionManager,
+    )
 
     creds = FabricCredentials(
         database=lakehouse_name,
@@ -153,8 +159,8 @@ def livy_session_lifecycle():
     client.get_livy_session_id()
     LivySession(client).wait_for_session_ready()
 
-    BaseFabricConnectionManager._fabric_api_client = client
-    BaseFabricConnectionManager._fabric_token_provider = token_provider
+    FabricSparkConnectionManager._fabric_api_client = client
+    FabricSparkConnectionManager._fabric_token_provider = token_provider
 
     yield
 


### PR DESCRIPTION
## Summary

- `TestWarehouseSnapshots` failed with "No Data Warehouse found with name lh" because the `livy_session_lifecycle` test fixture cached a `FabricApiClient` (created with lakehouse credentials) on `BaseFabricConnectionManager._fabric_api_client`. The DW adapter picked up this singleton via MRO and used lakehouse credentials for warehouse API calls.
- Fix: the livy lifecycle now only caches the token provider (credential-agnostic), not the API client. Each adapter creates its own `FabricApiClient` with the correct profile credentials, and finds the pre-warmed Livy session by name via `get_existing_livy_session()`.
- No production code changes — credentials are fixed per dbt run, so the singleton needs no defensive checks.

## Test plan

- [x] Run `uv run pytest -k "TestWarehouseSnapshots" --dw` and verify it passes
- [x] Run unit tests `uv run pytest tests/unit/` to verify no import breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)