### PR TITLE
Remove dbt Power User extension from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "charliermarsh.ruff",
-        "innoverio.vscode-dbt-power-user"
+        "charliermarsh.ruff"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Removes the `innoverio.vscode-dbt-power-user` extension from the devcontainer

## Test plan

- [x] Open repo in devcontainer and verify only Ruff extension is pre-installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)