### PR TITLE
Add devcontainer for cloud development environments

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
   },
-  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y libltdl7 && uv sync --all-extras --all-groups",
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y libltdl7 libkrb5-3 libgssapi-krb5-2 && uv sync --all-extras --all-groups",
   "containerEnv": {
     "UV_LINK_MODE": "copy"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "dbt-fabric",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
+  },
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y libltdl7 && uv sync --all-extras --all-groups",
+  "containerEnv": {
+    "UV_LINK_MODE": "copy"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "innoverio.vscode-dbt-power-user"
+      ]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,10 @@ Use `uv run ...` to run commands inside the virtual environment, or [activate it
 
 ### System dependencies
 
-The mssql-python driver requires `libltdl7` on Linux:
+The mssql-python driver requires the following libraries on Debian/Ubuntu Linux:
 
 ```shell
-sudo apt-get install libltdl7
+sudo apt-get install libltdl7 libkrb5-3 libgssapi-krb5-2
 ```
 
 This is installed automatically in the devcontainer and CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,25 @@
 
 ## Getting started
 
-We recommend [uv](https://docs.astral.sh/uv/) for managing Python environments and dependencies. A single command sets up everything you need (virtual environment, all dependencies, the adapter in editable mode):
+This repository includes a [devcontainer](.devcontainer/devcontainer.json) configuration that works with GitHub Codespaces, VS Code Dev Containers, and Claude Code environments. Opening the repo in any of these platforms gives you a ready-to-use environment with Python, uv, Azure CLI, and GitHub CLI pre-installed.
+
+For local development, we recommend [uv](https://docs.astral.sh/uv/) for managing Python environments and dependencies. A single command sets up everything you need (virtual environment, all dependencies, the adapter in editable mode):
 
 ```shell
 uv sync
 ```
 
 Use `uv run ...` to run commands inside the virtual environment, or [activate it](https://docs.astral.sh/uv/pip/environments/#using-a-virtual-environment) first.
+
+### System dependencies
+
+The mssql-python driver requires `libltdl7` on Linux:
+
+```shell
+sudo apt-get install libltdl7
+```
+
+This is installed automatically in the devcontainer and CI.
 
 ## Architecture
 
@@ -191,12 +203,12 @@ GitHub Actions workflows in `.github/workflows/`:
 | Workflow | Trigger | What it does |
 |---|---|---|
 | `lint-format.yml` | PR, push | `ruff format --check` + `ruff check` |
-| `integration-tests-dw.yml` | PR, push, manual | DW tests: Python 3.11/3.12/3.13 matrix |
+| `unit-tests.yml` | PR, push | Unit tests (no Fabric infrastructure needed) |
+| `integration-tests-dw.yml` | PR, push, manual, weekly | DW tests: Python 3.13 on PR/push, full matrix (3.11/3.12/3.13) on weekly schedule |
 | `integration-tests-de.yml` | Weekly, PR comment, manual | DE tests: weekly on main, on-demand per PR — see below |
-| `publish-docker.yml` | Manual | Build CI Docker image (`.github/CI.Dockerfile`) → ghcr.io |
 | `release-version.yml` | Tag `v*` | Update version, build, publish to PyPI |
 
-CI authenticates to Azure via OIDC (federated credentials, no secrets stored). Tests run inside Docker containers with pre-installed `mssql-python` dependencies.
+CI authenticates to Azure via OIDC (federated credentials, no secrets stored). Tests run on `ubuntu-latest` runners with `libltdl7` installed (required by mssql-python).
 
 ### On-demand DE tests
 


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` with Python 3.13, uv, Azure CLI, GitHub CLI, and `libltdl7` (mssql-python dependency)
- Updates `CONTRIBUTING.md`: documents the devcontainer, adds system dependencies section, corrects the CI workflow table (removes stale `publish-docker.yml` reference, adds `unit-tests.yml`)

Works out-of-the-box in GitHub Codespaces, VS Code Dev Containers, and Claude Code environments.

## Test plan

- [x] Open repo in GitHub Codespaces and verify `uv run ruff check .` works
- [x] Verify `az --version` and `gh --version` are available
- [x] Verify `python --version` shows 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)