### PR TITLE
Add workload_identity authentication for federated credentials

### DIFF
--- a/.github/workflows/integration-tests-de.yml
+++ b/.github/workflows/integration-tests-de.yml
@@ -53,13 +53,14 @@ jobs:
           FABRIC_TEST_AUTH: workload_identity
           FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
-          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_THREADS: 2
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
-        run: uv run pytest -ra -v --de --with-python
+        run: |
+          export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
+          export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
+          uv run pytest -ra -v --de --with-python
 
       - name: Upload test logs
         if: always()
@@ -167,14 +168,14 @@ jobs:
           FABRIC_TEST_AUTH: workload_identity
           FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
-          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_THREADS: 2
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
           PYTEST_FILTER: ${{ steps.filter.outputs.expression }}
         run: |
+          export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
+          export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
           if [ -n "$PYTEST_FILTER" ]; then
             uv run pytest -ra -v --de -k "$PYTEST_FILTER"
           else
@@ -243,14 +244,14 @@ jobs:
           FABRIC_TEST_AUTH: workload_identity
           FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
-          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_THREADS: 2
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
           PYTEST_FILTER: ${{ github.event.inputs.pytest_filter }}
         run: |
+          export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
+          export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
           if [ -n "$PYTEST_FILTER" ]; then
             uv run pytest -ra -v --de -k "$PYTEST_FILTER"
           else

--- a/.github/workflows/integration-tests-de.yml
+++ b/.github/workflows/integration-tests-de.yml
@@ -38,13 +38,6 @@ jobs:
       - name: Install mssql-python system dependencies
         run: sudo apt-get update && sudo apt-get install -y libltdl7
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
       - uses: actions/checkout@v6
 
       - name: Install uv
@@ -57,6 +50,11 @@ jobs:
 
       - name: Run DE integration tests
         env:
+          FABRIC_TEST_AUTH: workload_identity
+          FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
+          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_THREADS: 2
@@ -150,13 +148,6 @@ jobs:
       - name: Install mssql-python system dependencies
         run: sudo apt-get update && sudo apt-get install -y libltdl7
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
       - uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
@@ -173,6 +164,11 @@ jobs:
       - name: Run DE integration tests
         id: tests
         env:
+          FABRIC_TEST_AUTH: workload_identity
+          FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
+          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_THREADS: 2
@@ -232,13 +228,6 @@ jobs:
       - name: Install mssql-python system dependencies
         run: sudo apt-get update && sudo apt-get install -y libltdl7
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
       - uses: actions/checkout@v6
 
       - name: Install uv
@@ -251,6 +240,11 @@ jobs:
 
       - name: Run DE integration tests
         env:
+          FABRIC_TEST_AUTH: workload_identity
+          FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
+          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_THREADS: 2

--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -75,13 +75,6 @@ jobs:
       - name: Install mssql-python system dependencies
         run: sudo apt-get update && sudo apt-get install -y libltdl7
 
-      - name: Azure CLI Login
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
       - uses: actions/checkout@v6
 
       - name: Install uv
@@ -94,6 +87,11 @@ jobs:
 
       - name: Run DW integration tests
         env:
+          FABRIC_TEST_AUTH: workload_identity
+          FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
+          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ${{ matrix.dwh_name }}
           FABRIC_TEST_LAKEHOUSE_NAME: cilh

--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -90,14 +90,14 @@ jobs:
           FABRIC_TEST_AUTH: workload_identity
           FABRIC_TEST_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          FABRIC_TEST_FEDERATED_TOKEN_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}&audience=api://AzureADTokenExchange
-          FABRIC_TEST_FEDERATED_TOKEN_HEADER: bearer ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ${{ matrix.dwh_name }}
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ (github.event_name == 'schedule' || inputs.with_python) && github.run_id || '' }}
           PYTEST_FILTER: ${{ inputs.pytest_filter || '' }}
         run: |
