### PR TITLE
Add statistics config option for Fabric Data Warehouse

### DIFF
--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -70,17 +70,17 @@ Add `statistics` to your model's config block. It accepts `true` (all columns), 
 The generated SQL for specific columns:
 
 ```sql
-CREATE STATISTICS [dbt_stats__orders__customer_id]
+CREATE STATISTICS [dbt_stats__fcfc231ef98cf4ae86d587235eda4cd7]
 ON [schema].[orders] ([customer_id]) WITH FULLSCAN;
 
-CREATE STATISTICS [dbt_stats__orders__order_date]
+CREATE STATISTICS [dbt_stats__62b326a5adbe56da5634fa1bcf7b579e]
 ON [schema].[orders] ([order_date]) WITH FULLSCAN;
 ```
 
 On subsequent runs, existing statistics are updated instead of recreated:
 
 ```sql
-UPDATE STATISTICS [schema].[orders] [dbt_stats__orders__customer_id] WITH FULLSCAN;
+UPDATE STATISTICS [schema].[orders] [dbt_stats__fcfc231ef98cf4ae86d587235eda4cd7] WITH FULLSCAN;
 ```
 
 ---
@@ -110,7 +110,7 @@ models:
 This generates:
 
 ```sql
-CREATE STATISTICS [dbt_stats__orders__customer_id]
+CREATE STATISTICS [dbt_stats__fcfc231ef98cf4ae86d587235eda4cd7]
 ON [schema].[orders] ([customer_id]) WITH SAMPLE 50 PERCENT;
 ```
 
@@ -169,7 +169,7 @@ snapshots:
 
 ## Naming convention
 
-Statistics are named `dbt_stats__<table>__<column>` (e.g., `dbt_stats__orders__customer_id`). This avoids collisions with Fabric's auto-generated `_WA_Sys_*` statistics.
+Statistics are named `dbt_stats__<md5_hash>` where the hash is computed from `<table>__<column>` (e.g., `dbt_stats__fcfc231ef98cf4ae86d587235eda4cd7` for column `customer_id` on table `orders`). The `dbt_stats__` prefix avoids collisions with Fabric's auto-generated `_WA_Sys_*` statistics, and hashing guarantees uniqueness regardless of identifier length.
 
 ---
 

--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -70,17 +70,17 @@ Add `statistics` to your model's config block. It accepts `true` (all columns), 
 The generated SQL for specific columns:
 
 ```sql
-CREATE STATISTICS [stats__orders__customer_id]
+CREATE STATISTICS [dbt_stats__orders__customer_id]
 ON [schema].[orders] ([customer_id]) WITH FULLSCAN;
 
-CREATE STATISTICS [stats__orders__order_date]
+CREATE STATISTICS [dbt_stats__orders__order_date]
 ON [schema].[orders] ([order_date]) WITH FULLSCAN;
 ```
 
 On subsequent runs, existing statistics are updated instead of recreated:
 
 ```sql
-UPDATE STATISTICS [schema].[orders] [stats__orders__customer_id] WITH FULLSCAN;
+UPDATE STATISTICS [schema].[orders] [dbt_stats__orders__customer_id] WITH FULLSCAN;
 ```
 
 ---
@@ -110,7 +110,7 @@ models:
 This generates:
 
 ```sql
-CREATE STATISTICS [stats__orders__customer_id]
+CREATE STATISTICS [dbt_stats__orders__customer_id]
 ON [schema].[orders] ([customer_id]) WITH SAMPLE 50 PERCENT;
 ```
 
@@ -169,7 +169,7 @@ snapshots:
 
 ## Naming convention
 
-Statistics are named `stats__<table>__<column>` (e.g., `stats__orders__customer_id`). This avoids collisions with Fabric's auto-generated `_WA_Sys_*` statistics.
+Statistics are named `dbt_stats__<table>__<column>` (e.g., `dbt_stats__orders__customer_id`). This avoids collisions with Fabric's auto-generated `_WA_Sys_*` statistics.
 
 ---
 

