### PR TITLE
Add automatic query retry for transient snapshot isolation errors

### DIFF
--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -304,9 +304,14 @@ class FabricConnectionManager(BaseFabricConnectionManager):
         auto_begin: bool = True,
         bindings: Any | None = None,
         abridge_sql_log: bool = False,
-        retryable_exceptions: tuple[Type[Exception], ...] = tuple(),
-        retry_limit: int = 1,
+        retryable_exceptions: tuple[Type[Exception], ...] | None = None,
+        retry_limit: int = 3,
     ):
+        import mssql_python
+
+        if retryable_exceptions is None:
+            retryable_exceptions = (mssql_python.OperationalError, mssql_python.InternalError)
+
         if bindings is None:
             bindings = ()
         else:

--- a/tests/fabric/adapter/test_store_test_failures.py
+++ b/tests/fabric/adapter/test_store_test_failures.py
@@ -1,7 +1,4 @@
-import time
-
 import pytest
-from dbt_common.exceptions import DbtDatabaseError
 
 from dbt.tests.adapter.store_test_failures_tests import fixtures
 from dbt.tests.adapter.store_test_failures_tests.basic import (
@@ -16,7 +13,6 @@ from dbt.tests.adapter.store_test_failures_tests.test_store_test_failures import
     BaseStoreTestFailures,
     BaseStoreTestFailuresLimit,
 )
-from dbt.tests.util import check_relation_types, run_dbt
 
 tests__passing_test = """
 select * from {{ ref('fine_model') }}
@@ -24,35 +20,7 @@ where 1=0
 """
 
 
-class FabricStoreTestFailuresMixin:
-    """Retry check_relation_types to handle Fabric snapshot isolation errors.
-
-    When the full test suite runs in parallel, concurrent DDL from other test classes
-    can cause transient snapshot isolation failures in the sys.tables/sys.views queries
-    used by check_relation_types.
-    """
-
-    def run_and_assert(self, project, expected_results, expect_pass=False):
-        results = run_dbt(["test"], expect_pass=expect_pass)
-
-        actual = {(result.node.name, result.status) for result in results}
-        expected = {(result.name, result.status) for result in expected_results}
-        assert actual == expected
-
-        relation_to_type = {result.name: result.type for result in expected_results}
-        max_retries = 3
-        for attempt in range(max_retries):
-            try:
-                check_relation_types(project.adapter, relation_to_type)
-                break
-            except DbtDatabaseError:
-                if attempt < max_retries - 1:
-                    time.sleep(2)
-                else:
-                    raise
-
-
-class TestFabricStoreTestFailures(FabricStoreTestFailuresMixin, BaseStoreTestFailures):
+class TestFabricStoreTestFailures(BaseStoreTestFailures):
     @pytest.fixture(scope="class")
     def tests(self):
         return {
@@ -61,39 +29,27 @@ class TestFabricStoreTestFailures(FabricStoreTestFailuresMixin, BaseStoreTestFai
         }
 
 
-class TestFabricStoreTestFailuresAsGeneric(
-    FabricStoreTestFailuresMixin, StoreTestFailuresAsGeneric
-):
+class TestFabricStoreTestFailuresAsGeneric(StoreTestFailuresAsGeneric):
     pass
 
 
-class TestFabricStoreTestFailuresAsExceptions(
-    FabricStoreTestFailuresMixin, StoreTestFailuresAsExceptions
-):
+class TestFabricStoreTestFailuresAsExceptions(StoreTestFailuresAsExceptions):
     pass
 
 
-class TestFabricStoreTestFailuresAsInteractions(
-    FabricStoreTestFailuresMixin, StoreTestFailuresAsInteractions
-):
+class TestFabricStoreTestFailuresAsInteractions(StoreTestFailuresAsInteractions):
     pass
 
 
-class TestFabricStoreTestFailuresAsProjectLevelEphemeral(
-    FabricStoreTestFailuresMixin, StoreTestFailuresAsProjectLevelEphemeral
-):
+class TestFabricStoreTestFailuresAsProjectLevelEphemeral(StoreTestFailuresAsProjectLevelEphemeral):
     pass
 
 
-class TestFabricStoreTestFailuresAsProjectLevelOff(
-    FabricStoreTestFailuresMixin, StoreTestFailuresAsProjectLevelOff
-):
+class TestFabricStoreTestFailuresAsProjectLevelOff(StoreTestFailuresAsProjectLevelOff):
     pass
 
 
-class TestFabricStoreTestFailuresAsProjectLevelView(
-    FabricStoreTestFailuresMixin, StoreTestFailuresAsProjectLevelView
-):
+class TestFabricStoreTestFailuresAsProjectLevelView(StoreTestFailuresAsProjectLevelView):
     pass
 
 


### PR DESCRIPTION
## Summary

- Fabric Data Warehouse enforces snapshot isolation. Concurrent DDL (background compaction or test teardown) causes transient `OperationalError` (SQLSTATE 40001) on `sys.tables`/`sys.columns` queries, breaking `dbt docs generate` and catalog tests.
- Fix: activate dbt-adapters' built-in query retry in `FabricConnectionManager.add_query()` — default to retrying `OperationalError` and `InternalError` up to 3 attempts with 1-second sleep between each.
- Remove `FabricStoreTestFailuresMixin` from `test_store_test_failures.py` — the adapter now handles these retries transparently.

Fixes CI run [#25947292773](https://github.com/sdebruyn/dbt-fabric/actions/runs/25947292773/job/76279477444).

## Test plan

- [x] `uv run pytest tests/fabric/adapter/test_store_test_failures.py --dw` passes without the mixin
- [x] `uv run pytest -k "TestCatalogColumnsPopulated or TestDocsGenerateFabric" --dw` passes (transient errors now retried)
- [ ] Full DW test suite green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)