### PR TITLE
Fix FabricSpark snapshots failing with `character varying` type error

### DIFF
--- a/src/dbt/adapters/fabricspark/fabricspark_adapter.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_adapter.py
@@ -1,5 +1,5 @@
 from concurrent.futures import Future, as_completed
-from typing import TYPE_CHECKING, Callable, FrozenSet, Iterable, Tuple, TypeAlias
+from typing import TYPE_CHECKING, Callable, FrozenSet, Iterable, Tuple
 
 from dbt_common.clients.agate_helper import DEFAULT_TYPE_TESTER
 from dbt_common.events.functions import warn_or_error
@@ -31,10 +31,10 @@ logger = AdapterLogger("FabricSpark")
 
 
 class FabricSparkAdapter(BaseFabricAdapter, SparkAdapter):
-    Column: TypeAlias = FabricSparkColumn  # type: ignore
+    Column = FabricSparkColumn
     ConnectionManager = FabricSparkConnectionManager  # type: ignore
     connections: FabricSparkConnectionManager  # type: ignore
-    Relation: TypeAlias = FabricSparkRelation  # type: ignore
+    Relation = FabricSparkRelation
     RelationInfo = Tuple[str, str, str]
 
     _capabilities: CapabilityDict = CapabilityDict(

--- a/src/dbt/adapters/fabricspark/fabricspark_adapter.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_adapter.py
@@ -31,6 +31,7 @@ logger = AdapterLogger("FabricSpark")
 
 
 class FabricSparkAdapter(BaseFabricAdapter, SparkAdapter):
+    Column: TypeAlias = FabricSparkColumn  # type: ignore
     ConnectionManager = FabricSparkConnectionManager  # type: ignore
     connections: FabricSparkConnectionManager  # type: ignore
     Relation: TypeAlias = FabricSparkRelation  # type: ignore

--- a/src/dbt/adapters/fabricspark/fabricspark_column.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_column.py
@@ -10,7 +10,7 @@ class FabricSparkColumn(SparkColumn):
     column_comment: str | None = None
 
     @classmethod
-    def string_type(cls, size: int) -> str:
+    def string_type(cls, _size: int) -> str:
         return "string"
 
     def is_string(self) -> bool:

--- a/src/dbt/adapters/fabricspark/fabricspark_column.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_column.py
@@ -9,6 +9,10 @@ class FabricSparkColumn(SparkColumn):
     table_comment: str | None = None
     column_comment: str | None = None
 
+    @classmethod
+    def string_type(cls, size: int) -> str:
+        return "string"
+
     def is_string(self) -> bool:
         return super().is_string() or self.dtype.lower() == "string"
 


### PR DESCRIPTION
## Summary

- Override `string_type()` on `FabricSparkColumn` to return `string` instead of the inherited `character varying(N)` which is invalid Spark SQL
- Set the `Column` class attribute on `FabricSparkAdapter` to `FabricSparkColumn` so `expand_column_types()` uses the correct column class

Closes #161

## Test plan

- [x] `TestSnapshotCheckColsSpark::test_snapshot_check_cols` passes
- [x] `TestSnapshotTimestampSpark::test_snapshot_timestamp` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)