+          export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
+          export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
           ARGS="-ra -v --dw"
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.with_python }}" == "true" ]]; then
             ARGS="$ARGS --with-python"

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -13,7 +13,8 @@ The dbt-fabric-samdebruyn adapter supports a variety of authentication methods s
     | Scenario | Recommended method |
     | --- | --- |
     | Local development | [`CLI`](#azure-cli) or [`auto`](#automatic-defaultazurecredential) |
-    | CI/CD pipelines | [`environment`](#environment-variables) or [`ActiveDirectoryServicePrincipal`](#service-principal) |
+    | CI/CD pipelines (OIDC) | [`workload_identity`](#workload-identity-federated-credentials) |
+    | CI/CD pipelines (secret) | [`environment`](#environment-variables) or [`ActiveDirectoryServicePrincipal`](#service-principal) |
     | Fabric Notebook | [`environment`](#environment-variables) or [`ActiveDirectoryServicePrincipal`](#service-principal) |
     | Custom token source | [`token_credential`](#custom-token-credential) |
 
@@ -181,6 +182,65 @@ default:
 ```
 
 This method keeps your `profiles.yml` completely free of secrets, which is an advantage over the explicit `ActiveDirectoryServicePrincipal` method.
+
+### Workload Identity (federated credentials)
+
+Use `workload_identity` to authenticate with [Workload Identity Federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation?WT.mc_id=MVP_310840) — no client secret needed. The adapter uses [`ClientAssertionCredential`](https://learn.microsoft.com/python/api/azure-identity/azure.identity.clientassertioncredential?view=azure-python&WT.mc_id=MVP_310840) under the hood, fetching a fresh federated token on each Azure token refresh.
+
+This works with any identity provider that issues OIDC tokens: GitHub Actions, Kubernetes, or any custom OIDC endpoint.
+
+**Prerequisites:**
+
+- A registered application in Microsoft Entra ID with a [federated credential](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp&WT.mc_id=MVP_310840) configured for your identity provider
+- The application must have access to your Fabric workspace
+- You need the **client ID** and **tenant ID** (no client secret)
+
+=== "GitHub Actions"
+
+    ```yaml
+    default:
+      target: ci
+      outputs:
+        ci:
+          type: fabric
+          database: my_data_warehouse
+          schema: dbt
+          workspace: My Workspace
+          authentication: workload_identity
+          tenant_id: "{{ env_var('AZURE_TENANT_ID') }}"
+          client_id: "{{ env_var('AZURE_CLIENT_ID') }}"
+          federated_token_url: "{{ env_var('ACTIONS_ID_TOKEN_REQUEST_URL') }}&audience=api://AzureADTokenExchange"
+          federated_token_header: "bearer {{ env_var('ACTIONS_ID_TOKEN_REQUEST_TOKEN') }}"
+    ```
+
+    Your workflow needs `permissions: id-token: write` to make the OIDC token endpoint available.
+
+=== "Kubernetes"
+
+    ```yaml
+    default:
+      target: ci
+      outputs:
+        ci:
+          type: fabric
+          database: my_data_warehouse
+          schema: dbt
+          workspace: My Workspace
+          authentication: workload_identity
+          tenant_id: "{{ env_var('AZURE_TENANT_ID') }}"
+          client_id: "{{ env_var('AZURE_CLIENT_ID') }}"
+          federated_token_file: /var/run/secrets/azure/tokens/azure-identity-token
+    ```
+
+    The kubelet automatically refreshes the token file, and the adapter re-reads it on each Azure token refresh.
+
+!!! info "No client secret required"
+
+    Unlike `ActiveDirectoryServicePrincipal`, this method does not need a `client_secret`. Authentication is based on the trust relationship between Microsoft Entra ID and your identity provider's OIDC tokens.
+
+!!! tip "Token lifetime"
+
+    The adapter automatically refreshes Azure access tokens (valid ~60-90 minutes) by calling the federated token source again. This works for long-running jobs — the GitHub Actions request token stays valid for the entire job duration (up to 6 hours).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,6 +229,12 @@ Alias: `SynapseSpark`
 
 This authentication methods works inside a Fabric or Synapse notebook. It uses [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebook-utilities?WT.mc_id=MVP_310840) to get an access token for the current user.
 
+#### `workload_identity`
+
+Authenticate with [Workload Identity Federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation?WT.mc_id=MVP_310840) using a federated OIDC token. No client secret needed. Works with GitHub Actions, Kubernetes, and any OIDC provider. See the [authentication guide](authentication.md#workload-identity-federated-credentials) for examples.
+
+Requires [`tenant_id`](#tenant_id), [`client_id`](#client_id), and exactly one of [`federated_token_url`](#federated_token_url) or [`federated_token_file`](#federated_token_file).
+
 #### `token_credential`
 
 Load any [`azure.core.credentials.TokenCredential`](https://learn.microsoft.com/python/api/azure-core/azure.core.credentials.tokencredential?view=azure-python&WT.mc_id=MVP_310840) implementation by its dotted import path. This is useful when the built-in methods don't cover your scenario -- for example, when using a custom OAuth flow, a token broker, or Workload Identity Federation with a non-standard setup. See the [authentication guide](authentication.md#custom-token-credential) for a full walkthrough.
@@ -315,6 +321,28 @@ credential_kwargs:
 ```
 
 A dictionary of keyword arguments passed to the constructor of the class specified in [`credential_class`](#credential_class). This is optional and can only be used when [`authentication`](#authentication) is set to `token_credential`.
+
+### `federated_token_url`
+
+Example value: `https://token.actions.githubusercontent.com`
+
+The URL to fetch a federated OIDC token from. The adapter performs a GET request to this URL and reads the token from the `value` field of the JSON response. Can only be used when [`authentication`](#authentication) is set to `workload_identity`.
+
+Mutually exclusive with [`federated_token_file`](#federated_token_file) — exactly one must be set.
+
+### `federated_token_header`
+
+Example value: `bearer ghs_xxxxxxxxxxxxxxxxxxxx`
+
+The value for the `Authorization` header when fetching the federated token from [`federated_token_url`](#federated_token_url). Can only be used together with `federated_token_url`, not with `federated_token_file`.
+
+### `federated_token_file`
+
+Example value: `/var/run/secrets/azure/tokens/azure-identity-token`
+
+Path to a file containing a federated OIDC token. The adapter re-reads this file each time it needs a fresh token, so external processes (like kubelet) can refresh it. Can only be used when [`authentication`](#authentication) is set to `workload_identity`.
+
+Mutually exclusive with [`federated_token_url`](#federated_token_url) — exactly one must be set.
 
 ### `schema_auth`
 

--- a/src/dbt/adapters/fabric/base_credentials.py
+++ b/src/dbt/adapters/fabric/base_credentials.py
@@ -71,6 +71,11 @@ class BaseFabricCredentials(Credentials, metaclass=abc.ABCMeta):
                     "Exactly one of federated_token_url or federated_token_file "
                     "must be set when authentication is 'workload_identity'"
                 )
+            if has_file and des.get("federated_token_header"):
+                raise ValueError(
+                    "federated_token_header can only be used with federated_token_url, "
+                    "not with federated_token_file"
+                )
         else:
             if des.get("federated_token_url") or des.get("federated_token_file"):
                 raise ValueError(

--- a/src/dbt/adapters/fabric/base_credentials.py
+++ b/src/dbt/adapters/fabric/base_credentials.py
@@ -26,6 +26,9 @@ class BaseFabricCredentials(Credentials, metaclass=abc.ABCMeta):
     purview_endpoint: str | None = None
     credential_class: str | None = None
     credential_kwargs: dict[str, Any] = field(default_factory=dict)
+    federated_token_url: str | None = None
+    federated_token_header: str | None = None
+    federated_token_file: str | None = None
 
     _ALIASES = {
         "trusted_connection": "windows_login",
@@ -55,6 +58,31 @@ class BaseFabricCredentials(Credentials, metaclass=abc.ABCMeta):
                 "with authentication: token_credential"
             )
 
+        if auth == "workload_identity":
+            if not des.get("tenant_id") or not des.get("client_id"):
+                raise ValueError(
+                    "tenant_id and client_id are required "
+                    "when authentication is 'workload_identity'"
+                )
+            has_url = bool(des.get("federated_token_url"))
+            has_file = bool(des.get("federated_token_file"))
+            if has_url == has_file:
+                raise ValueError(
+                    "Exactly one of federated_token_url or federated_token_file "
+                    "must be set when authentication is 'workload_identity'"
+                )
+        else:
+            if des.get("federated_token_url") or des.get("federated_token_file"):
+                raise ValueError(
+                    "federated_token_url and federated_token_file can only be used "
+                    "with authentication: workload_identity"
+                )
+            if des.get("federated_token_header"):
+                raise ValueError(
+                    "federated_token_header can only be used "
+                    "with authentication: workload_identity"
+                )
+
         return des
 
     @property
@@ -80,6 +108,8 @@ class BaseFabricCredentials(Credentials, metaclass=abc.ABCMeta):
             "powerbi_base_api_uri",
             "livy_session_name",
             "purview_endpoint",
+            "federated_token_url",
+            "federated_token_file",
         )
 
     @property

--- a/src/dbt/adapters/fabric/fabric_token_provider.py
+++ b/src/dbt/adapters/fabric/fabric_token_provider.py
@@ -2,12 +2,15 @@ import importlib
 import re
 import struct
 import time
+from collections.abc import Callable
 from itertools import chain, repeat
 from typing import Any
 
+import requests
 from azure.core.credentials import AccessToken, TokenCredential
 from azure.identity import (
     AzureCliCredential,
+    ClientAssertionCredential,
     ClientSecretCredential,
     DefaultAzureCredential,
     DeviceCodeCredential,
@@ -36,6 +39,32 @@ def get_notebookutils_access_token(scope: str) -> AccessToken:
         expires_on=expires_on,
     )
     return token
+
+
+def _build_federated_token_callable(
+    credentials: BaseFabricCredentials,
+) -> Callable[[], str]:
+    if credentials.federated_token_url:
+        url = credentials.federated_token_url
+        headers = {}
+        if credentials.federated_token_header:
+            headers["Authorization"] = credentials.federated_token_header
+
+        def fetch_from_url() -> str:
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            return response.json()["value"]
+
+        return fetch_from_url
+
+    assert credentials.federated_token_file is not None
+    path = credentials.federated_token_file
+
+    def read_from_file() -> str:
+        with open(path) as f:
+            return f.read().strip()
+
+    return read_from_file
 
 
 def load_token_credential(
@@ -150,6 +179,14 @@ class FabricTokenProvider:
             credential = EnvironmentCredential()
         elif self.credentials.authentication.lower() == "notebookutils":
             token = get_notebookutils_access_token(scope)
+        elif self.credentials.authentication.lower() == "workload_identity":
+            if self._custom_credential is None:
+                self._custom_credential = ClientAssertionCredential(
+                    tenant_id=self.credentials.tenant_id,
+                    client_id=self.credentials.client_id,
+                    func=_build_federated_token_callable(self.credentials),
+                )
+            credential = self._custom_credential
         elif self.credentials.authentication.lower() == "token_credential":
             if self._custom_credential is None:
                 assert self.credentials.credential_class is not None

--- a/src/dbt/adapters/fabric/fabric_token_provider.py
+++ b/src/dbt/adapters/fabric/fabric_token_provider.py
@@ -57,7 +57,11 @@ def _build_federated_token_callable(
 
         return fetch_from_url
 
-    assert credentials.federated_token_file is not None
+    if not credentials.federated_token_file:
+        raise ValueError(
+            "Either federated_token_url or federated_token_file must be configured "
+            "for workload_identity authentication"
+        )
     path = credentials.federated_token_file
 
     def read_from_file() -> str:

--- a/test.env.sample
+++ b/test.env.sample
@@ -6,6 +6,15 @@ FABRIC_TEST_HOST=your-endpoint.datawarehouse.fabric.microsoft.com
 #FABRIC_TEST_LAKEHOUSE_NAME=lakehousename
 #FABRIC_TEST_LIVY_SESSION_NAME=sessionname
 #FABRIC_TEST_THREADS=20
+# Authentication method (optional, defaults to auto/DefaultAzureCredential)
+#FABRIC_TEST_AUTH=workload_identity
+#FABRIC_TEST_TENANT_ID=00000000-0000-0000-0000-000000000000
+#FABRIC_TEST_CLIENT_ID=00000000-0000-0000-0000-000000000000
+# For URL-based federated tokens (GitHub Actions, Azure DevOps OIDC):
+#FABRIC_TEST_FEDERATED_TOKEN_URL=https://oidc.example.com/token
+#FABRIC_TEST_FEDERATED_TOKEN_HEADER=bearer your-request-token
+# For file-based federated tokens (Kubernetes):
+#FABRIC_TEST_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token
 # Purview endpoint for integration tests (optional, tests are skipped without it)
 #FABRIC_TEST_PURVIEW_ENDPOINT=https://your-account.purview.azure.com
 # Extra users in your data warehouse to run authorization & grant tests with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,17 @@ def dbt_profile_target(dbt_profile_target_update, adapter_type: str, prefix: str
         "threads": int(os.getenv("FABRIC_TEST_THREADS", 10)),
     }
 
+    auth = os.getenv("FABRIC_TEST_AUTH")
+    if auth:
+        target["authentication"] = auth
+    for key in ("tenant_id", "client_id", "federated_token_url", "federated_token_file"):
+        val = os.getenv(f"FABRIC_TEST_{key.upper()}")
+        if val:
+            target[key] = val
+    federated_header = os.getenv("FABRIC_TEST_FEDERATED_TOKEN_HEADER")
+    if federated_header:
+        target["federated_token_header"] = federated_header
+
     if adapter_type == "fabric":
         adapter_settings = {
             "type": "fabric",

--- a/tests/unit/test_workload_identity_auth.py
+++ b/tests/unit/test_workload_identity_auth.py
@@ -1,4 +1,3 @@
-import json
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -108,6 +107,16 @@ class TestCredentialsValidation:
             federated_token_header="bearer my-token",
         )
         assert result["federated_token_header"] == "bearer my-token"
+
+    def test_workload_identity_rejects_header_with_file(self):
+        with pytest.raises(ValueError, match="can only be used with federated_token_url"):
+            self._serialize(
+                authentication="workload_identity",
+                tenant_id="test",
+                client_id="test",
+                federated_token_file="/tmp/token",
+                federated_token_header="bearer my-token",
+            )
 
     def test_other_auth_rejects_federated_token_url(self):
         with pytest.raises(ValueError, match="can only be used.*workload_identity"):

--- a/tests/unit/test_workload_identity_auth.py
+++ b/tests/unit/test_workload_identity_auth.py
@@ -1,0 +1,264 @@
+import json
+import time
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from azure.core.credentials import AccessToken
+
+from dbt.adapters.fabric.base_credentials import BaseFabricCredentials
+from dbt.adapters.fabric.fabric_token_provider import (
+    FabricTokenProvider,
+    _build_federated_token_callable,
+)
+
+
+@dataclass
+class ConcreteCredentials(BaseFabricCredentials):
+    @property
+    def lakehouse_name(self) -> str | None:
+        return None
+
+    @property
+    def type(self):
+        return "fabric"
+
+
+@dataclass
+class FakeWorkloadCredentials:
+    database: str = "test_db"
+    schema: str = "dbo"
+    tenant_id: str | None = "test-tenant"
+    client_id: str | None = "test-client"
+    client_secret: str | None = None
+    access_token: str | None = None
+    token_scope: str | None = None
+    authentication: str = "workload_identity"
+    credential_class: str | None = None
+    credential_kwargs: dict[str, Any] | None = None
+    federated_token_url: str | None = None
+    federated_token_header: str | None = None
+    federated_token_file: str | None = None
+
+
+class TestCredentialsValidation:
+    def _serialize(self, **kwargs) -> dict:
+        creds = ConcreteCredentials(database="db", schema="dbo", **kwargs)
+        return creds.__post_serialize__(creds.__dict__.copy(), None)
+
+    def test_workload_identity_requires_tenant_id(self):
+        with pytest.raises(ValueError, match="tenant_id and client_id are required"):
+            self._serialize(
+                authentication="workload_identity",
+                client_id="test",
+                federated_token_url="https://example.com",
+            )
+
+    def test_workload_identity_requires_client_id(self):
+        with pytest.raises(ValueError, match="tenant_id and client_id are required"):
+            self._serialize(
+                authentication="workload_identity",
+                tenant_id="test",
+                federated_token_url="https://example.com",
+            )
+
+    def test_workload_identity_requires_exactly_one_source(self):
+        with pytest.raises(ValueError, match="Exactly one of"):
+            self._serialize(
+                authentication="workload_identity",
+                tenant_id="test",
+                client_id="test",
+            )
+
+    def test_workload_identity_rejects_both_sources(self):
+        with pytest.raises(ValueError, match="Exactly one of"):
+            self._serialize(
+                authentication="workload_identity",
+                tenant_id="test",
+                client_id="test",
+                federated_token_url="https://example.com",
+                federated_token_file="/tmp/token",
+            )
+
+    def test_workload_identity_accepts_url(self):
+        result = self._serialize(
+            authentication="workload_identity",
+            tenant_id="test",
+            client_id="test",
+            federated_token_url="https://example.com",
+        )
+        assert result["federated_token_url"] == "https://example.com"
+
+    def test_workload_identity_accepts_file(self):
+        result = self._serialize(
+            authentication="workload_identity",
+            tenant_id="test",
+            client_id="test",
+            federated_token_file="/tmp/token",
+        )
+        assert result["federated_token_file"] == "/tmp/token"
+
+    def test_workload_identity_accepts_url_with_header(self):
+        result = self._serialize(
+            authentication="workload_identity",
+            tenant_id="test",
+            client_id="test",
+            federated_token_url="https://example.com",
+            federated_token_header="bearer my-token",
+        )
+        assert result["federated_token_header"] == "bearer my-token"
+
+    def test_other_auth_rejects_federated_token_url(self):
+        with pytest.raises(ValueError, match="can only be used.*workload_identity"):
+            self._serialize(
+                authentication="CLI",
+                federated_token_url="https://example.com",
+            )
+
+    def test_other_auth_rejects_federated_token_file(self):
+        with pytest.raises(ValueError, match="can only be used.*workload_identity"):
+            self._serialize(
+                authentication="CLI",
+                federated_token_file="/tmp/token",
+            )
+
+    def test_other_auth_rejects_federated_token_header(self):
+        with pytest.raises(ValueError, match="can only be used.*workload_identity"):
+            self._serialize(
+                authentication="CLI",
+                federated_token_header="bearer test",
+            )
+
+    def test_connection_keys_include_federated_fields(self):
+        creds = ConcreteCredentials(database="db", schema="dbo")
+        keys = creds._connection_keys()
+        assert "federated_token_url" in keys
+        assert "federated_token_file" in keys
+
+
+class TestBuildFederatedTokenCallable:
+    def test_url_mode_fetches_token(self):
+        creds = FakeWorkloadCredentials(
+            federated_token_url="https://oidc.example.com/token",
+            federated_token_header="bearer request-token",
+        )
+
+        callback = _build_federated_token_callable(creds)
+
+        with patch("dbt.adapters.fabric.fabric_token_provider.requests") as mock_requests:
+            mock_response = mock_requests.get.return_value
+            mock_response.json.return_value = {"value": "fresh-oidc-jwt"}
+
+            result = callback()
+
+            assert result == "fresh-oidc-jwt"
+            mock_requests.get.assert_called_once_with(
+                "https://oidc.example.com/token",
+                headers={"Authorization": "bearer request-token"},
+                timeout=30,
+            )
+            mock_response.raise_for_status.assert_called_once()
+
+    def test_url_mode_without_header(self):
+        creds = FakeWorkloadCredentials(
+            federated_token_url="https://oidc.example.com/token",
+        )
+
+        callback = _build_federated_token_callable(creds)
+
+        with patch("dbt.adapters.fabric.fabric_token_provider.requests") as mock_requests:
+            mock_response = mock_requests.get.return_value
+            mock_response.json.return_value = {"value": "jwt-no-header"}
+
+            result = callback()
+
+            assert result == "jwt-no-header"
+            mock_requests.get.assert_called_once_with(
+                "https://oidc.example.com/token",
+                headers={},
+                timeout=30,
+            )
+
+    def test_file_mode_reads_token(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("file-based-jwt\n")
+
+        creds = FakeWorkloadCredentials(
+            federated_token_file=str(token_file),
+        )
+
+        callback = _build_federated_token_callable(creds)
+        result = callback()
+
+        assert result == "file-based-jwt"
+
+    def test_file_mode_rereads_on_each_call(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("first-jwt")
+
+        creds = FakeWorkloadCredentials(
+            federated_token_file=str(token_file),
+        )
+
+        callback = _build_federated_token_callable(creds)
+        assert callback() == "first-jwt"
+
+        token_file.write_text("refreshed-jwt")
+        assert callback() == "refreshed-jwt"
+
+
+class TestFabricTokenProviderWorkloadIdentity:
+    def setup_method(self):
+        FabricTokenProvider._tokens.clear()
+
+    def test_creates_client_assertion_credential(self):
+        creds = FakeWorkloadCredentials(
+            federated_token_url="https://oidc.example.com/token",
+        )
+        provider = FabricTokenProvider(creds)
+
+        with (
+            patch(
+                "dbt.adapters.fabric.fabric_token_provider.ClientAssertionCredential"
+            ) as mock_cac,
+            patch("dbt.adapters.fabric.fabric_token_provider.requests"),
+        ):
+            mock_cac.return_value.get_token.return_value = AccessToken(
+                token="azure-access-token", expires_on=int(time.time()) + 3600
+            )
+
+            token = provider.get_access_token("https://example.com/.default")
+
+            assert token == "azure-access-token"
+            mock_cac.assert_called_once()
+            call_kwargs = mock_cac.call_args
+            assert call_kwargs.kwargs["tenant_id"] == "test-tenant"
+            assert call_kwargs.kwargs["client_id"] == "test-client"
+            assert callable(call_kwargs.kwargs["func"])
+
+    def test_caches_credential_instance(self):
+        creds = FakeWorkloadCredentials(
+            federated_token_url="https://oidc.example.com/token",
+        )
+        provider = FabricTokenProvider(creds)
+
+        with (
+            patch(
+                "dbt.adapters.fabric.fabric_token_provider.ClientAssertionCredential"
+            ) as mock_cac,
+            patch("dbt.adapters.fabric.fabric_token_provider.requests"),
+        ):
+            mock_cac.return_value.get_token.return_value = AccessToken(
+                token="azure-access-token", expires_on=int(time.time()) + 3600
+            )
+
+            provider.get_access_token("https://example.com/.default")
+            first = provider._custom_credential
+
+            FabricTokenProvider._tokens.clear()
+            provider.get_access_token("https://example.com/.default")
+            second = provider._custom_credential
+
+            assert first is second
+            mock_cac.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds a generic `workload_identity` authentication method using `ClientAssertionCredential` from azure-identity
- Two federated token sources: HTTP URL (GitHub Actions, Azure DevOps OIDC) or file path (Kubernetes, self-managed)
- New credential fields: `federated_token_url`, `federated_token_header`, `federated_token_file`
- Full validation: exactly one source required, header only with URL mode, fields restricted to `workload_identity` auth only
- Switches CI workflows from `azure/login` + `AzureCliCredential` to `workload_identity` with GitHub OIDC tokens
- Removes `az` CLI dependency from CI

## Test plan

- [x] Unit tests for credential validation (12 tests including header+file rejection)
- [x] Unit tests for `_build_federated_token_callable` — URL mode with/without header, file mode with re-read (4 tests)
- [x] Unit tests for `FabricTokenProvider` integration — credential creation and caching (2 tests)
- [x] Existing `token_credential` tests still pass (regression)
- [x] Local integration test with CLI auth passes (conftest changes don't break existing flow)
- [x] CI integration test with GitHub Actions OIDC passes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)