--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -1,0 +1,180 @@
+# Statistics
+
+Fabric Data Warehouse supports [manual statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840) that give the query optimizer accurate cardinality estimates. While Fabric creates automatic statistics at query time (using sampling), manual statistics use `FULLSCAN` by default — reading all rows for exact histograms — and persist across sessions without needing a query to trigger creation.
+
+This adapter lets you manage manual statistics declaratively using the `statistics` config option.
+
+---
+
+## When to use manual statistics
+
+Fabric creates automatic statistics for columns used in `GROUP BY`, `JOIN`, `WHERE`, and `ORDER BY` clauses. Manual statistics add value when:
+
+- **After large data loads** — automatic stats may be stale until the next query triggers a refresh
+- **For critical query paths** — avoid the first query after a data change paying the cost of synchronous statistics creation
+- **When sampling isn't accurate enough** — automatic stats use sampling; `FULLSCAN` reads all rows
+
+!!! tip "Choosing which columns"
+    Focus on columns in `WHERE`, `JOIN`, `GROUP BY`, and `ORDER BY` clauses — these are where the optimizer needs cardinality estimates. Columns only in the `SELECT` list don't benefit from statistics.
+
+---
+
+## Usage
+
+Add `statistics` to your model's config block. It accepts `true` (all columns), a single column name, or a list of column names:
+
+=== "Specific columns"
+
+    ```sql title="models/orders.sql"
+    {{ config(
+        materialized='table',
+        statistics=['customer_id', 'order_date', 'product_id']
+    ) }}
+
+    select
+        order_id,
+        order_date,
+        customer_id,
+        product_id,
+        total_amount
+    from {{ source('raw', 'orders') }}
+    ```
+
+=== "All columns"
+
+    ```sql title="models/orders.sql"
+    {{ config(
+        materialized='table',
+        statistics=true
+    ) }}
+
+    select
+        order_id,
+        order_date,
+        customer_id,
+        total_amount
+    from {{ source('raw', 'orders') }}
+    ```
+
+=== "In dbt_project.yml"
+
+    ```yaml title="dbt_project.yml"
+    models:
+      my_project:
+        marts:
+          +statistics: ['customer_id', 'order_date']
+        staging:
+          +statistics: true
+    ```
+
+The generated SQL for specific columns:
+
+```sql
+CREATE STATISTICS [stats__orders__customer_id]
+ON [schema].[orders] ([customer_id]) WITH FULLSCAN;
+
+CREATE STATISTICS [stats__orders__order_date]
+ON [schema].[orders] ([order_date]) WITH FULLSCAN;
+```
+
+On subsequent runs, existing statistics are updated instead of recreated:
+
+```sql
+UPDATE STATISTICS [schema].[orders] [stats__orders__customer_id] WITH FULLSCAN;
+```
+
+---
+
+## Sampling
+
+By default, manual statistics use `FULLSCAN` (exact counts). For large tables where a full scan is too expensive, use `statistics_sample_percent` to switch to sampling:
+
+```sql title="models/orders.sql"
+{{ config(
+    materialized='table',
+    statistics=['customer_id', 'order_date'],
+    statistics_sample_percent=50
+) }}
+
+select ...
+```
+
+```yaml title="dbt_project.yml"
+models:
+  my_project:
+    staging:
+      +statistics: true
+      +statistics_sample_percent: 25
+```
+
+This generates:
+
+```sql
+CREATE STATISTICS [stats__orders__customer_id]
+ON [schema].[orders] ([customer_id]) WITH SAMPLE 50 PERCENT;
+```
+
+---
+
+## Works with incremental models
+
+Statistics are created or updated on every run — both full refresh and incremental merge:
+
+```sql title="models/orders_incremental.sql"
+{{ config(
+    materialized='incremental',
+    unique_key='order_id',
+    statistics=['customer_id', 'order_date']
+) }}
+
+select
+    order_id,
+    order_date,
+    customer_id,
+    total_amount
+from {{ source('raw', 'orders') }}
+{% if is_incremental() %}
+where order_date > (select max(order_date) from {{ this }})
+{% endif %}
+```
+
+---
+
+## Works with snapshots
+
+Statistics can also be configured on snapshots:
+
+```yaml title="snapshots/schema.yml"
+snapshots:
+  - name: orders_snapshot
+    config:
+      statistics: ['customer_id', 'dbt_valid_from', 'dbt_valid_to']
+```
+
+---
+
+## `statistics: true` vs explicit column list
+
+`statistics: true` creates statistics on every column in the table. This is convenient but has trade-offs:
+
+| | `statistics: true` | Explicit column list |
+|---|---|---|
+| **Convenience** | No maintenance needed | Must update when columns change |
+| **Performance** | Full scan per column — slow on wide, large tables | Only scans the columns you specify |
+| **Value** | Covers columns that don't affect query plans | Targets columns the optimizer actually uses |
+
+**Rule of thumb**: use `true` for small-to-medium tables or when simplicity matters. Use an explicit list for large tables where you want to minimize post-create overhead.
+
+---
+
+## Naming convention
+
+Statistics are named `stats__<table>__<column>` (e.g., `stats__orders__customer_id`). This avoids collisions with Fabric's auto-generated `_WA_Sys_*` statistics.
+
+---
+
+## Limitations
+
+- **Fabric Data Warehouse only** — FabricSpark (Lakehouse) uses a different statistics mechanism (`ANALYZE TABLE`) and is not supported by this config option
+- **Single-column statistics only** — Fabric Data Warehouse [does not support multi-column statistics](https://learn.microsoft.com/fabric/data-warehouse/statistics?WT.mc_id=MVP_310840#limitations)
+- **One scan method per model** — all columns in a model use the same `FULLSCAN` or `SAMPLE` setting; for per-column control, use post-hooks

--- a/src/dbt/adapters/fabric/fabric_configs.py
+++ b/src/dbt/adapters/fabric/fabric_configs.py
@@ -7,3 +7,5 @@ from dbt.adapters.protocol import AdapterConfig
 class FabricConfigs(AdapterConfig):
     auto_provision_aad_principals: bool | None = False
     cluster_by: str | list[str] | None = None
+    statistics: bool | str | list[str] | None = None
+    statistics_sample_percent: int | None = None

--- a/src/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
@@ -102,7 +102,7 @@
 
   {# Add constraints including FK relation #}
   {{ build_model_constraints(target_relation) }}
-  {{ create_or_update_statistics(target_relation) }}
+  {{ create_or_update_statistics(target_relation, existing_table=true) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/src/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
@@ -102,6 +102,7 @@
 
   {# Add constraints including FK relation #}
   {{ build_model_constraints(target_relation) }}
+  {{ create_or_update_statistics(target_relation) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/src/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
@@ -102,7 +102,7 @@
 
   {# Add constraints including FK relation #}
   {{ build_model_constraints(target_relation) }}
-  {{ create_or_update_statistics(target_relation, existing_table=true) }}
+  {{ create_or_update_statistics(target_relation, existing_table=(existing_relation is not none and not full_refresh_mode)) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
@@ -1,11 +1,11 @@
-{% macro create_or_update_statistics(relation) %}
-    {{ return(adapter.dispatch('create_or_update_statistics', 'dbt')(relation)) }}
+{% macro create_or_update_statistics(relation, existing_table=false) %}
+    {{ return(adapter.dispatch('create_or_update_statistics', 'dbt')(relation, existing_table)) }}
 {% endmacro %}
 
-{% macro default__create_or_update_statistics(relation) %}
+{% macro default__create_or_update_statistics(relation, existing_table=false) %}
 {% endmacro %}
 
-{% macro fabric__create_or_update_statistics(relation) %}
+{% macro fabric__create_or_update_statistics(relation, existing_table=false) %}
     {%- set statistics = config.get('statistics') -%}
     {%- if statistics is none or statistics is false -%}
         {{ return('') }}
@@ -41,6 +41,7 @@
         {%- set quoted_col = '[' ~ col | replace(']', ']]') ~ ']' -%}
 
         {% call statement('create_or_update_statistics_' ~ loop.index) %}
+            {%- if existing_table %}
             IF EXISTS (
                 SELECT 1 FROM sys.stats
                 WHERE name = N'{{ stats_name_escaped }}'
@@ -48,6 +49,7 @@
             )
                 UPDATE STATISTICS {{ relation_fqn }} {{ quoted_stats_name }} {{ with_clause }}
             ELSE
+            {%- endif %}
                 CREATE STATISTICS {{ quoted_stats_name }}
                 ON {{ relation_fqn }} ({{ quoted_col }}) {{ with_clause }}
         {% endcall %}

--- a/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
@@ -35,7 +35,7 @@
     {%- set relation_fqn_escaped = relation_fqn | replace("'", "''") -%}
 
     {%- for col in column_names -%}
-        {%- set stats_name = 'dbt_stats__' ~ relation.identifier[:55] ~ '__' ~ col[:55] -%}
+        {%- set stats_name = 'dbt_stats__' ~ local_md5(relation.identifier ~ '__' ~ col) -%}
         {%- set stats_name_escaped = stats_name | replace("'", "''") -%}
         {%- set quoted_stats_name = '[' ~ stats_name | replace(']', ']]') ~ ']' -%}
         {%- set quoted_col = '[' ~ col | replace(']', ']]') ~ ']' -%}

--- a/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
@@ -23,23 +23,28 @@
     {%- endif -%}
 
     {%- if statistics_sample_percent is not none -%}
-        {%- set with_clause = "WITH SAMPLE " ~ statistics_sample_percent ~ " PERCENT" -%}
+        {%- if statistics_sample_percent is not number or statistics_sample_percent < 1 or statistics_sample_percent > 100 -%}
+            {% do exceptions.raise_compiler_error("statistics_sample_percent must be a number between 1 and 100, got: " ~ statistics_sample_percent) %}
+        {%- endif -%}
+        {%- set with_clause = "WITH SAMPLE " ~ statistics_sample_percent | int ~ " PERCENT" -%}
     {%- else -%}
         {%- set with_clause = "WITH FULLSCAN" -%}
     {%- endif -%}
 
     {%- set relation_fqn = relation.render() -%}
+    {%- set relation_fqn_escaped = relation_fqn | replace("'", "''") -%}
 
     {%- for col in column_names -%}
-        {%- set stats_name = 'stats__' ~ relation.identifier ~ '__' ~ col -%}
+        {%- set stats_name = ('stats__' ~ relation.identifier ~ '__' ~ col)[:128] -%}
+        {%- set stats_name_escaped = stats_name | replace("'", "''") -%}
         {%- set quoted_stats_name = '[' ~ stats_name | replace(']', ']]') ~ ']' -%}
         {%- set quoted_col = '[' ~ col | replace(']', ']]') ~ ']' -%}
 
         {% call statement('create_or_update_statistics_' ~ loop.index) %}
             IF EXISTS (
                 SELECT 1 FROM sys.stats
-                WHERE name = N'{{ stats_name }}'
-                AND object_id = OBJECT_ID(N'{{ relation_fqn }}')
+                WHERE name = N'{{ stats_name_escaped }}'
+                AND object_id = OBJECT_ID(N'{{ relation_fqn_escaped }}')
             )
                 UPDATE STATISTICS {{ relation_fqn }} {{ quoted_stats_name }} {{ with_clause }}
             ELSE

--- a/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
@@ -35,7 +35,7 @@
     {%- set relation_fqn_escaped = relation_fqn | replace("'", "''") -%}
 
     {%- for col in column_names -%}
-        {%- set stats_name = ('stats__' ~ relation.identifier ~ '__' ~ col)[:128] -%}
+        {%- set stats_name = 'dbt_stats__' ~ relation.identifier[:55] ~ '__' ~ col[:55] -%}
         {%- set stats_name_escaped = stats_name | replace("'", "''") -%}
         {%- set quoted_stats_name = '[' ~ stats_name | replace(']', ']]') ~ ']' -%}
         {%- set quoted_col = '[' ~ col | replace(']', ']]') ~ ']' -%}

--- a/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/statistics.sql
@@ -1,0 +1,50 @@
+{% macro create_or_update_statistics(relation) %}
+    {{ return(adapter.dispatch('create_or_update_statistics', 'dbt')(relation)) }}
+{% endmacro %}
+
+{% macro default__create_or_update_statistics(relation) %}
+{% endmacro %}
+
+{% macro fabric__create_or_update_statistics(relation) %}
+    {%- set statistics = config.get('statistics') -%}
+    {%- if statistics is none or statistics is false -%}
+        {{ return('') }}
+    {%- endif -%}
+
+    {%- set statistics_sample_percent = config.get('statistics_sample_percent') -%}
+
+    {%- if statistics is true -%}
+        {%- set columns = adapter.get_columns_in_relation(relation) -%}
+        {%- set column_names = columns | map(attribute='name') | list -%}
+    {%- elif statistics is string -%}
+        {%- set column_names = [statistics] -%}
+    {%- else -%}
+        {%- set column_names = statistics -%}
+    {%- endif -%}
+
+    {%- if statistics_sample_percent is not none -%}
+        {%- set with_clause = "WITH SAMPLE " ~ statistics_sample_percent ~ " PERCENT" -%}
+    {%- else -%}
+        {%- set with_clause = "WITH FULLSCAN" -%}
+    {%- endif -%}
+
+    {%- set relation_fqn = relation.render() -%}
+
+    {%- for col in column_names -%}
+        {%- set stats_name = 'stats__' ~ relation.identifier ~ '__' ~ col -%}
+        {%- set quoted_stats_name = '[' ~ stats_name | replace(']', ']]') ~ ']' -%}
+        {%- set quoted_col = '[' ~ col | replace(']', ']]') ~ ']' -%}
+
+        {% call statement('create_or_update_statistics_' ~ loop.index) %}
+            IF EXISTS (
+                SELECT 1 FROM sys.stats
+                WHERE name = N'{{ stats_name }}'
+                AND object_id = OBJECT_ID(N'{{ relation_fqn }}')
+            )
+                UPDATE STATISTICS {{ relation_fqn }} {{ quoted_stats_name }} {{ with_clause }}
+            ELSE
+                CREATE STATISTICS {{ quoted_stats_name }}
+                ON {{ relation_fqn }} ({{ quoted_col }}) {{ with_clause }}
+        {% endcall %}
+    {%- endfor -%}
+{% endmacro %}

--- a/src/dbt/include/fabric/macros/materializations/models/table/table.sql
+++ b/src/dbt/include/fabric/macros/materializations/models/table/table.sql
@@ -59,6 +59,7 @@
 
   {# Add constraints including FK relation. #}
   {{ build_model_constraints(target_relation) }}
+  {{ create_or_update_statistics(target_relation) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/src/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
@@ -109,6 +109,7 @@
       {% do post_snapshot(staging_table) %}
   {% endif %}
 
+  {{ create_or_update_statistics(target_relation) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/src/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
@@ -109,7 +109,7 @@
       {% do post_snapshot(staging_table) %}
   {% endif %}
 
-  {{ create_or_update_statistics(target_relation) }}
+  {{ create_or_update_statistics(target_relation, existing_table=true) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/src/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
+++ b/src/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
@@ -109,7 +109,7 @@
       {% do post_snapshot(staging_table) %}
   {% endif %}
 
-  {{ create_or_update_statistics(target_relation, existing_table=true) }}
+  {{ create_or_update_statistics(target_relation, existing_table=target_relation_exists) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/tests/fabric/adapter/test_statistics.py
+++ b/tests/fabric/adapter/test_statistics.py
@@ -1,0 +1,145 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_sql_with_adapter
+
+model_stats_specific = """
+{{ config(materialized='table', statistics=['id', 'color']) }}
+select 1 as id, 'blue' as color, cast('2024-01-01' as date) as date_day
+"""
+
+model_stats_all = """
+{{ config(materialized='table', statistics=true) }}
+select 1 as id, 'blue' as color
+"""
+
+model_stats_none = """
+{{ config(materialized='table') }}
+select 1 as id, 'blue' as color
+"""
+
+model_stats_sample = """
+{{ config(materialized='table', statistics=['id'], statistics_sample_percent=50) }}
+select 1 as id, 'blue' as color
+"""
+
+model_stats_single_string = """
+{{ config(materialized='table', statistics='id') }}
+select 1 as id, 'blue' as color
+"""
+
+model_stats_incremental = """
+{{ config(materialized='incremental', statistics=['id', 'color'], unique_key='id') }}
+select 1 as id, 'blue' as color
+"""
+
+
+def _get_stats_names(project, adapter, table_name):
+    schema = project.test_schema
+    sql = f"""
+        SELECT s.name
+        FROM sys.stats s
+        WHERE s.object_id = OBJECT_ID(N'{schema}.{table_name}')
+          AND s.name LIKE 'stats\\_\\_%' ESCAPE '\\'
+        ORDER BY s.name
+    """
+    result = run_sql_with_adapter(adapter, sql, fetch="all")
+    return [row[0] for row in result]
+
+
+class TestStatisticsSpecificColumns:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_stats.sql": model_stats_specific}
+
+    def test_statistics_specific_columns(self, project, adapter):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_stats")
+        assert "stats__model_stats__id" in stats
+        assert "stats__model_stats__color" in stats
+        assert len(stats) == 2
+
+
+class TestStatisticsAllColumns:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_stats_all.sql": model_stats_all}
+
+    def test_statistics_all_columns(self, project, adapter):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_stats_all")
+        assert "stats__model_stats_all__id" in stats
+        assert "stats__model_stats_all__color" in stats
+        assert len(stats) == 2
+
+
+class TestStatisticsNone:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_no_stats.sql": model_stats_none}
+
+    def test_no_statistics(self, project, adapter):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_no_stats")
+        assert len(stats) == 0
+
+
+class TestStatisticsSamplePercent:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_stats_sample.sql": model_stats_sample}
+
+    def test_statistics_sample_percent(self, project, adapter):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_stats_sample")
+        assert "stats__model_stats_sample__id" in stats
+        assert len(stats) == 1
+
+
+class TestStatisticsSingleString:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_stats_str.sql": model_stats_single_string}
+
+    def test_statistics_single_string(self, project, adapter):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_stats_str")
+        assert "stats__model_stats_str__id" in stats
+        assert len(stats) == 1
+
+
+class TestStatisticsIncremental:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_stats_incr.sql": model_stats_incremental}
+
+    def test_statistics_incremental(self, project, adapter):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_stats_incr")
+        assert "stats__model_stats_incr__id" in stats
+        assert "stats__model_stats_incr__color" in stats
+
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "model_stats_incr")
+        assert "stats__model_stats_incr__id" in stats
+        assert "stats__model_stats_incr__color" in stats

--- a/tests/fabric/adapter/test_statistics.py
+++ b/tests/fabric/adapter/test_statistics.py
@@ -32,6 +32,24 @@ model_stats_incremental = """
 select 1 as id, 'blue' as color
 """
 
+seed_snapshot_source_csv = """id,name,updated_at
+1,Alice,2024-01-01 00:00:00
+2,Bob,2024-01-01 00:00:00
+""".lstrip()
+
+snapshot_with_stats_yml = """
+snapshots:
+  - name: snapshot_with_stats
+    relation: "ref('snapshot_source')"
+    config:
+      strategy: timestamp
+      unique_key: id
+      updated_at: updated_at
+      statistics:
+        - id
+        - name
+"""
+
 
 def _get_stats_names(project, adapter, table_name):
     schema = project.test_schema
@@ -143,3 +161,24 @@ class TestStatisticsIncremental:
         stats = _get_stats_names(project, adapter, "model_stats_incr")
         assert "stats__model_stats_incr__id" in stats
         assert "stats__model_stats_incr__color" in stats
+
+
+class TestStatisticsSnapshot:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"snapshot_source.csv": seed_snapshot_source_csv}
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"snapshot_with_stats.yml": snapshot_with_stats_yml}
+
+    def test_statistics_snapshot(self, project, adapter):
+        run_dbt(["seed"])
+        results = run_dbt(["snapshot"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        stats = _get_stats_names(project, adapter, "snapshot_with_stats")
+        assert "stats__snapshot_with_stats__id" in stats
+        assert "stats__snapshot_with_stats__name" in stats
+        assert len(stats) == 2

--- a/tests/fabric/adapter/test_statistics.py
+++ b/tests/fabric/adapter/test_statistics.py
@@ -75,8 +75,8 @@ class TestStatisticsSpecificColumns:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats")
-        assert "dbt_stats__model_stats__id" in stats
-        assert "dbt_stats__model_stats__color" in stats
+        assert "dbt_stats__654860f237c1a1100a59e92e008491e3" in stats
+        assert "dbt_stats__0db04178af0265b62f71f904912ae5ba" in stats
         assert len(stats) == 2
 
 
@@ -91,8 +91,8 @@ class TestStatisticsAllColumns:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_all")
-        assert "dbt_stats__model_stats_all__id" in stats
-        assert "dbt_stats__model_stats_all__color" in stats
+        assert "dbt_stats__22093bb7ed4a4384b9485ced909caa35" in stats
+        assert "dbt_stats__c8cf7ff4d87ba0b890fb58b852ea5d3e" in stats
         assert len(stats) == 2
 
 
@@ -121,7 +121,7 @@ class TestStatisticsSamplePercent:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_sample")
-        assert "dbt_stats__model_stats_sample__id" in stats
+        assert "dbt_stats__3a3d26900c39f6332a0083830a72f388" in stats
         assert len(stats) == 1
 
 
@@ -136,7 +136,7 @@ class TestStatisticsSingleString:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_str")
-        assert "dbt_stats__model_stats_str__id" in stats
+        assert "dbt_stats__c890bde6fdccca0839fe9e66745c66bb" in stats
         assert len(stats) == 1
 
 
@@ -151,16 +151,16 @@ class TestStatisticsIncremental:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_incr")
-        assert "dbt_stats__model_stats_incr__id" in stats
-        assert "dbt_stats__model_stats_incr__color" in stats
+        assert "dbt_stats__8688dd6b37d7c41f2c99346fa4ecf5f9" in stats
+        assert "dbt_stats__dd605aa100cc243ea28fd7744e7508a3" in stats
 
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_incr")
-        assert "dbt_stats__model_stats_incr__id" in stats
-        assert "dbt_stats__model_stats_incr__color" in stats
+        assert "dbt_stats__8688dd6b37d7c41f2c99346fa4ecf5f9" in stats
+        assert "dbt_stats__dd605aa100cc243ea28fd7744e7508a3" in stats
 
 
 class TestStatisticsSnapshot:
@@ -179,6 +179,6 @@ class TestStatisticsSnapshot:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "snapshot_with_stats")
-        assert "dbt_stats__snapshot_with_stats__id" in stats
-        assert "dbt_stats__snapshot_with_stats__name" in stats
+        assert "dbt_stats__d8bf1e35d81c82e7363466b42a43a51e" in stats
+        assert "dbt_stats__2241f3897afe01e76defbd12d39e9578" in stats
         assert len(stats) == 2

--- a/tests/fabric/adapter/test_statistics.py
+++ b/tests/fabric/adapter/test_statistics.py
@@ -57,7 +57,7 @@ def _get_stats_names(project, adapter, table_name):
         SELECT s.name
         FROM sys.stats s
         WHERE s.object_id = OBJECT_ID(N'{schema}.{table_name}')
-          AND s.name LIKE 'stats\\_\\_%' ESCAPE '\\'
+          AND s.name LIKE 'dbt\\_stats\\_\\_%' ESCAPE '\\'
         ORDER BY s.name
     """
     result = run_sql_with_adapter(adapter, sql, fetch="all")
@@ -75,8 +75,8 @@ class TestStatisticsSpecificColumns:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats")
-        assert "stats__model_stats__id" in stats
-        assert "stats__model_stats__color" in stats
+        assert "dbt_stats__model_stats__id" in stats
+        assert "dbt_stats__model_stats__color" in stats
         assert len(stats) == 2
 
 
@@ -91,8 +91,8 @@ class TestStatisticsAllColumns:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_all")
-        assert "stats__model_stats_all__id" in stats
-        assert "stats__model_stats_all__color" in stats
+        assert "dbt_stats__model_stats_all__id" in stats
+        assert "dbt_stats__model_stats_all__color" in stats
         assert len(stats) == 2
 
 
@@ -121,7 +121,7 @@ class TestStatisticsSamplePercent:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_sample")
-        assert "stats__model_stats_sample__id" in stats
+        assert "dbt_stats__model_stats_sample__id" in stats
         assert len(stats) == 1
 
 
@@ -136,7 +136,7 @@ class TestStatisticsSingleString:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_str")
-        assert "stats__model_stats_str__id" in stats
+        assert "dbt_stats__model_stats_str__id" in stats
         assert len(stats) == 1
 
 
@@ -151,16 +151,16 @@ class TestStatisticsIncremental:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_incr")
-        assert "stats__model_stats_incr__id" in stats
-        assert "stats__model_stats_incr__color" in stats
+        assert "dbt_stats__model_stats_incr__id" in stats
+        assert "dbt_stats__model_stats_incr__color" in stats
 
         results = run_dbt(["run"])
         assert len(results) == 1
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "model_stats_incr")
-        assert "stats__model_stats_incr__id" in stats
-        assert "stats__model_stats_incr__color" in stats
+        assert "dbt_stats__model_stats_incr__id" in stats
+        assert "dbt_stats__model_stats_incr__color" in stats
 
 
 class TestStatisticsSnapshot:
@@ -179,6 +179,6 @@ class TestStatisticsSnapshot:
         assert results[0].status == "success"
 
         stats = _get_stats_names(project, adapter, "snapshot_with_stats")
-        assert "stats__snapshot_with_stats__id" in stats
-        assert "stats__snapshot_with_stats__name" in stats
+        assert "dbt_stats__snapshot_with_stats__id" in stats
+        assert "dbt_stats__snapshot_with_stats__name" in stats
         assert len(stats) == 2

--- a/zensical.toml
+++ b/zensical.toml
@@ -34,6 +34,7 @@ nav = [
     { "Lakehouse (Spark SQL)" = "lakehouse.md" },
     { "Microsoft Purview integration" = "purview-integration.md" },
     { "CLUSTER BY" = "cluster-by.md" },
+    { "Statistics" = "statistics.md" },
     { "Python models" = "python-models.md" },
     { "Warehouse snapshots" = "warehouse-snapshots.md" },
     { "External tables" = "external-tables.md" },


### PR DESCRIPTION
## Summary

- Adds `statistics` and `statistics_sample_percent` config options to `FabricConfigs`
- Creates `create_or_update_statistics` macro that generates `CREATE STATISTICS` / `UPDATE STATISTICS` DDL per column, using `sys.stats` to decide which operation
- Integrates the macro into table, incremental, and snapshot materializations (runs after table creation/merge, outside the transaction)
- Supports `statistics: true` (all columns), a single string, or a list of column names
- Defaults to `FULLSCAN`; optional `statistics_sample_percent` switches to `WITH SAMPLE N PERCENT`
- Adds integration tests covering specific columns, all columns, no statistics, sample percent, single string, and incremental models
- Adds documentation page with usage examples, sampling, incremental/snapshot support, and limitations

Closes #166

## Test plan

- [x] Run `uv run pytest -k "TestStatistics" --dw` to verify all statistics test classes pass
- [x] Verify statistics appear in `sys.stats` after model runs
- [x] Verify incremental second run uses UPDATE STATISTICS (not CREATE)
- [x] Verify no statistics created when config is absent
- [x] Run `uv run zensical build --strict` to verify docs build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)