### PR TITLE
Add remote Spark test orchestration framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,10 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,linux,visualstudiocode,python
 test.env
+test.env.remote
+requirements-remote.txt
+dbt-test-artifacts/
+remote-test-results/
 docs_build/site
 .claude/*
 !.claude/skills/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,33 @@ uv run pytest --with-grants          # Include GRANT/authorization tests
 uv run pytest -k "TestClassName"     # A specific test class
 ```
 
+### Remote Spark test execution
+
+FabricSpark tests normally run via a local Livy session. The `--remote` flag delegates test execution to a Spark Job Definition on Fabric infrastructure instead. Locally, pytest collects tests as usual, but instead of executing them it syncs the project to a lakehouse via azcopy and submits a Spark job that runs the tests remotely. Results are downloaded as junitxml and reported back in the local pytest session.
+
+```shell
+uv run pytest --de --remote -k "TestClassName"   # Run a specific test remotely
+uv run pytest --de --remote                      # Run all DE tests remotely
+```
+
+`--remote` requires `--de` — it only applies to FabricSpark tests.
+
+#### Prerequisites
+
+1. [azcopy](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?WT.mc_id=MVP_310840) installed and on your `PATH`
+2. Azure credentials (`az login` or service principal configured in `test.env`)
+3. A Spark Job Definition in the Fabric workspace (the name is configurable via `FABRIC_TEST_SPARK_JOB_NAME`, default: `dbt-fabric-tests`)
+
+#### Optional environment variables
+
+| Variable | Description |
+|---|---|
+| `FABRIC_TEST_SPARK_EXEC_MODE` | `remote` or `mounted` (default: local execution when omitted) |
+| `FABRIC_TEST_ONELAKE_PATH` | Local mount path for OneLake (required for `mounted` mode) |
+| `FABRIC_TEST_SPARK_JOB_NAME` | Spark Job Definition display name (default: `dbt-fabric-tests`) |
+
+The remote orchestrator reuses `FABRIC_TEST_WORKSPACE_NAME` and `FABRIC_TEST_LAKEHOUSE_NAME` from `test.env` and resolves their IDs via the Fabric API — no separate ID variables are needed.
+
 ### Test architecture
 
 Tests use [dbt-tests-adapter](https://github.com/dbt-labs/dbt-adapters), dbt's official adapter test harness. It provides base test classes for standard adapter behavior. Our tests inherit from these and override fixtures where Fabric's SQL dialect differs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dev = [
     "dbt-core>=1.9.6,<1.13.0",
     "dbt-tests-adapter>=1.19.7,<2.0",
     # Linting & formatting
-    "ruff>=0.15.1"
+    "ruff>=0.15.1",
+    "junitparser>=5.0.0",
 ]
 docs = [
     "zensical>=0.0.41",

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -104,18 +104,6 @@ class FabricApiClient:
         """Send an authenticated DELETE request with 429 retry."""
         return self._api_request(url, method="delete")
 
-    def _api_get(self, url: str) -> requests.Response:
-        return self.api_get(url)
-
-    def _api_post(self, url: str, body: dict) -> requests.Response:
-        return self.api_post(url, body)
-
-    def _api_patch(self, url: str, body: dict) -> requests.Response:
-        return self.api_patch(url, body)
-
-    def _api_delete(self, url: str) -> requests.Response:
-        return self.api_delete(url)
-
     def get_workspace_id(self) -> str:
         """Resolve the Fabric workspace ID from config or by looking up the workspace name.
 
@@ -137,7 +125,7 @@ class FabricApiClient:
 
         query_param = f"name eq '{self._credentials.workspace_name}'"
         query_param_encoded = urllib.parse.quote_plus(query_param)
-        response = self._api_get(
+        response = self.api_get(
             f"{self._credentials.powerbi_base_api_uri}/myorg/groups?$filter={query_param_encoded}"
         )
         workspaces = response.json().get("value", [])
@@ -167,7 +155,7 @@ class FabricApiClient:
         warehouses = []
 
         while url is not None:
-            response = self._api_get(url)
+            response = self.api_get(url)
             warehouses = warehouses + response.json().get("value", [])
             url = response.json().get("continuationUri", None) if fetch_all else None
 
@@ -191,7 +179,7 @@ class FabricApiClient:
         lakehouses = []
 
         while url is not None:
-            response = self._api_get(url)
+            response = self.api_get(url)
             lakehouses = lakehouses + response.json().get("value", [])
             url = response.json().get("continuationUri", None) if fetch_all else None
 
@@ -283,7 +271,7 @@ class FabricApiClient:
         snapshots = []
 
         while url is not None:
-            response = self._api_get(url)
+            response = self.api_get(url)
             for snapshot in response.json().get("value", []):
                 parent_warehouse_id = snapshot.get("properties", {}).get("parentWarehouseId")
                 if parent_warehouse_id == warehouse_id:
@@ -314,7 +302,7 @@ class FabricApiClient:
         if description is not None:
             body["description"] = description
 
-        response = self._api_post(
+        response = self.api_post(
             url,
             body,
         )
@@ -342,7 +330,7 @@ class FabricApiClient:
         body: dict[str, Any] = {"properties": {}}
         if description is not None:
             body["description"] = description
-        response = self._api_patch(url, body)
+        response = self.api_patch(url, body)
 
         # Spec documents 200, but in practice updates sometimes return 202 (LRO)
         location_uri = response.headers.get("Location")
@@ -367,13 +355,13 @@ class FabricApiClient:
                     f"to complete after {timeout} seconds."
                 )
 
-            response = self._api_get(operation_uri)
+            response = self.api_get(operation_uri)
             operation_status = response.json().get("status", "Unknown")
             retry_sleep = int(response.headers.get("Retry-After", 5))
 
             if operation_status == "Succeeded":
                 result_location = response.headers["Location"]
-                result_response = self._api_get(result_location)
+                result_response = self.api_get(result_location)
                 return result_response.json()["id"]
 
             if operation_status not in ("NotStarted", "Running"):
@@ -422,7 +410,7 @@ class FabricApiClient:
         """
         for snapshot in self.get_warehouse_snapshots():
             if snapshot["displayName"] == snapshot_name:
-                self._api_delete(
+                self.api_delete(
                     f"{self._credentials.fabric_base_api_uri}/workspaces/{self.get_workspace_id()}/warehouseSnapshots/{snapshot['id']}"
                 )
 
@@ -450,7 +438,7 @@ class FabricApiClient:
             "sessionTag": session_tag,
             "name": self._credentials.livy_session_name,
         }
-        response = self._api_post(url, body)
+        response = self.api_post(url, body)
         return response.json()
 
     def get_hc_session(self, hc_id: str) -> dict[str, Any]:
@@ -460,7 +448,7 @@ class FabricApiClient:
             JSON with ``state``, and when idle also ``sessionId`` and ``replId``.
         """
         url = self.get_livy_base_api_uri() + f"/highConcurrencySessions/{hc_id}"
-        response = self._api_get(url)
+        response = self.api_get(url)
         return response.json()
 
     def submit_hc_sql_statement(self, livy_session_id: str, repl_id: str, code: str) -> int:
@@ -470,7 +458,7 @@ class FabricApiClient:
             + f"/highConcurrencySessions/{livy_session_id}"
             + f"/repls/{repl_id}/statements"
         )
-        response = self._api_post(url, {"code": code, "kind": "sql"})
+        response = self.api_post(url, {"code": code, "kind": "sql"})
         return response.json()["id"]
 
     def submit_hc_python_statement(self, livy_session_id: str, repl_id: str, code: str) -> int:
@@ -480,7 +468,7 @@ class FabricApiClient:
             + f"/highConcurrencySessions/{livy_session_id}"
             + f"/repls/{repl_id}/statements"
         )
-        response = self._api_post(url, {"code": code, "kind": "pyspark"})
+        response = self.api_post(url, {"code": code, "kind": "pyspark"})
         return response.json()["id"]
 
     def get_hc_statement(
@@ -492,7 +480,7 @@ class FabricApiClient:
             + f"/highConcurrencySessions/{livy_session_id}"
             + f"/repls/{repl_id}/statements/{statement_id}"
         )
-        response = self._api_get(url)
+        response = self.api_get(url)
         return response.json()
 
     def cancel_hc_statement(self, livy_session_id: str, repl_id: str, statement_id: int) -> str:
@@ -502,14 +490,14 @@ class FabricApiClient:
             + f"/highConcurrencySessions/{livy_session_id}"
             + f"/repls/{repl_id}/statements/{statement_id}/cancel"
         )
-        response = self._api_post(url, {})
+        response = self.api_post(url, {})
         return response.json()["msg"]
 
     def delete_hc_session(self, hc_id: str) -> None:
         """Release an HC session (REPL slot). Best-effort; ignores 404."""
         url = self.get_livy_base_api_uri() + f"/highConcurrencySessions/{hc_id}"
         try:
-            self._api_delete(url)
+            self.api_delete(url)
         except FabricApiError as e:
             if e.status_code != 404:
                 raise

--- a/src/dbt/adapters/fabric/fabric_api_client.py
+++ b/src/dbt/adapters/fabric/fabric_api_client.py
@@ -83,17 +83,38 @@ class FabricApiClient:
             raise FabricApiError(method, url, response.status_code, response.text)
         return response
 
-    def _api_get(self, url: str) -> requests.Response:
+    @property
+    def base_url(self) -> str:
+        """The Fabric REST API base URL from credentials."""
+        return self._credentials.fabric_base_api_uri
+
+    def api_get(self, url: str) -> requests.Response:
+        """Send an authenticated GET request with 429 retry."""
         return self._api_request(url, method="get")
 
-    def _api_post(self, url: str, body: dict) -> requests.Response:
+    def api_post(self, url: str, body: dict) -> requests.Response:
+        """Send an authenticated POST request with 429 retry."""
         return self._api_request(url, method="post", body=body)
 
-    def _api_patch(self, url: str, body: dict) -> requests.Response:
+    def api_patch(self, url: str, body: dict) -> requests.Response:
+        """Send an authenticated PATCH request with 429 retry."""
         return self._api_request(url, method="patch", body=body)
 
-    def _api_delete(self, url: str) -> requests.Response:
+    def api_delete(self, url: str) -> requests.Response:
+        """Send an authenticated DELETE request with 429 retry."""
         return self._api_request(url, method="delete")
+
+    def _api_get(self, url: str) -> requests.Response:
+        return self.api_get(url)
+
+    def _api_post(self, url: str, body: dict) -> requests.Response:
+        return self.api_post(url, body)
+
+    def _api_patch(self, url: str, body: dict) -> requests.Response:
+        return self.api_patch(url, body)
+
+    def _api_delete(self, url: str) -> requests.Response:
+        return self.api_delete(url)
 
     def get_workspace_id(self) -> str:
         """Resolve the Fabric workspace ID from config or by looking up the workspace name.

--- a/test.env.sample
+++ b/test.env.sample
@@ -24,3 +24,8 @@ FABRIC_TEST_HOST=your-endpoint.datawarehouse.fabric.microsoft.com
 DBT_TEST_USER_1=dbo
 DBT_TEST_USER_2=dbo
 DBT_TEST_USER_3=dbo
+# Remote Spark test execution (optional, use with pytest --remote --de)
+#FABRIC_TEST_SPARK_EXEC_MODE=        # "remote" or "mounted"; empty = local (default)
+#FABRIC_TEST_ONELAKE_PATH=           # required for "mounted" mode (local mount path)
+#FABRIC_TEST_SPARK_JOB_NAME=dbt-fabric-tests  # Spark Job Definition display name
+#FABRIC_TEST_REMOTE_LAKEHOUSE_ID=00000000-0000-0000-0000-000000000000

--- a/test.env.sample
+++ b/test.env.sample
@@ -25,6 +25,7 @@ DBT_TEST_USER_1=dbo
 DBT_TEST_USER_2=dbo
 DBT_TEST_USER_3=dbo
 # Remote Spark test execution (optional, use with pytest --remote --de)
+# Requires FABRIC_TEST_WORKSPACE_ID (above) and FABRIC_TEST_REMOTE_LAKEHOUSE_ID
 #FABRIC_TEST_SPARK_EXEC_MODE=        # "remote" or "mounted"; empty = local (default)
 #FABRIC_TEST_ONELAKE_PATH=           # required for "mounted" mode (local mount path)
 #FABRIC_TEST_SPARK_JOB_NAME=dbt-fabric-tests  # Spark Job Definition display name

--- a/test.env.sample
+++ b/test.env.sample
@@ -25,8 +25,7 @@ DBT_TEST_USER_1=dbo
 DBT_TEST_USER_2=dbo
 DBT_TEST_USER_3=dbo
 # Remote Spark test execution (optional, use with pytest --remote --de)
-# Requires FABRIC_TEST_WORKSPACE_ID (above) and FABRIC_TEST_REMOTE_LAKEHOUSE_ID
+# Uses FABRIC_TEST_WORKSPACE_NAME/ID and FABRIC_TEST_LAKEHOUSE_NAME from above
 #FABRIC_TEST_SPARK_EXEC_MODE=        # "remote" or "mounted"; empty = local (default)
 #FABRIC_TEST_ONELAKE_PATH=           # required for "mounted" mode (local mount path)
 #FABRIC_TEST_SPARK_JOB_NAME=dbt-fabric-tests  # Spark Job Definition display name
-#FABRIC_TEST_REMOTE_LAKEHOUSE_ID=00000000-0000-0000-0000-000000000000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,9 @@ def _on_fabric_project_base() -> Path | None:
     elif mode == "mounted":
         path = os.getenv("FABRIC_TEST_ONELAKE_PATH")
         if not path:
-            raise ValueError("FABRIC_TEST_ONELAKE_PATH required when SPARK_EXEC_MODE=mounted")
+            raise ValueError(
+                "FABRIC_TEST_ONELAKE_PATH required when FABRIC_TEST_SPARK_EXEC_MODE=mounted"
+            )
         return Path(path) / "dbt-test-artifacts"
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,11 @@ def dbt_profile_target(dbt_profile_target_update, adapter_type: str, prefix: str
         **_auth_kwargs_from_env(),
     }
 
+    if base_api_uri := os.getenv("FABRIC_TEST_BASE_API_URI"):
+        target["fabric_base_api_uri"] = base_api_uri
+    if powerbi_api_uri := os.getenv("FABRIC_TEST_POWERBI_BASE_API_URI"):
+        target["powerbi_base_api_uri"] = powerbi_api_uri
+
     if adapter_type == "fabric":
         adapter_settings = {
             "type": "fabric",
@@ -121,9 +126,7 @@ def _requires_spark(collection_path, tests_root):
         return False
     if parts[0] == "fabricspark":
         return True
-    if "fabricspark" in collection_path.name:
-        return True
-    return False
+    return "fabricspark" in collection_path.name
 
 
 @functools.lru_cache(maxsize=1)
@@ -144,20 +147,22 @@ def pytest_ignore_collect(collection_path, config):
 
     top_dir = parts[0]
 
-    if config.getoption("--dw", default=False):
-        if _requires_spark(collection_path, tests_root):
-            return True
+    if config.getoption("--dw", default=False) and _requires_spark(collection_path, tests_root):
+        return True
     if config.getoption("--de", default=False) and top_dir == "fabric":
         return True
 
     if _requires_spark(collection_path, tests_root) and not _spark_extra_available():
-        if config.getoption("--de", default=False):
+        if config.getoption("--remote", default=False):
+            pass
+        elif config.getoption("--de", default=False):
             pytest.exit(
                 "The spark extra is required for FabricSpark tests. "
                 "Install with: uv sync --extra spark",
                 returncode=4,
             )
-        return True
+        else:
+            return True
 
     return None
 
@@ -246,7 +251,11 @@ def profiles_root(tmpdir_factory, prefix):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def livy_session_lifecycle():
+def livy_session_lifecycle(request):
+    if request.config.getoption("--remote", default=False):
+        yield
+        return
+
     session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
     lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
     workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
@@ -329,7 +338,7 @@ def project(
                     where lower(s.name) = '{self.test_schema.lower()}'
                     """
             result = self.run_sql(sql, fetch="all")
-            return {model_name: materialization for (model_name, materialization) in result}
+            return dict(result)
 
     return TestProjInfoFabric(
         project_root=project_setup.project_root,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import importlib.util
 import os
 from pathlib import Path
 
+import py
 import pytest
 import yaml
 
@@ -49,11 +50,6 @@ def dbt_profile_target(dbt_profile_target_update, adapter_type: str, prefix: str
         "threads": int(os.getenv("FABRIC_TEST_THREADS", 10)),
         **_auth_kwargs_from_env(),
     }
-
-    if base_api_uri := os.getenv("FABRIC_TEST_BASE_API_URI"):
-        target["fabric_base_api_uri"] = base_api_uri
-    if powerbi_api_uri := os.getenv("FABRIC_TEST_POWERBI_BASE_API_URI"):
-        target["powerbi_base_api_uri"] = powerbi_api_uri
 
     if adapter_type == "fabric":
         adapter_settings = {
@@ -102,6 +98,12 @@ def pytest_addoption(parser):
     parser.addoption(
         "--dw", action="store_true", default=False, help="run only Fabric T-SQL tests"
     )
+    parser.addoption(
+        "--remote",
+        action="store_true",
+        default=False,
+        help="Run FabricSpark tests as a remote Spark job on Fabric infrastructure",
+    )
 
 
 def pytest_configure(config):
@@ -119,7 +121,9 @@ def _requires_spark(collection_path, tests_root):
         return False
     if parts[0] == "fabricspark":
         return True
-    return "fabricspark" in collection_path.name
+    if "fabricspark" in collection_path.name:
+        return True
+    return False
 
 
 @functools.lru_cache(maxsize=1)
@@ -140,12 +144,13 @@ def pytest_ignore_collect(collection_path, config):
 
     top_dir = parts[0]
 
-    if config.getoption("--dw", default=False) and _requires_spark(collection_path, tests_root):
-        return True
+    if config.getoption("--dw", default=False):
+        if _requires_spark(collection_path, tests_root):
+            return True
     if config.getoption("--de", default=False) and top_dir == "fabric":
         return True
 
-    if _requires_spark(collection_path, tests_root) and not _spark_extra_available():  # noqa: SIM102
+    if _requires_spark(collection_path, tests_root) and not _spark_extra_available():
         if config.getoption("--de", default=False):
             pytest.exit(
                 "The spark extra is required for FabricSpark tests. "
@@ -193,12 +198,98 @@ def pytest_collection_modifyitems(config, items):
             )
 
 
+def _on_fabric_project_base() -> Path | None:
+    mode = os.getenv("FABRIC_TEST_SPARK_EXEC_MODE", "").lower()
+    if mode == "remote":
+        return Path("/lakehouse/default/Files/dbt-test-artifacts")
+    elif mode == "mounted":
+        path = os.getenv("FABRIC_TEST_ONELAKE_PATH")
+        if not path:
+            raise ValueError("FABRIC_TEST_ONELAKE_PATH required when SPARK_EXEC_MODE=mounted")
+        return Path(path) / "dbt-test-artifacts"
+    return None
+
+
+def pytest_runtestloop(session):
+    if not session.config.getoption("--remote", default=False):
+        return None
+    if not session.config.getoption("--de", default=False):
+        pytest.exit("--remote requires --de (FabricSpark tests only)", returncode=4)
+    from tests.spark_remote.conftest_plugin import remote_runtestloop
+
+    return remote_runtestloop(session)
+
+
+@pytest.fixture(scope="class")
+def project_root(tmpdir_factory, prefix):
+    base = _on_fabric_project_base()
+    if base is None:
+        project_root = tmpdir_factory.mktemp("project")
+        print(f"\n=== Test project_root: {project_root}")
+        return project_root
+    path = base / prefix / "project"
+    path.mkdir(parents=True, exist_ok=True)
+    print(f"\n=== Test project_root: {path}")
+    return py.path.local(path)
+
+
+@pytest.fixture(scope="class")
+def profiles_root(tmpdir_factory, prefix):
+    base = _on_fabric_project_base()
+    if base is None:
+        return tmpdir_factory.mktemp("profile")
+    path = base / prefix / "profile"
+    path.mkdir(parents=True, exist_ok=True)
+    return py.path.local(path)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def livy_session_lifecycle():
+    session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
+    lakehouse_name = os.getenv("FABRIC_TEST_LAKEHOUSE_NAME")
+    workspace_name = os.getenv("FABRIC_TEST_WORKSPACE_NAME")
+    workspace_id = os.getenv("FABRIC_TEST_WORKSPACE_ID")
+
+    if not session_name or not lakehouse_name or not (workspace_name or workspace_id):
+        yield
+        return
+
+    from dbt.adapters.fabric.fabric_livy_session import LivySession
+
+    creds = FabricCredentials(
+        database=lakehouse_name,
+        schema="dbo",
+        lakehouse=lakehouse_name,
+        workspace_name=workspace_name,
+        workspace_id=workspace_id,
+        livy_session_name=session_name,
+        **_auth_kwargs_from_env(),
+    )
+    token_provider = FabricTokenProvider(creds)
+    client = FabricApiClient(creds, token_provider)
+
+    client.get_livy_session_id()
+    LivySession(client).wait_for_session_ready()
+
+    yield
+
+    try:
+        client.delete_livy_session()
+    except Exception as e:
+        print(f"\nWarning: failed to delete Livy session: {e}")
+
+
 @pytest.fixture(scope="class")
 def logs_dir(request, prefix):
-    dbt_log_dir = os.path.join(request.config.rootdir, "logs", prefix)
+    base = _on_fabric_project_base()
+    if base is not None:
+        dbt_log_dir = str(base / prefix / "logs")
+    else:
+        dbt_log_dir = os.path.join(request.config.rootdir, "logs", prefix)
+    os.makedirs(dbt_log_dir, exist_ok=True)
     print(f"\n=== Test logs_dir: {dbt_log_dir}\n")
-    os.environ["DBT_LOG_PATH"] = str(dbt_log_dir)
-    yield str(Path(dbt_log_dir))
+    os.environ["DBT_LOG_PATH"] = dbt_log_dir
+    yield dbt_log_dir
     del os.environ["DBT_LOG_PATH"]
 
 
@@ -236,7 +327,7 @@ def project(
                     where lower(s.name) = '{self.test_schema.lower()}'
                     """
             result = self.run_sql(sql, fetch="all")
-            return dict(result)
+            return {model_name: materialization for (model_name, materialization) in result}
 
     return TestProjInfoFabric(
         project_root=project_setup.project_root,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@ import importlib.util
 import os
 from pathlib import Path
 
-import py
 import pytest
 import yaml
+from py.path import local as LocalPath
 
 from dbt.adapters.fabric.fabric_api_client import FabricApiClient
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials
@@ -232,7 +232,7 @@ def project_root(tmpdir_factory, prefix):
     path = base / prefix / "project"
     path.mkdir(parents=True, exist_ok=True)
     print(f"\n=== Test project_root: {path}")
-    return py.path.local(path)
+    return LocalPath(path)
 
 
 @pytest.fixture(scope="class")
@@ -242,7 +242,7 @@ def profiles_root(tmpdir_factory, prefix):
         return tmpdir_factory.mktemp("profile")
     path = base / prefix / "profile"
     path.mkdir(parents=True, exist_ok=True)
-    return py.path.local(path)
+    return LocalPath(path)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 
 from tests.spark_remote.orchestrator import RemoteTestOrchestrator
@@ -9,9 +11,9 @@ from tests.spark_remote.result_reporter import report_remote_results
 def remote_runtestloop(session: pytest.Session) -> bool:
     """Replace pytest's default test loop with remote Spark execution.
 
-    Syncs the project to a lakehouse, submits a Spark job that runs pytest
-    remotely, downloads junitxml results, and reports them back into the
-    local session.
+    Generates a unique run ID to isolate concurrent runs, syncs the project
+    to a per-run lakehouse directory, submits a Spark job, downloads junitxml
+    results, and reports them back into the local session.
 
     Args:
         session: The pytest Session (already collected).
@@ -25,13 +27,14 @@ def remote_runtestloop(session: pytest.Session) -> bool:
     if not session.items:
         return True
 
+    run_id = uuid4().hex[:8]
     remote_args = _build_remote_args(session)
 
-    print("\nRemote execution: syncing project to lakehouse...")
-    orchestrator = RemoteTestOrchestrator.from_env()
+    print(f"\nRemote execution [{run_id}]: syncing project to lakehouse...")
+    orchestrator = RemoteTestOrchestrator.from_env(run_id)
     orchestrator.sync_project()
 
-    print("\nRemote execution: submitting Spark job...")
+    print(f"\nRemote execution [{run_id}]: submitting Spark job...")
     job_result = orchestrator.run_spark_job(remote_args)
 
     print(f"\n  {job_result.status} — downloading results...")
@@ -44,8 +47,8 @@ def remote_runtestloop(session: pytest.Session) -> bool:
 def _build_remote_args(session: pytest.Session) -> list[str]:
     """Extract relevant pytest options from the local session for remote forwarding.
 
-    Forwards -k, -v, --de, -x, positional paths, and appends --junitxml for
-    result collection.
+    Forwards -k, -v, --de, -x, and positional test paths. The --junitxml path
+    is set by the remote entry point based on the run ID.
 
     Args:
         session: The local pytest Session to extract options from.
@@ -71,7 +74,5 @@ def _build_remote_args(session: pytest.Session) -> list[str]:
     positional = config.args
     if positional:
         args.extend(positional)
-
-    args.append("--junitxml=/lakehouse/default/Files/dbt-test-artifacts/results.xml")
 
     return args

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -42,12 +42,6 @@ def _build_remote_args(session: pytest.Session) -> list[str]:
     if config.getoption("--de", default=False):
         args.append("--de")
 
-    if config.getoption("--with-grants", default=False):
-        args.append("--with-grants")
-
-    if config.getoption("--with-python", default=False):
-        args.append("--with-python")
-
     if config.getoption("-x", default=False):
         args.append("-x")
 

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -11,9 +11,10 @@ from tests.spark_remote.result_reporter import report_remote_results
 def remote_runtestloop(session: pytest.Session) -> bool:
     """Replace pytest's default test loop with remote Spark execution.
 
-    Generates a unique run ID to isolate concurrent runs, syncs the project
-    to a per-run lakehouse directory, submits a Spark job, downloads junitxml
-    results, and reports them back into the local session.
+    Generates a unique run ID per invocation (for artifact isolation) and
+    derives a stable worktree key from the project root (for incremental
+    project sync). Multiple agents in separate worktrees can run concurrently
+    without interference.
 
     Args:
         session: The pytest Session (already collected).
@@ -30,11 +31,14 @@ def remote_runtestloop(session: pytest.Session) -> bool:
     run_id = uuid4().hex[:8]
     remote_args = _build_remote_args(session)
 
-    print(f"\nRemote execution [{run_id}]: syncing project to lakehouse...")
     orchestrator = RemoteTestOrchestrator.from_env(run_id)
+    print(
+        f"\nRemote execution [run={run_id}, worktree={orchestrator._worktree_key}]:"
+        f" syncing project to lakehouse..."
+    )
     orchestrator.sync_project()
 
-    print(f"\nRemote execution [{run_id}]: submitting Spark job...")
+    print(f"\nRemote execution [run={run_id}]: submitting Spark job...")
     job_result = orchestrator.run_spark_job(remote_args)
 
     print(f"\n  {job_result.status} — downloading results...")

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -51,8 +51,9 @@ def remote_runtestloop(session: pytest.Session) -> bool:
 def _build_remote_args(session: pytest.Session) -> list[str]:
     """Extract relevant pytest options from the local session for remote forwarding.
 
-    Forwards -k, -v, --de, -x, and positional test paths. The --junitxml path
-    is set by the remote entry point based on the run ID.
+    Forwards -k, -v, --de, -x, --with-python, --with-grants, and positional
+    test paths. The --junitxml path is set by the remote entry point based on
+    the run ID.
 
     Args:
         session: The local pytest Session to extract options from.
@@ -74,6 +75,12 @@ def _build_remote_args(session: pytest.Session) -> list[str]:
 
     if config.getoption("-x", default=False):
         args.append("-x")
+
+    if config.getoption("--with-python", default=False):
+        args.append("--with-python")
+
+    if config.getoption("--with-grants", default=False):
+        args.append("--with-grants")
 
     positional = config.args
     if positional:

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -29,21 +29,6 @@ def remote_runtestloop(session: pytest.Session) -> bool:
     return True
 
 
-_FORWARDED_OPTIONS = (
-    "-k",
-    "-v",
-    "--verbose",
-    "-s",
-    "--capture",
-    "--with-grants",
-    "--with-python",
-    "--de",
-    "--dw",
-    "-x",
-    "--exitfirst",
-)
-
-
 def _build_remote_args(session: pytest.Session) -> list[str]:
     args: list[str] = []
     config = session.config

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -7,6 +7,18 @@ from tests.spark_remote.result_reporter import report_remote_results
 
 
 def remote_runtestloop(session: pytest.Session) -> bool:
+    """Replace pytest's default test loop with remote Spark execution.
+
+    Syncs the project to a lakehouse, submits a Spark job that runs pytest
+    remotely, downloads junitxml results, and reports them back into the
+    local session.
+
+    Args:
+        session: The pytest Session (already collected).
+
+    Returns:
+        True to signal that the test loop has been handled.
+    """
     if session.config.option.collectonly:
         return True
 
@@ -30,6 +42,17 @@ def remote_runtestloop(session: pytest.Session) -> bool:
 
 
 def _build_remote_args(session: pytest.Session) -> list[str]:
+    """Extract relevant pytest options from the local session for remote forwarding.
+
+    Forwards -k, -v, --de, -x, positional paths, and appends --junitxml for
+    result collection.
+
+    Args:
+        session: The local pytest Session to extract options from.
+
+    Returns:
+        List of CLI arguments to pass to the remote pytest invocation.
+    """
     args: list[str] = []
     config = session.config
 

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.spark_remote.orchestrator import RemoteTestOrchestrator
+from tests.spark_remote.result_reporter import report_remote_results
+
+
+def remote_runtestloop(session: pytest.Session) -> bool:
+    if session.config.option.collectonly:
+        return True
+
+    if not session.items:
+        return True
+
+    remote_args = _build_remote_args(session)
+
+    print("\nRemote execution: syncing project to lakehouse...")
+    orchestrator = RemoteTestOrchestrator.from_env()
+    orchestrator.sync_project()
+
+    print("\nRemote execution: submitting Spark job...")
+    job_result = orchestrator.run_spark_job(remote_args)
+
+    print(f"\n  {job_result.status} — downloading results...")
+    results_path = orchestrator.download_results()
+    report_remote_results(session, results_path, job_result)
+
+    return True
+
+
+_FORWARDED_OPTIONS = (
+    "-k",
+    "-v",
+    "--verbose",
+    "-s",
+    "--capture",
+    "--with-grants",
+    "--with-python",
+    "--de",
+    "--dw",
+    "-x",
+    "--exitfirst",
+)
+
+
+def _build_remote_args(session: pytest.Session) -> list[str]:
+    args: list[str] = []
+    config = session.config
+
+    if config.getoption("-k"):
+        args.extend(["-k", config.getoption("-k")])
+
+    if config.getoption("verbose", 0) > 0:
+        args.append("-" + "v" * config.getoption("verbose"))
+
+    if config.getoption("--de", default=False):
+        args.append("--de")
+
+    if config.getoption("--dw", default=False):
+        args.append("--dw")
+
+    if config.getoption("--with-grants", default=False):
+        args.append("--with-grants")
+
+    if config.getoption("--with-python", default=False):
+        args.append("--with-python")
+
+    if config.getoption("-x", default=False):
+        args.append("-x")
+
+    args.append("--junitxml=/lakehouse/default/Files/dbt-test-artifacts/results.xml")
+
+    return args

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -42,9 +42,6 @@ def _build_remote_args(session: pytest.Session) -> list[str]:
     if config.getoption("--de", default=False):
         args.append("--de")
 
-    if config.getoption("--dw", default=False):
-        args.append("--dw")
-
     if config.getoption("--with-grants", default=False):
         args.append("--with-grants")
 

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -45,6 +45,10 @@ def _build_remote_args(session: pytest.Session) -> list[str]:
     if config.getoption("-x", default=False):
         args.append("-x")
 
+    positional = config.args
+    if positional:
+        args.extend(positional)
+
     args.append("--junitxml=/lakehouse/default/Files/dbt-test-artifacts/results.xml")
 
     return args

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -13,6 +13,14 @@ from tests.spark_remote.sync import ProjectSync, check_prerequisites
 
 
 class RemoteTestOrchestrator:
+    """Coordinates remote test execution: sync, job submission, and result retrieval.
+
+    Args:
+        api_client: Authenticated FabricApiClient for API communication.
+        project_root: Local path to the dbt-fabric project root.
+        job_name: Display name of the Spark Job Definition to use or create.
+    """
+
     def __init__(
         self,
         api_client: FabricApiClient,
@@ -26,6 +34,13 @@ class RemoteTestOrchestrator:
 
     @classmethod
     def from_env(cls) -> RemoteTestOrchestrator:
+        """Create an orchestrator from environment variables.
+
+        Uses FABRIC_TEST_* env vars to build credentials and resolve workspace/lakehouse.
+
+        Raises:
+            SystemExit: If prerequisites (azcopy, Azure CLI) are not met.
+        """
         errors = check_prerequisites()
         if errors:
             for error in errors:
@@ -52,12 +67,30 @@ class RemoteTestOrchestrator:
         )
 
     def sync_project(self) -> None:
+        """Upload the project to the lakehouse via azcopy.
+
+        Raises:
+            RuntimeError: If azcopy sync fails.
+        """
         workspace_id = self._api_client.get_workspace_id()
         lakehouse_id = self._api_client.get_lakehouse_id()
         sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)
         sync.upload()
 
     def run_spark_job(self, pytest_args: list[str]) -> SparkJobResult:
+        """Submit a Spark job to run pytest remotely and wait for completion.
+
+        Creates a Spark Job Definition if one doesn't exist with the configured name.
+
+        Args:
+            pytest_args: Command-line arguments to forward to the remote pytest invocation.
+
+        Returns:
+            SparkJobResult with final job status and metadata.
+
+        Raises:
+            FabricApiError: If any Fabric API call fails.
+        """
         workspace_id = self._api_client.get_workspace_id()
         lakehouse_id = self._api_client.get_lakehouse_id()
 
@@ -93,6 +126,14 @@ class RemoteTestOrchestrator:
         return job_client.poll_until_done(item_id, job_instance_id)
 
     def download_results(self) -> Path | None:
+        """Download test result artifacts from the lakehouse.
+
+        Returns:
+            Path to the results.xml file, or None if it was not produced.
+
+        Raises:
+            RuntimeError: If azcopy download fails.
+        """
         workspace_id = self._api_client.get_workspace_id()
         lakehouse_id = self._api_client.get_lakehouse_id()
         sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -138,7 +138,8 @@ class RemoteTestOrchestrator:
 
         job_client = SparkJobClient(self._api_client)
 
-        job_definition_name = f"{self._job_name}-{self._worktree_key}"
+        lakehouse_short = lakehouse_id[:8]
+        job_definition_name = f"{self._job_name}-{self._worktree_key}-{lakehouse_short}"
         existing = job_client.find_by_name(job_definition_name)
         if existing:
             item_id = existing["id"]

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -12,20 +12,16 @@ class RemoteTestOrchestrator:
     def __init__(
         self,
         workspace_id: str,
-        workspace_name: str,
-        lakehouse_name: str,
         lakehouse_id: str,
         project_root: Path,
         job_name: str = "dbt-fabric-tests",
     ):
         self._workspace_id = workspace_id
-        self._workspace_name = workspace_name
-        self._lakehouse_name = lakehouse_name
         self._lakehouse_id = lakehouse_id
         self._project_root = project_root
         self._job_name = job_name
 
-        self._sync = ProjectSync(workspace_name, lakehouse_name, project_root)
+        self._sync = ProjectSync(workspace_id, lakehouse_id, project_root)
         self._job_client = SparkJobClient(workspace_id, self._get_token)
         self._local_results_dir = project_root / "remote-test-results"
 
@@ -38,18 +34,12 @@ class RemoteTestOrchestrator:
             raise SystemExit(1)
 
         workspace_id = os.environ.get("FABRIC_TEST_WORKSPACE_ID", "")
-        workspace_name = os.environ.get("FABRIC_TEST_WORKSPACE_NAME", "")
-        lakehouse_name = os.environ.get("FABRIC_TEST_LAKEHOUSE_NAME", "")
         lakehouse_id = os.environ.get("FABRIC_TEST_REMOTE_LAKEHOUSE_ID", "")
         job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
 
         missing = []
         if not workspace_id:
             missing.append("FABRIC_TEST_WORKSPACE_ID")
-        if not workspace_name:
-            missing.append("FABRIC_TEST_WORKSPACE_NAME")
-        if not lakehouse_name:
-            missing.append("FABRIC_TEST_LAKEHOUSE_NAME")
         if not lakehouse_id:
             missing.append("FABRIC_TEST_REMOTE_LAKEHOUSE_ID")
         if missing:
@@ -58,8 +48,6 @@ class RemoteTestOrchestrator:
         project_root = Path(__file__).resolve().parent.parent.parent
         return cls(
             workspace_id=workspace_id,
-            workspace_name=workspace_name,
-            lakehouse_name=lakehouse_name,
             lakehouse_id=lakehouse_id,
             project_root=project_root,
             job_name=job_name,

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import sys
 from pathlib import Path
@@ -12,16 +13,34 @@ from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
 from tests.spark_remote.sync import ProjectSync, check_prerequisites
 
 
+def _worktree_key(project_root: Path) -> str:
+    """Derive a stable short key from the worktree's absolute path.
+
+    Args:
+        project_root: Absolute path to the project root.
+
+    Returns:
+        8-character hex digest, stable across runs from the same directory.
+    """
+    return hashlib.md5(str(project_root).encode()).hexdigest()[:8]
+
+
 class RemoteTestOrchestrator:
     """Coordinates remote test execution: sync, job submission, and result retrieval.
 
-    Each invocation uses a unique ``run_id`` to isolate concurrent runs on
-    OneLake and in the Spark Job Definition namespace.
+    Uses a two-level namespace on OneLake:
+
+    - **worktree_key** (hash of project root path) — determines the project
+      upload path. Stable across runs from the same worktree, enabling
+      incremental sync. Also used to name and reuse the Spark Job Definition.
+    - **run_id** (random UUID fragment) — determines the artifacts path.
+      Unique per invocation, preventing concurrent runs from overwriting
+      each other's results.
 
     Args:
         api_client: Authenticated FabricApiClient for API communication.
         project_root: Local path to the dbt-fabric project root.
-        run_id: Unique identifier for this test run (used in OneLake paths).
+        run_id: Unique identifier for this test run.
         job_name: Base display name of the Spark Job Definition.
     """
 
@@ -35,6 +54,7 @@ class RemoteTestOrchestrator:
         self._api_client = api_client
         self._project_root = project_root
         self._run_id = run_id
+        self._worktree_key = _worktree_key(project_root)
         self._job_name = job_name
         self._local_results_dir = project_root / "remote-test-results" / run_id
 
@@ -76,24 +96,33 @@ class RemoteTestOrchestrator:
             job_name=job_name,
         )
 
+    def _make_sync(self) -> ProjectSync:
+        """Create a ProjectSync configured for this worktree and run."""
+        return ProjectSync(
+            self._api_client.get_workspace_id(),
+            self._api_client.get_lakehouse_id(),
+            self._project_root,
+            self._worktree_key,
+            self._run_id,
+        )
+
     def sync_project(self) -> None:
-        """Upload the project to a per-run lakehouse directory via azcopy.
+        """Upload the project to a per-worktree lakehouse directory via azcopy.
+
+        Uses incremental sync — only files that changed since the last upload
+        from this worktree are transferred.
 
         Raises:
             RuntimeError: If azcopy sync fails.
         """
-        workspace_id = self._api_client.get_workspace_id()
-        lakehouse_id = self._api_client.get_lakehouse_id()
-        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root, self._run_id)
-        sync.upload()
+        self._make_sync().upload()
 
     def run_spark_job(self, pytest_args: list[str]) -> SparkJobResult:
         """Submit a Spark job to run pytest remotely and wait for completion.
 
-        Creates a per-run Spark Job Definition (``{job_name}-{run_id}``) pointing
-        to the uploaded entry point, passes the run ID as the first command-line
-        argument so the entry point can locate its project and artifacts directories,
-        and deletes the job definition after completion.
+        Reuses the Spark Job Definition for this worktree if one exists,
+        otherwise creates a new one. Passes both the worktree key and run ID
+        to the entry point so it can locate the project and artifacts directories.
 
         Args:
             pytest_args: Command-line arguments to forward to the remote pytest invocation.
@@ -109,20 +138,25 @@ class RemoteTestOrchestrator:
 
         job_client = SparkJobClient(self._api_client)
 
-        executable_path = (
-            f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com"
-            f"/{lakehouse_id}/Files/dbt-remote-runs/{self._run_id}/project"
-            f"/tests/spark_remote/spark_entry_point.py"
-        )
-        job_definition_name = f"{self._job_name}-{self._run_id}"
-        item_id = job_client.create_spark_job_definition(
-            name=job_definition_name,
-            lakehouse_id=lakehouse_id,
-            executable_path=executable_path,
-        )
-        print(f"  Created Spark Job Definition: {job_definition_name} ({item_id})")
+        job_definition_name = f"{self._job_name}-{self._worktree_key}"
+        existing = job_client.find_by_name(job_definition_name)
+        if existing:
+            item_id = existing["id"]
+            print(f"  Reusing Spark Job Definition: {job_definition_name} ({item_id})")
+        else:
+            executable_path = (
+                f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com"
+                f"/{lakehouse_id}/Files/dbt-remote-runs/projects/{self._worktree_key}"
+                f"/tests/spark_remote/spark_entry_point.py"
+            )
+            item_id = job_client.create_spark_job_definition(
+                name=job_definition_name,
+                lakehouse_id=lakehouse_id,
+                executable_path=executable_path,
+            )
+            print(f"  Created Spark Job Definition: {job_definition_name} ({item_id})")
 
-        full_args = [self._run_id, *pytest_args]
+        full_args = [self._worktree_key, self._run_id, *pytest_args]
         print(f"  Remote pytest args: {' '.join(pytest_args)}")
         item_id, job_instance_id = job_client.run_on_demand(item_id, full_args)
 
@@ -133,14 +167,10 @@ class RemoteTestOrchestrator:
         print(f"  Job URL: {job_url}")
         print("\nWaiting for Spark job...")
 
-        result = job_client.poll_until_done(item_id, job_instance_id)
-
-        job_client.delete_spark_job_definition(item_id)
-
-        return result
+        return job_client.poll_until_done(item_id, job_instance_id)
 
     def download_results(self) -> Path | None:
-        """Download test result artifacts from the per-run lakehouse directory.
+        """Download test result artifacts from the per-run artifacts directory.
 
         Returns:
             Path to the results.xml file, or None if it was not produced.
@@ -148,7 +178,4 @@ class RemoteTestOrchestrator:
         Raises:
             RuntimeError: If azcopy download fails.
         """
-        workspace_id = self._api_client.get_workspace_id()
-        lakehouse_id = self._api_client.get_lakehouse_id()
-        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root, self._run_id)
-        return sync.download_artifacts(self._local_results_dir)
+        return self._make_sync().download_artifacts(self._local_results_dir)

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
+from tests.spark_remote.sync import ProjectSync, check_prerequisites
+
+
+class RemoteTestOrchestrator:
+    def __init__(
+        self,
+        workspace_id: str,
+        workspace_name: str,
+        lakehouse_name: str,
+        lakehouse_id: str,
+        project_root: Path,
+        job_name: str = "dbt-fabric-tests",
+    ):
+        self._workspace_id = workspace_id
+        self._workspace_name = workspace_name
+        self._lakehouse_name = lakehouse_name
+        self._lakehouse_id = lakehouse_id
+        self._project_root = project_root
+        self._job_name = job_name
+
+        self._sync = ProjectSync(workspace_name, lakehouse_name, project_root)
+        self._job_client = SparkJobClient(workspace_id, self._get_token)
+        self._local_results_dir = project_root / "remote-test-results"
+
+    @classmethod
+    def from_env(cls) -> RemoteTestOrchestrator:
+        errors = check_prerequisites()
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}", file=sys.stderr)
+            raise SystemExit(1)
+
+        workspace_id = os.environ.get("FABRIC_TEST_WORKSPACE_ID", "")
+        workspace_name = os.environ.get("FABRIC_TEST_WORKSPACE_NAME", "")
+        lakehouse_name = os.environ.get("FABRIC_TEST_LAKEHOUSE_NAME", "")
+        lakehouse_id = os.environ.get("FABRIC_TEST_REMOTE_LAKEHOUSE_ID", "")
+        job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
+
+        if not workspace_id and not workspace_name:
+            raise ValueError("FABRIC_TEST_WORKSPACE_ID or FABRIC_TEST_WORKSPACE_NAME must be set")
+        if not lakehouse_name:
+            raise ValueError("FABRIC_TEST_LAKEHOUSE_NAME must be set")
+
+        project_root = Path(__file__).resolve().parent.parent.parent
+        return cls(
+            workspace_id=workspace_id,
+            workspace_name=workspace_name,
+            lakehouse_name=lakehouse_name,
+            lakehouse_id=lakehouse_id,
+            project_root=project_root,
+            job_name=job_name,
+        )
+
+    def sync_project(self) -> None:
+        self._sync.upload()
+
+    def run_spark_job(self, pytest_args: list[str]) -> SparkJobResult:
+        existing = self._job_client.find_by_name(self._job_name)
+        if existing:
+            item_id = existing["id"]
+            print(f"  Reusing Spark Job Definition: {self._job_name} ({item_id})")
+        else:
+            executable_path = (
+                f"abfss://{self._workspace_id}@onelake.dfs.fabric.microsoft.com"
+                f"/{self._lakehouse_id}/Files/dbt-fabric-tests"
+                f"/tests/spark_remote/spark_entry_point.py"
+            )
+            item_id = self._job_client.create_spark_job_definition(
+                name=self._job_name,
+                lakehouse_id=self._lakehouse_id,
+                executable_path=executable_path,
+            )
+            print(f"  Created Spark Job Definition: {self._job_name} ({item_id})")
+
+        print(f"  Remote pytest args: {' '.join(pytest_args)}")
+        item_id, job_instance_id = self._job_client.run_on_demand(item_id, pytest_args)
+
+        job_url = (
+            f"https://app.fabric.microsoft.com/groups/{self._workspace_id}"
+            f"/sparkJobDefinitions/{item_id}/runs/{job_instance_id}"
+        )
+        print(f"  Job URL: {job_url}")
+        print("\nWaiting for Spark job...")
+
+        return self._job_client.poll_until_done(item_id, job_instance_id)
+
+    def download_results(self) -> Path | None:
+        return self._sync.download_artifacts(self._local_results_dir)
+
+    def _get_token(self) -> str:
+        from azure.identity import AzureCliCredential
+
+        credential = AzureCliCredential()
+        token = credential.get_token("https://analysis.windows.net/powerbi/api/.default")
+        return token.token

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -43,10 +43,17 @@ class RemoteTestOrchestrator:
         lakehouse_id = os.environ.get("FABRIC_TEST_REMOTE_LAKEHOUSE_ID", "")
         job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
 
-        if not workspace_id and not workspace_name:
-            raise ValueError("FABRIC_TEST_WORKSPACE_ID or FABRIC_TEST_WORKSPACE_NAME must be set")
+        missing = []
+        if not workspace_id:
+            missing.append("FABRIC_TEST_WORKSPACE_ID")
+        if not workspace_name:
+            missing.append("FABRIC_TEST_WORKSPACE_NAME")
         if not lakehouse_name:
-            raise ValueError("FABRIC_TEST_LAKEHOUSE_NAME must be set")
+            missing.append("FABRIC_TEST_LAKEHOUSE_NAME")
+        if not lakehouse_id:
+            missing.append("FABRIC_TEST_REMOTE_LAKEHOUSE_ID")
+        if missing:
+            raise ValueError(f"Required env vars not set: {', '.join(missing)}")
 
         project_root = Path(__file__).resolve().parent.parent.parent
         return cls(

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+from dbt.adapters.fabric.fabric_credentials import FabricCredentials
+from dbt.adapters.fabric.fabric_token_provider import FabricTokenProvider
 from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
 from tests.spark_remote.sync import ProjectSync, check_prerequisites
 
@@ -14,6 +16,7 @@ class RemoteTestOrchestrator:
         workspace_id: str,
         lakehouse_id: str,
         project_root: Path,
+        token_provider: FabricTokenProvider,
         job_name: str = "dbt-fabric-tests",
     ):
         self._workspace_id = workspace_id
@@ -22,6 +25,7 @@ class RemoteTestOrchestrator:
         self._job_name = job_name
 
         self._sync = ProjectSync(workspace_id, lakehouse_id, project_root)
+        self._token_provider = token_provider
         self._job_client = SparkJobClient(workspace_id, self._get_token)
         self._local_results_dir = project_root / "remote-test-results"
 
@@ -45,11 +49,32 @@ class RemoteTestOrchestrator:
         if missing:
             raise ValueError(f"Required env vars not set: {', '.join(missing)}")
 
+        auth_kwargs: dict[str, str] = {}
+        auth = os.getenv("FABRIC_TEST_AUTH")
+        if auth:
+            auth_kwargs["authentication"] = auth
+        for key in ("tenant_id", "client_id", "federated_token_url", "federated_token_file"):
+            val = os.getenv(f"FABRIC_TEST_{key.upper()}")
+            if val:
+                auth_kwargs[key] = val
+        federated_header = os.getenv("FABRIC_TEST_FEDERATED_TOKEN_HEADER")
+        if federated_header:
+            auth_kwargs["federated_token_header"] = federated_header
+
+        creds = FabricCredentials(
+            database="",
+            schema="dbo",
+            workspace_id=workspace_id,
+            **auth_kwargs,
+        )
+        token_provider = FabricTokenProvider(creds)
+
         project_root = Path(__file__).resolve().parent.parent.parent
         return cls(
             workspace_id=workspace_id,
             lakehouse_id=lakehouse_id,
             project_root=project_root,
+            token_provider=token_provider,
             job_name=job_name,
         )
 
@@ -90,8 +115,4 @@ class RemoteTestOrchestrator:
         return self._sync.download_artifacts(self._local_results_dir)
 
     def _get_token(self) -> str:
-        from azure.identity import AzureCliCredential
-
-        credential = AzureCliCredential()
-        token = credential.get_token("https://analysis.windows.net/powerbi/api/.default")
-        return token.token
+        return self._token_provider.get_access_token()

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -5,8 +5,10 @@ import sys
 from pathlib import Path
 
 from dbt.adapters.fabric.fabric_api_client import FabricApiClient
-from dbt.adapters.fabric.fabric_credentials import FabricCredentials
 from dbt.adapters.fabric.fabric_token_provider import FabricTokenProvider
+from dbt.adapters.fabricspark.fabricspark_credentials import (
+    FabricSparkCredentials,
+)
 from tests.conftest import _auth_kwargs_from_env
 from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
 from tests.spark_remote.sync import ProjectSync, check_prerequisites
@@ -34,12 +36,11 @@ class RemoteTestOrchestrator:
 
         job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
 
-        creds = FabricCredentials(
-            database="",
+        creds = FabricSparkCredentials(
+            database=os.getenv("FABRIC_TEST_LAKEHOUSE_NAME", ""),
             schema="dbo",
             workspace_name=os.getenv("FABRIC_TEST_WORKSPACE_NAME"),
             workspace_id=os.getenv("FABRIC_TEST_WORKSPACE_ID"),
-            lakehouse=os.getenv("FABRIC_TEST_LAKEHOUSE_NAME"),
             **_auth_kwargs_from_env(),
         )
         token_provider = FabricTokenProvider(creds)

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -6,9 +6,7 @@ from pathlib import Path
 
 from dbt.adapters.fabric.fabric_api_client import FabricApiClient
 from dbt.adapters.fabric.fabric_token_provider import FabricTokenProvider
-from dbt.adapters.fabricspark.fabricspark_credentials import (
-    FabricSparkCredentials,
-)
+from dbt.adapters.fabricspark.fabricspark_credentials import FabricSparkCredentials
 from tests.conftest import _auth_kwargs_from_env
 from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
 from tests.spark_remote.sync import ProjectSync, check_prerequisites
@@ -63,7 +61,7 @@ class RemoteTestOrchestrator:
         workspace_id = self._api_client.get_workspace_id()
         lakehouse_id = self._api_client.get_lakehouse_id()
 
-        job_client = SparkJobClient(workspace_id, self._get_token)
+        job_client = SparkJobClient(self._api_client)
 
         existing = job_client.find_by_name(self._job_name)
         if existing:
@@ -99,6 +97,3 @@ class RemoteTestOrchestrator:
         lakehouse_id = self._api_client.get_lakehouse_id()
         sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)
         return sync.download_artifacts(self._local_results_dir)
-
-    def _get_token(self) -> str:
-        return self._api_client._token_provider.get_access_token()

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -4,8 +4,10 @@ import os
 import sys
 from pathlib import Path
 
+from dbt.adapters.fabric.fabric_api_client import FabricApiClient
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials
 from dbt.adapters.fabric.fabric_token_provider import FabricTokenProvider
+from tests.conftest import _auth_kwargs_from_env
 from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
 from tests.spark_remote.sync import ProjectSync, check_prerequisites
 
@@ -13,20 +15,13 @@ from tests.spark_remote.sync import ProjectSync, check_prerequisites
 class RemoteTestOrchestrator:
     def __init__(
         self,
-        workspace_id: str,
-        lakehouse_id: str,
+        api_client: FabricApiClient,
         project_root: Path,
-        token_provider: FabricTokenProvider,
         job_name: str = "dbt-fabric-tests",
     ):
-        self._workspace_id = workspace_id
-        self._lakehouse_id = lakehouse_id
+        self._api_client = api_client
         self._project_root = project_root
         self._job_name = job_name
-
-        self._sync = ProjectSync(workspace_id, lakehouse_id, project_root)
-        self._token_provider = token_provider
-        self._job_client = SparkJobClient(workspace_id, self._get_token)
         self._local_results_dir = project_root / "remote-test-results"
 
     @classmethod
@@ -37,82 +32,72 @@ class RemoteTestOrchestrator:
                 print(f"ERROR: {error}", file=sys.stderr)
             raise SystemExit(1)
 
-        workspace_id = os.environ.get("FABRIC_TEST_WORKSPACE_ID", "")
-        lakehouse_id = os.environ.get("FABRIC_TEST_REMOTE_LAKEHOUSE_ID", "")
         job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
-
-        missing = []
-        if not workspace_id:
-            missing.append("FABRIC_TEST_WORKSPACE_ID")
-        if not lakehouse_id:
-            missing.append("FABRIC_TEST_REMOTE_LAKEHOUSE_ID")
-        if missing:
-            raise ValueError(f"Required env vars not set: {', '.join(missing)}")
-
-        auth_kwargs: dict[str, str] = {}
-        auth = os.getenv("FABRIC_TEST_AUTH")
-        if auth:
-            auth_kwargs["authentication"] = auth
-        for key in ("tenant_id", "client_id", "federated_token_url", "federated_token_file"):
-            val = os.getenv(f"FABRIC_TEST_{key.upper()}")
-            if val:
-                auth_kwargs[key] = val
-        federated_header = os.getenv("FABRIC_TEST_FEDERATED_TOKEN_HEADER")
-        if federated_header:
-            auth_kwargs["federated_token_header"] = federated_header
 
         creds = FabricCredentials(
             database="",
             schema="dbo",
-            workspace_id=workspace_id,
-            **auth_kwargs,
+            workspace_name=os.getenv("FABRIC_TEST_WORKSPACE_NAME"),
+            workspace_id=os.getenv("FABRIC_TEST_WORKSPACE_ID"),
+            lakehouse=os.getenv("FABRIC_TEST_LAKEHOUSE_NAME"),
+            **_auth_kwargs_from_env(),
         )
         token_provider = FabricTokenProvider(creds)
+        api_client = FabricApiClient(creds, token_provider)
 
         project_root = Path(__file__).resolve().parent.parent.parent
         return cls(
-            workspace_id=workspace_id,
-            lakehouse_id=lakehouse_id,
+            api_client=api_client,
             project_root=project_root,
-            token_provider=token_provider,
             job_name=job_name,
         )
 
     def sync_project(self) -> None:
-        self._sync.upload()
+        workspace_id = self._api_client.get_workspace_id()
+        lakehouse_id = self._api_client.get_lakehouse_id()
+        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)
+        sync.upload()
 
     def run_spark_job(self, pytest_args: list[str]) -> SparkJobResult:
-        existing = self._job_client.find_by_name(self._job_name)
+        workspace_id = self._api_client.get_workspace_id()
+        lakehouse_id = self._api_client.get_lakehouse_id()
+
+        job_client = SparkJobClient(workspace_id, self._get_token)
+
+        existing = job_client.find_by_name(self._job_name)
         if existing:
             item_id = existing["id"]
             print(f"  Reusing Spark Job Definition: {self._job_name} ({item_id})")
         else:
             executable_path = (
-                f"abfss://{self._workspace_id}@onelake.dfs.fabric.microsoft.com"
-                f"/{self._lakehouse_id}/Files/dbt-fabric-tests"
+                f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com"
+                f"/{lakehouse_id}/Files/dbt-fabric-tests"
                 f"/tests/spark_remote/spark_entry_point.py"
             )
-            item_id = self._job_client.create_spark_job_definition(
+            item_id = job_client.create_spark_job_definition(
                 name=self._job_name,
-                lakehouse_id=self._lakehouse_id,
+                lakehouse_id=lakehouse_id,
                 executable_path=executable_path,
             )
             print(f"  Created Spark Job Definition: {self._job_name} ({item_id})")
 
         print(f"  Remote pytest args: {' '.join(pytest_args)}")
-        item_id, job_instance_id = self._job_client.run_on_demand(item_id, pytest_args)
+        item_id, job_instance_id = job_client.run_on_demand(item_id, pytest_args)
 
         job_url = (
-            f"https://app.fabric.microsoft.com/groups/{self._workspace_id}"
+            f"https://app.fabric.microsoft.com/groups/{workspace_id}"
             f"/sparkJobDefinitions/{item_id}/runs/{job_instance_id}"
         )
         print(f"  Job URL: {job_url}")
         print("\nWaiting for Spark job...")
 
-        return self._job_client.poll_until_done(item_id, job_instance_id)
+        return job_client.poll_until_done(item_id, job_instance_id)
 
     def download_results(self) -> Path | None:
-        return self._sync.download_artifacts(self._local_results_dir)
+        workspace_id = self._api_client.get_workspace_id()
+        lakehouse_id = self._api_client.get_lakehouse_id()
+        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)
+        return sync.download_artifacts(self._local_results_dir)
 
     def _get_token(self) -> str:
-        return self._token_provider.get_access_token()
+        return self._api_client._token_provider.get_access_token()

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -15,28 +15,37 @@ from tests.spark_remote.sync import ProjectSync, check_prerequisites
 class RemoteTestOrchestrator:
     """Coordinates remote test execution: sync, job submission, and result retrieval.
 
+    Each invocation uses a unique ``run_id`` to isolate concurrent runs on
+    OneLake and in the Spark Job Definition namespace.
+
     Args:
         api_client: Authenticated FabricApiClient for API communication.
         project_root: Local path to the dbt-fabric project root.
-        job_name: Display name of the Spark Job Definition to use or create.
+        run_id: Unique identifier for this test run (used in OneLake paths).
+        job_name: Base display name of the Spark Job Definition.
     """
 
     def __init__(
         self,
         api_client: FabricApiClient,
         project_root: Path,
+        run_id: str,
         job_name: str = "dbt-fabric-tests",
     ):
         self._api_client = api_client
         self._project_root = project_root
+        self._run_id = run_id
         self._job_name = job_name
-        self._local_results_dir = project_root / "remote-test-results"
+        self._local_results_dir = project_root / "remote-test-results" / run_id
 
     @classmethod
-    def from_env(cls) -> RemoteTestOrchestrator:
+    def from_env(cls, run_id: str) -> RemoteTestOrchestrator:
         """Create an orchestrator from environment variables.
 
         Uses FABRIC_TEST_* env vars to build credentials and resolve workspace/lakehouse.
+
+        Args:
+            run_id: Unique identifier for this test run.
 
         Raises:
             SystemExit: If prerequisites (azcopy, Azure CLI) are not met.
@@ -63,24 +72,28 @@ class RemoteTestOrchestrator:
         return cls(
             api_client=api_client,
             project_root=project_root,
+            run_id=run_id,
             job_name=job_name,
         )
 
     def sync_project(self) -> None:
-        """Upload the project to the lakehouse via azcopy.
+        """Upload the project to a per-run lakehouse directory via azcopy.
 
         Raises:
             RuntimeError: If azcopy sync fails.
         """
         workspace_id = self._api_client.get_workspace_id()
         lakehouse_id = self._api_client.get_lakehouse_id()
-        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)
+        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root, self._run_id)
         sync.upload()
 
     def run_spark_job(self, pytest_args: list[str]) -> SparkJobResult:
         """Submit a Spark job to run pytest remotely and wait for completion.
 
-        Creates a Spark Job Definition if one doesn't exist with the configured name.
+        Creates a per-run Spark Job Definition (``{job_name}-{run_id}``) pointing
+        to the uploaded entry point, passes the run ID as the first command-line
+        argument so the entry point can locate its project and artifacts directories,
+        and deletes the job definition after completion.
 
         Args:
             pytest_args: Command-line arguments to forward to the remote pytest invocation.
@@ -96,25 +109,22 @@ class RemoteTestOrchestrator:
 
         job_client = SparkJobClient(self._api_client)
 
-        existing = job_client.find_by_name(self._job_name)
-        if existing:
-            item_id = existing["id"]
-            print(f"  Reusing Spark Job Definition: {self._job_name} ({item_id})")
-        else:
-            executable_path = (
-                f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com"
-                f"/{lakehouse_id}/Files/dbt-fabric-tests"
-                f"/tests/spark_remote/spark_entry_point.py"
-            )
-            item_id = job_client.create_spark_job_definition(
-                name=self._job_name,
-                lakehouse_id=lakehouse_id,
-                executable_path=executable_path,
-            )
-            print(f"  Created Spark Job Definition: {self._job_name} ({item_id})")
+        executable_path = (
+            f"abfss://{workspace_id}@onelake.dfs.fabric.microsoft.com"
+            f"/{lakehouse_id}/Files/dbt-remote-runs/{self._run_id}/project"
+            f"/tests/spark_remote/spark_entry_point.py"
+        )
+        job_definition_name = f"{self._job_name}-{self._run_id}"
+        item_id = job_client.create_spark_job_definition(
+            name=job_definition_name,
+            lakehouse_id=lakehouse_id,
+            executable_path=executable_path,
+        )
+        print(f"  Created Spark Job Definition: {job_definition_name} ({item_id})")
 
+        full_args = [self._run_id, *pytest_args]
         print(f"  Remote pytest args: {' '.join(pytest_args)}")
-        item_id, job_instance_id = job_client.run_on_demand(item_id, pytest_args)
+        item_id, job_instance_id = job_client.run_on_demand(item_id, full_args)
 
         job_url = (
             f"https://app.fabric.microsoft.com/groups/{workspace_id}"
@@ -123,10 +133,14 @@ class RemoteTestOrchestrator:
         print(f"  Job URL: {job_url}")
         print("\nWaiting for Spark job...")
 
-        return job_client.poll_until_done(item_id, job_instance_id)
+        result = job_client.poll_until_done(item_id, job_instance_id)
+
+        job_client.delete_spark_job_definition(item_id)
+
+        return result
 
     def download_results(self) -> Path | None:
-        """Download test result artifacts from the lakehouse.
+        """Download test result artifacts from the per-run lakehouse directory.
 
         Returns:
             Path to the results.xml file, or None if it was not produced.
@@ -136,5 +150,5 @@ class RemoteTestOrchestrator:
         """
         workspace_id = self._api_client.get_workspace_id()
         lakehouse_id = self._api_client.get_lakehouse_id()
-        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root)
+        sync = ProjectSync(workspace_id, lakehouse_id, self._project_root, self._run_id)
         return sync.download_artifacts(self._local_results_dir)

--- a/tests/spark_remote/result_reporter.py
+++ b/tests/spark_remote/result_reporter.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 from _pytest.reports import TestReport
+from junitparser import Error, Failure, JUnitXml, Skipped, TestCase
 
 from tests.spark_remote.spark_job_client import SparkJobResult
 
@@ -146,89 +146,81 @@ def _parse_junitxml(path: Path) -> list[JunitTestResult]:
         path: Path to the junitxml file.
 
     Returns:
-        List of JunitTestResult, one per <testcase> element.
-
-    Raises:
-        ET.ParseError: If the XML is malformed.
+        List of JunitTestResult, one per test case.
     """
-    tree = ET.parse(path)
-    root = tree.getroot()
+    xml = JUnitXml.fromfile(str(path))
 
     results = []
-    for testcase in root.iter("testcase"):
-        nodeid = _reconstruct_nodeid(testcase)
-        duration = float(testcase.get("time", "0"))
+    for suite in xml:
+        for case in suite:
+            if not isinstance(case, TestCase):
+                continue
+            nodeid = _reconstruct_nodeid(case)
+            duration = case.time or 0.0
 
-        failure_el = testcase.find("failure")
-        error_el = testcase.find("error")
-        skipped_el = testcase.find("skipped")
+            sections: list[tuple[str, str]] = []
+            if case.system_out:
+                sections.append(("Captured stdout (remote)", case.system_out))
+            if case.system_err:
+                sections.append(("Captured stderr (remote)", case.system_err))
 
-        sections: list[tuple[str, str]] = []
-        stdout_el = testcase.find("system-out")
-        if stdout_el is not None and stdout_el.text:
-            sections.append(("Captured stdout (remote)", stdout_el.text))
-        stderr_el = testcase.find("system-err")
-        if stderr_el is not None and stderr_el.text:
-            sections.append(("Captured stderr (remote)", stderr_el.text))
+            failure_entry = None
+            skip_entry = None
+            for entry in case.result:
+                if isinstance(entry, (Failure, Error)):
+                    failure_entry = entry
+                    break
+                if isinstance(entry, Skipped):
+                    skip_entry = entry
 
-        if failure_el is not None:
-            results.append(
-                JunitTestResult(
-                    nodeid=nodeid,
-                    outcome="failed",
-                    duration=duration,
-                    failure_message=failure_el.text or failure_el.get("message", ""),
-                    sections=sections,
+            if failure_entry is not None:
+                results.append(
+                    JunitTestResult(
+                        nodeid=nodeid,
+                        outcome="failed",
+                        duration=duration,
+                        failure_message=failure_entry.text or failure_entry.message or "",
+                        sections=sections,
+                    )
                 )
-            )
-        elif error_el is not None:
-            results.append(
-                JunitTestResult(
-                    nodeid=nodeid,
-                    outcome="failed",
-                    duration=duration,
-                    failure_message=error_el.text or error_el.get("message", ""),
-                    sections=sections,
+            elif skip_entry is not None:
+                results.append(
+                    JunitTestResult(
+                        nodeid=nodeid,
+                        outcome="skipped",
+                        duration=duration,
+                        skip_reason=skip_entry.message or "Skipped",
+                        sections=sections,
+                    )
                 )
-            )
-        elif skipped_el is not None:
-            results.append(
-                JunitTestResult(
-                    nodeid=nodeid,
-                    outcome="skipped",
-                    duration=duration,
-                    skip_reason=skipped_el.get("message", "Skipped"),
-                    sections=sections,
+            else:
+                results.append(
+                    JunitTestResult(
+                        nodeid=nodeid,
+                        outcome="passed",
+                        duration=duration,
+                        sections=sections,
+                    )
                 )
-            )
-        else:
-            results.append(
-                JunitTestResult(
-                    nodeid=nodeid,
-                    outcome="passed",
-                    duration=duration,
-                    sections=sections,
-                )
-            )
 
     return results
 
 
-def _reconstruct_nodeid(testcase: ET.Element) -> str:
-    """Reconstruct a pytest node ID from junitxml testcase attributes.
+def _reconstruct_nodeid(case: TestCase) -> str:
+    """Reconstruct a pytest node ID from a junitparser TestCase.
 
     Handles the mapping from junitxml's (file, classname, name) triple back to
     pytest's ``file::Class::method`` format.
 
     Args:
-        testcase: An XML <testcase> element with file, classname, and name attributes.
+        case: A junitparser TestCase with classname and name attributes.
 
     Returns:
         A pytest-compatible node ID string (e.g. "tests/test_foo.py::TestBar::test_baz").
     """
-    file_attr = testcase.get("file")
-    classname = testcase.get("classname", "")
-    name = testcase.get("name", "")
+    file_attr = case._elem.get("file")
+    classname = case.classname or ""
+    name = case.name or ""
 
     if file_attr:
         file_module = file_attr.replace("/", ".").removesuffix(".py")

--- a/tests/spark_remote/result_reporter.py
+++ b/tests/spark_remote/result_reporter.py
@@ -52,7 +52,13 @@ def report_remote_results(
 
         result = result_map.get(item.nodeid)
         if result is None:
-            _report_item_as_error(item, "Test not found in remote execution results")
+            not_run = JunitTestResult(
+                nodeid=item.nodeid,
+                outcome="skipped",
+                duration=0,
+                skip_reason="Not executed by remote run (possibly due to -x/maxfail)",
+            )
+            _report_item_result(item, not_run)
         else:
             _report_item_result(item, result)
 

--- a/tests/spark_remote/result_reporter.py
+++ b/tests/spark_remote/result_reporter.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from _pytest.reports import TestReport
+
+from tests.spark_remote.spark_job_client import SparkJobResult
+
+
+@dataclass
+class JunitTestResult:
+    nodeid: str
+    outcome: str
+    duration: float
+    failure_message: str | None = None
+    skip_reason: str | None = None
+    sections: list[tuple[str, str]] = field(default_factory=list)
+
+
+def report_remote_results(
+    session: pytest.Session, results_path: Path | None, job_result: SparkJobResult
+) -> None:
+    if results_path is None:
+        msg = f"Remote job {job_result.status}"
+        if job_result.error_message:
+            msg += f": {job_result.error_message}"
+        msg += f"\nJob URL: {job_result.job_url}"
+        _report_all_as_error(session, msg)
+        return
+
+    results = _parse_junitxml(results_path)
+    result_map = {r.nodeid: r for r in results}
+
+    for item in session.items:
+        ihook = item.ihook
+        ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+
+        result = result_map.get(item.nodeid)
+        if result is None:
+            _report_item_as_error(item, "Test not found in remote execution results")
+        else:
+            _report_item_result(item, result)
+
+        ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+
+
+def _report_all_as_error(session: pytest.Session, message: str) -> None:
+    for item in session.items:
+        ihook = item.ihook
+        ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+        _report_item_as_error(item, message)
+        ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+
+
+def _report_item_as_error(item: pytest.Item, message: str) -> None:
+    ihook = item.ihook
+    for when in ("setup", "call", "teardown"):
+        report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="failed" if when == "call" else "passed",
+            longrepr=message if when == "call" else None,
+            when=when,
+            duration=0,
+        )
+        ihook.pytest_runtest_logreport(report=report)
+
+
+def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
+    ihook = item.ihook
+
+    setup_report = TestReport(
+        nodeid=item.nodeid,
+        location=item.location,
+        keywords={x: 1 for x in item.keywords},
+        outcome="passed",
+        longrepr=None,
+        when="setup",
+        duration=0,
+    )
+    ihook.pytest_runtest_logreport(report=setup_report)
+
+    if result.outcome == "passed":
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="passed",
+            longrepr=None,
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    elif result.outcome == "failed":
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="failed",
+            longrepr=result.failure_message,
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    elif result.outcome == "skipped":
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="skipped",
+            longrepr=("", 0, result.skip_reason or "Skipped"),
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    else:
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="failed",
+            longrepr=f"Unknown outcome: {result.outcome}",
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    ihook.pytest_runtest_logreport(report=call_report)
+
+    teardown_report = TestReport(
+        nodeid=item.nodeid,
+        location=item.location,
+        keywords={x: 1 for x in item.keywords},
+        outcome="passed",
+        longrepr=None,
+        when="teardown",
+        duration=0,
+    )
+    ihook.pytest_runtest_logreport(report=teardown_report)
+
+
+def _parse_junitxml(path: Path) -> list[JunitTestResult]:
+    tree = ET.parse(path)
+    root = tree.getroot()
+
+    results = []
+    for testcase in root.iter("testcase"):
+        nodeid = _reconstruct_nodeid(testcase)
+        duration = float(testcase.get("time", "0"))
+
+        failure_el = testcase.find("failure")
+        error_el = testcase.find("error")
+        skipped_el = testcase.find("skipped")
+
+        sections: list[tuple[str, str]] = []
+        stdout_el = testcase.find("system-out")
+        if stdout_el is not None and stdout_el.text:
+            sections.append(("Captured stdout (remote)", stdout_el.text))
+        stderr_el = testcase.find("system-err")
+        if stderr_el is not None and stderr_el.text:
+            sections.append(("Captured stderr (remote)", stderr_el.text))
+
+        if failure_el is not None:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="failed",
+                    duration=duration,
+                    failure_message=failure_el.text or failure_el.get("message", ""),
+                    sections=sections,
+                )
+            )
+        elif error_el is not None:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="failed",
+                    duration=duration,
+                    failure_message=error_el.text or error_el.get("message", ""),
+                    sections=sections,
+                )
+            )
+        elif skipped_el is not None:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="skipped",
+                    duration=duration,
+                    skip_reason=skipped_el.get("message", "Skipped"),
+                    sections=sections,
+                )
+            )
+        else:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="passed",
+                    duration=duration,
+                    sections=sections,
+                )
+            )
+
+    return results
+
+
+def _reconstruct_nodeid(testcase: ET.Element) -> str:
+    file_attr = testcase.get("file")
+    classname = testcase.get("classname", "")
+    name = testcase.get("name", "")
+
+    if file_attr:
+        file_module = file_attr.replace("/", ".").removesuffix(".py")
+        remaining = classname.removeprefix(file_module + ".")
+        if remaining and remaining != classname:
+            return f"{file_attr}::{remaining.replace('.', '::')}::{name}"
+        return f"{file_attr}::{name}"
+
+    # Fallback: split classname on first uppercase component (class name boundary)
+    parts = classname.split(".")
+    file_parts = []
+    class_parts = []
+    for i, part in enumerate(parts):
+        if part and part[0].isupper():
+            class_parts = parts[i:]
+            break
+        file_parts.append(part)
+
+    file_path = "/".join(file_parts) + ".py" if file_parts else ""
+    node_parts = class_parts + [name]
+    node_path = "::".join(node_parts)
+
+    if file_path:
+        return f"{file_path}::{node_path}"
+    return node_path

--- a/tests/spark_remote/result_reporter.py
+++ b/tests/spark_remote/result_reporter.py
@@ -12,6 +12,8 @@ from tests.spark_remote.spark_job_client import SparkJobResult
 
 @dataclass
 class JunitTestResult:
+    """Parsed result of a single test case from junitxml."""
+
     nodeid: str
     outcome: str
     duration: float
@@ -23,6 +25,16 @@ class JunitTestResult:
 def report_remote_results(
     session: pytest.Session, results_path: Path | None, job_result: SparkJobResult
 ) -> None:
+    """Report remote test results back into the local pytest session.
+
+    Parses the junitxml from the remote run and replays each result as a
+    pytest TestReport so the local session shows correct pass/fail/skip counts.
+
+    Args:
+        session: The local pytest Session with collected items.
+        results_path: Path to the downloaded results.xml, or None if unavailable.
+        job_result: The SparkJobResult with job status and error info.
+    """
     if results_path is None:
         msg = f"Remote job {job_result.status}"
         if job_result.error_message:
@@ -48,6 +60,12 @@ def report_remote_results(
 
 
 def _report_all_as_error(session: pytest.Session, message: str) -> None:
+    """Report all collected items as failed with the given error message.
+
+    Args:
+        session: The pytest Session with collected items.
+        message: Error message to attach to each test report.
+    """
     for item in session.items:
         ihook = item.ihook
         ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
@@ -56,12 +74,18 @@ def _report_all_as_error(session: pytest.Session, message: str) -> None:
 
 
 def _report_item_as_error(item: pytest.Item, message: str) -> None:
+    """Emit setup/call/teardown reports for a single item, marking call as failed.
+
+    Args:
+        item: The pytest Item to report on.
+        message: Error message for the call phase.
+    """
     ihook = item.ihook
     for when in ("setup", "call", "teardown"):
         report = TestReport(
             nodeid=item.nodeid,
             location=item.location,
-            keywords={x: 1 for x in item.keywords},
+            keywords=dict.fromkeys(item.keywords, 1),
             outcome="failed" if when == "call" else "passed",
             longrepr=message if when == "call" else None,
             when=when,
@@ -71,12 +95,18 @@ def _report_item_as_error(item: pytest.Item, message: str) -> None:
 
 
 def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
+    """Emit setup/call/teardown reports for a single item based on remote results.
+
+    Args:
+        item: The pytest Item to report on.
+        result: Parsed JunitTestResult from the remote junitxml.
+    """
     ihook = item.ihook
 
     setup_report = TestReport(
         nodeid=item.nodeid,
         location=item.location,
-        keywords={x: 1 for x in item.keywords},
+        keywords=dict.fromkeys(item.keywords, 1),
         outcome="passed",
         longrepr=None,
         when="setup",
@@ -88,7 +118,7 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
         call_report = TestReport(
             nodeid=item.nodeid,
             location=item.location,
-            keywords={x: 1 for x in item.keywords},
+            keywords=dict.fromkeys(item.keywords, 1),
             outcome="passed",
             longrepr=None,
             when="call",
@@ -99,7 +129,7 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
         call_report = TestReport(
             nodeid=item.nodeid,
             location=item.location,
-            keywords={x: 1 for x in item.keywords},
+            keywords=dict.fromkeys(item.keywords, 1),
             outcome="failed",
             longrepr=result.failure_message,
             when="call",
@@ -110,7 +140,7 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
         call_report = TestReport(
             nodeid=item.nodeid,
             location=item.location,
-            keywords={x: 1 for x in item.keywords},
+            keywords=dict.fromkeys(item.keywords, 1),
             outcome="skipped",
             longrepr=("", 0, result.skip_reason or "Skipped"),
             when="call",
@@ -121,7 +151,7 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
         call_report = TestReport(
             nodeid=item.nodeid,
             location=item.location,
-            keywords={x: 1 for x in item.keywords},
+            keywords=dict.fromkeys(item.keywords, 1),
             outcome="failed",
             longrepr=f"Unknown outcome: {result.outcome}",
             when="call",
@@ -133,7 +163,7 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
     teardown_report = TestReport(
         nodeid=item.nodeid,
         location=item.location,
-        keywords={x: 1 for x in item.keywords},
+        keywords=dict.fromkeys(item.keywords, 1),
         outcome="passed",
         longrepr=None,
         when="teardown",
@@ -143,6 +173,17 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
 
 
 def _parse_junitxml(path: Path) -> list[JunitTestResult]:
+    """Parse a junitxml file into a list of test results.
+
+    Args:
+        path: Path to the junitxml file.
+
+    Returns:
+        List of JunitTestResult, one per <testcase> element.
+
+    Raises:
+        ET.ParseError: If the XML is malformed.
+    """
     tree = ET.parse(path)
     root = tree.getroot()
 
@@ -207,6 +248,17 @@ def _parse_junitxml(path: Path) -> list[JunitTestResult]:
 
 
 def _reconstruct_nodeid(testcase: ET.Element) -> str:
+    """Reconstruct a pytest node ID from junitxml testcase attributes.
+
+    Handles the mapping from junitxml's (file, classname, name) triple back to
+    pytest's ``file::Class::method`` format.
+
+    Args:
+        testcase: An XML <testcase> element with file, classname, and name attributes.
+
+    Returns:
+        A pytest-compatible node ID string (e.g. "tests/test_foo.py::TestBar::test_baz").
+    """
     file_attr = testcase.get("file")
     classname = testcase.get("classname", "")
     name = testcase.get("name", "")
@@ -218,7 +270,6 @@ def _reconstruct_nodeid(testcase: ET.Element) -> str:
             return f"{file_attr}::{remaining.replace('.', '::')}::{name}"
         return f"{file_attr}::{name}"
 
-    # Fallback: split classname on first uppercase component (class name boundary)
     parts = classname.split(".")
     file_parts = []
     class_parts = []

--- a/tests/spark_remote/result_reporter.py
+++ b/tests/spark_remote/result_reporter.py
@@ -102,74 +102,35 @@ def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
         result: Parsed JunitTestResult from the remote junitxml.
     """
     ihook = item.ihook
+    keywords = dict.fromkeys(item.keywords, 1)
 
-    setup_report = TestReport(
-        nodeid=item.nodeid,
-        location=item.location,
-        keywords=dict.fromkeys(item.keywords, 1),
-        outcome="passed",
-        longrepr=None,
-        when="setup",
-        duration=0,
-    )
-    ihook.pytest_runtest_logreport(report=setup_report)
-
-    if result.outcome == "passed":
-        call_report = TestReport(
-            nodeid=item.nodeid,
-            location=item.location,
-            keywords=dict.fromkeys(item.keywords, 1),
-            outcome="passed",
-            longrepr=None,
-            when="call",
-            duration=result.duration,
-            sections=result.sections,
-        )
+    if result.outcome == "skipped":
+        longrepr = ("", 0, result.skip_reason or "Skipped")
     elif result.outcome == "failed":
-        call_report = TestReport(
-            nodeid=item.nodeid,
-            location=item.location,
-            keywords=dict.fromkeys(item.keywords, 1),
-            outcome="failed",
-            longrepr=result.failure_message,
-            when="call",
-            duration=result.duration,
-            sections=result.sections,
-        )
-    elif result.outcome == "skipped":
-        call_report = TestReport(
-            nodeid=item.nodeid,
-            location=item.location,
-            keywords=dict.fromkeys(item.keywords, 1),
-            outcome="skipped",
-            longrepr=("", 0, result.skip_reason or "Skipped"),
-            when="call",
-            duration=result.duration,
-            sections=result.sections,
-        )
+        longrepr = result.failure_message
+    elif result.outcome == "passed":
+        longrepr = None
     else:
-        call_report = TestReport(
+        longrepr = f"Unknown outcome: {result.outcome}"
+
+    outcome = "failed" if result.outcome not in ("passed", "skipped") else result.outcome
+
+    for when, phase_outcome, phase_longrepr, duration in (
+        ("setup", "passed", None, 0),
+        ("call", outcome, longrepr, result.duration),
+        ("teardown", "passed", None, 0),
+    ):
+        report = TestReport(
             nodeid=item.nodeid,
             location=item.location,
-            keywords=dict.fromkeys(item.keywords, 1),
-            outcome="failed",
-            longrepr=f"Unknown outcome: {result.outcome}",
-            when="call",
-            duration=result.duration,
-            sections=result.sections,
+            keywords=keywords,
+            outcome=phase_outcome,
+            longrepr=phase_longrepr,
+            when=when,
+            duration=duration,
+            sections=result.sections if when == "call" else [],
         )
-    ihook.pytest_runtest_logreport(report=call_report)
-
-    teardown_report = TestReport(
-        nodeid=item.nodeid,
-        location=item.location,
-        keywords=dict.fromkeys(item.keywords, 1),
-        outcome="passed",
-        longrepr=None,
-        when="teardown",
-        duration=0,
-    )
-    ihook.pytest_runtest_logreport(report=teardown_report)
+        ihook.pytest_runtest_logreport(report=report)
 
 
 def _parse_junitxml(path: Path) -> list[JunitTestResult]:

--- a/tests/spark_remote/spark_entry_point.py
+++ b/tests/spark_remote/spark_entry_point.py
@@ -18,6 +18,9 @@ ARTIFACTS_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-test-artifacts"
 
 
 def main() -> None:
+    if os.path.isdir(ARTIFACTS_DIR):
+        for f in os.listdir(ARTIFACTS_DIR):
+            os.remove(os.path.join(ARTIFACTS_DIR, f))
     os.makedirs(ARTIFACTS_DIR, exist_ok=True)
 
     requirements_file = f"{PROJECT_DIR}/requirements-remote.txt"

--- a/tests/spark_remote/spark_entry_point.py
+++ b/tests/spark_remote/spark_entry_point.py
@@ -18,6 +18,15 @@ ARTIFACTS_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-test-artifacts"
 
 
 def main() -> None:
+    """Install dependencies, configure env, run pytest, and write exit code.
+
+    Reads command-line arguments from sys.argv (forwarded by the Spark Job Definition)
+    and passes them to pytest. Ensures --junitxml is set so results can be collected.
+
+    Raises:
+        subprocess.CalledProcessError: If pip install fails.
+        SystemExit: Always exits with the pytest exit code.
+    """
     if os.path.isdir(ARTIFACTS_DIR):
         for f in os.listdir(ARTIFACTS_DIR):
             os.remove(os.path.join(ARTIFACTS_DIR, f))

--- a/tests/spark_remote/spark_entry_point.py
+++ b/tests/spark_remote/spark_entry_point.py
@@ -1,9 +1,9 @@
 """Entry point for remote pytest execution on Fabric Spark.
 
-This script is submitted as a Spark Job Definition. It installs the project
-and its dependencies, then runs pytest with the provided arguments. Results
-are written to junitxml on the lakehouse filesystem for the local pytest
-session to parse.
+This script is submitted as a Spark Job Definition. It receives a run ID
+as its first argument (used to locate the per-run project and artifacts
+directories on the lakehouse), installs the project and its dependencies,
+then runs pytest with the remaining arguments.
 """
 
 from __future__ import annotations
@@ -13,35 +13,40 @@ import subprocess
 import sys
 
 LAKEHOUSE_ROOT = "/lakehouse/default"
-PROJECT_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-fabric-tests"
-ARTIFACTS_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-test-artifacts"
 
 
 def main() -> None:
     """Install dependencies, configure env, run pytest, and write exit code.
 
-    Reads command-line arguments from sys.argv (forwarded by the Spark Job Definition)
-    and passes them to pytest. Ensures --junitxml is set so results can be collected.
+    The first positional argument is the run ID, which determines the project
+    and artifacts paths on the lakehouse. All remaining arguments are forwarded
+    to pytest. Ensures --junitxml is set so results can be collected.
 
     Raises:
         subprocess.CalledProcessError: If pip install fails.
         SystemExit: Always exits with the pytest exit code.
     """
-    if os.path.isdir(ARTIFACTS_DIR):
-        for f in os.listdir(ARTIFACTS_DIR):
-            os.remove(os.path.join(ARTIFACTS_DIR, f))
-    os.makedirs(ARTIFACTS_DIR, exist_ok=True)
+    run_id = sys.argv[1]
+    pytest_args = sys.argv[2:]
 
-    requirements_file = f"{PROJECT_DIR}/requirements-remote.txt"
+    project_dir = f"{LAKEHOUSE_ROOT}/Files/dbt-remote-runs/{run_id}/project"
+    artifacts_dir = f"{LAKEHOUSE_ROOT}/Files/dbt-remote-runs/{run_id}/artifacts"
+
+    if os.path.isdir(artifacts_dir):
+        for f in os.listdir(artifacts_dir):
+            os.remove(os.path.join(artifacts_dir, f))
+    os.makedirs(artifacts_dir, exist_ok=True)
+
+    requirements_file = f"{project_dir}/requirements-remote.txt"
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "-r", requirements_file, "--quiet"],
     )
 
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "-e", PROJECT_DIR, "--no-deps", "--quiet"],
+        [sys.executable, "-m", "pip", "install", "-e", project_dir, "--no-deps", "--quiet"],
     )
 
-    env_file = f"{PROJECT_DIR}/test.env.remote"
+    env_file = f"{project_dir}/test.env.remote"
     if os.path.exists(env_file):
         from dotenv import load_dotenv
 
@@ -49,18 +54,16 @@ def main() -> None:
 
     os.environ["FABRIC_TEST_SPARK_EXEC_MODE"] = "remote"
 
-    pytest_args = sys.argv[1:]
-
     has_junitxml = any(arg.startswith("--junitxml") for arg in pytest_args)
     if not has_junitxml:
-        pytest_args.extend(["--junitxml", f"{ARTIFACTS_DIR}/results.xml"])
+        pytest_args.extend(["--junitxml", f"{artifacts_dir}/results.xml"])
 
     exit_code = subprocess.call(
         [sys.executable, "-m", "pytest"] + pytest_args,
-        cwd=PROJECT_DIR,
+        cwd=project_dir,
     )
 
-    exit_code_file = f"{ARTIFACTS_DIR}/exit_code.txt"
+    exit_code_file = f"{artifacts_dir}/exit_code.txt"
     with open(exit_code_file, "w") as f:
         f.write(str(exit_code))
 

--- a/tests/spark_remote/spark_entry_point.py
+++ b/tests/spark_remote/spark_entry_point.py
@@ -1,9 +1,9 @@
 """Entry point for remote pytest execution on Fabric Spark.
 
-This script is submitted as a Spark Job Definition. It receives a run ID
-as its first argument (used to locate the per-run project and artifacts
-directories on the lakehouse), installs the project and its dependencies,
-then runs pytest with the remaining arguments.
+This script is submitted as a Spark Job Definition. It receives a worktree
+key and run ID as its first two arguments, which determine the project and
+artifacts paths on the lakehouse. It installs the project and its
+dependencies, then runs pytest with the remaining arguments.
 """
 
 from __future__ import annotations
@@ -18,19 +18,20 @@ LAKEHOUSE_ROOT = "/lakehouse/default"
 def main() -> None:
     """Install dependencies, configure env, run pytest, and write exit code.
 
-    The first positional argument is the run ID, which determines the project
-    and artifacts paths on the lakehouse. All remaining arguments are forwarded
-    to pytest. Ensures --junitxml is set so results can be collected.
+    The first positional argument is the worktree key (locates the project
+    directory), the second is the run ID (locates the artifacts directory).
+    All remaining arguments are forwarded to pytest.
 
     Raises:
         subprocess.CalledProcessError: If pip install fails.
         SystemExit: Always exits with the pytest exit code.
     """
-    run_id = sys.argv[1]
-    pytest_args = sys.argv[2:]
+    worktree_key = sys.argv[1]
+    run_id = sys.argv[2]
+    pytest_args = sys.argv[3:]
 
-    project_dir = f"{LAKEHOUSE_ROOT}/Files/dbt-remote-runs/{run_id}/project"
-    artifacts_dir = f"{LAKEHOUSE_ROOT}/Files/dbt-remote-runs/{run_id}/artifacts"
+    project_dir = f"{LAKEHOUSE_ROOT}/Files/dbt-remote-runs/projects/{worktree_key}"
+    artifacts_dir = f"{LAKEHOUSE_ROOT}/Files/dbt-remote-runs/artifacts/{run_id}"
 
     if os.path.isdir(artifacts_dir):
         for f in os.listdir(artifacts_dir):

--- a/tests/spark_remote/spark_entry_point.py
+++ b/tests/spark_remote/spark_entry_point.py
@@ -1,0 +1,59 @@
+"""Entry point for remote pytest execution on Fabric Spark.
+
+This script is submitted as a Spark Job Definition. It installs the project
+and its dependencies, then runs pytest with the provided arguments. Results
+are written to junitxml on the lakehouse filesystem for the local pytest
+session to parse.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+LAKEHOUSE_ROOT = "/lakehouse/default"
+PROJECT_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-fabric-tests"
+ARTIFACTS_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-test-artifacts"
+
+
+def main() -> None:
+    os.makedirs(ARTIFACTS_DIR, exist_ok=True)
+
+    requirements_file = f"{PROJECT_DIR}/requirements-remote.txt"
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-r", requirements_file, "--quiet"],
+    )
+
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-e", PROJECT_DIR, "--no-deps", "--quiet"],
+    )
+
+    env_file = f"{PROJECT_DIR}/test.env.remote"
+    if os.path.exists(env_file):
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file, override=True)
+
+    os.environ["FABRIC_TEST_SPARK_EXEC_MODE"] = "remote"
+
+    pytest_args = sys.argv[1:]
+
+    has_junitxml = any(arg.startswith("--junitxml") for arg in pytest_args)
+    if not has_junitxml:
+        pytest_args.extend(["--junitxml", f"{ARTIFACTS_DIR}/results.xml"])
+
+    exit_code = subprocess.call(
+        [sys.executable, "-m", "pytest"] + pytest_args,
+        cwd=PROJECT_DIR,
+    )
+
+    exit_code_file = f"{ARTIFACTS_DIR}/exit_code.txt"
+    with open(exit_code_file, "w") as f:
+        f.write(str(exit_code))
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import requests
+
+FABRIC_API_BASE = "https://api.fabric.microsoft.com"
+FABRIC_CREDENTIAL_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+
+
+@dataclass
+class SparkJobResult:
+    status: str
+    start_time: str | None
+    end_time: str | None
+    job_url: str
+    error_message: str | None
+
+
+class SparkJobClient:
+    def __init__(self, workspace_id: str, token_provider_fn: Callable[[], str]):
+        self._workspace_id = workspace_id
+        self._token_provider_fn = token_provider_fn
+
+    def _headers(self) -> dict[str, str]:
+        token = self._token_provider_fn()
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def _get(self, path: str, **kwargs) -> requests.Response:
+        url = f"{FABRIC_API_BASE}{path}"
+        resp = requests.get(url, headers=self._headers(), **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def _post(self, path: str, json_data: dict | None = None, **kwargs) -> requests.Response:
+        url = f"{FABRIC_API_BASE}{path}"
+        resp = requests.post(url, headers=self._headers(), json=json_data, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def list_spark_job_definitions(self) -> list[dict]:
+        items = []
+        path = f"/v1/workspaces/{self._workspace_id}/sparkJobDefinitions"
+        while path:
+            resp = self._get(path)
+            data = resp.json()
+            items.extend(data.get("value", []))
+            path = data.get("continuationUri")
+        return items
+
+    def find_by_name(self, name: str) -> dict | None:
+        for item in self.list_spark_job_definitions():
+            if item.get("displayName") == name:
+                return item
+        return None
+
+    def create_spark_job_definition(
+        self, name: str, lakehouse_id: str, executable_path: str
+    ) -> str:
+        payload_json = json.dumps(
+            {
+                "executableFile": executable_path,
+                "defaultLakehouseArtifactId": lakehouse_id,
+                "language": "Python",
+                "environmentArtifactId": None,
+            }
+        )
+        payload_b64 = base64.b64encode(payload_json.encode()).decode()
+
+        body = {
+            "displayName": name,
+            "definition": {
+                "parts": [
+                    {
+                        "path": "SparkJobDefinitionV1.json",
+                        "payload": payload_b64,
+                        "payloadType": "InlineBase64",
+                    }
+                ]
+            },
+        }
+
+        path = f"/v1/workspaces/{self._workspace_id}/sparkJobDefinitions"
+        resp = self._post(path, json_data=body)
+        return resp.json()["id"]
+
+    def run_on_demand(self, item_id: str, command_line_args: list[str]) -> tuple[str, str]:
+        path = (
+            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances?jobType=sparkjob"
+        )
+        body = {"executionData": {"commandLineArguments": " ".join(command_line_args)}}
+        resp = self._post(path, json_data=body)
+
+        location = resp.headers.get("Location", "")
+        # Location header format: .../items/{item_id}/jobs/instances/{job_instance_id}
+        parts = location.rstrip("/").split("/")
+        job_instance_id = parts[-1] if parts else ""
+        return item_id, job_instance_id
+
+    def get_job_instance(self, item_id: str, job_instance_id: str) -> dict:
+        path = (
+            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances/{job_instance_id}"
+        )
+        return self._get(path).json()
+
+    def poll_until_done(
+        self, item_id: str, job_instance_id: str, interval: int = 10, timeout: int = 1800
+    ) -> SparkJobResult:
+        job_url = (
+            f"https://app.fabric.microsoft.com/groups/{self._workspace_id}"
+            f"/sparkJobDefinitions/{item_id}/runs/{job_instance_id}"
+        )
+        start = time.time()
+        last_status = ""
+
+        while True:
+            elapsed = time.time() - start
+            if elapsed > timeout:
+                return SparkJobResult(
+                    status="Timeout",
+                    start_time=None,
+                    end_time=None,
+                    job_url=job_url,
+                    error_message=f"Job timed out after {timeout}s. Check: {job_url}",
+                )
+
+            instance = self._get_with_retry(item_id, job_instance_id)
+            status = instance.get("status", "Unknown")
+
+            if status != last_status:
+                minutes = int(elapsed) // 60
+                seconds = int(elapsed) % 60
+                print(f"  [{minutes}:{seconds:02d}] {status}...")
+                last_status = status
+
+            if status in ("Completed", "Failed", "Cancelled", "Deduped"):
+                return SparkJobResult(
+                    status=status,
+                    start_time=instance.get("startTimeUtc"),
+                    end_time=instance.get("endTimeUtc"),
+                    job_url=job_url,
+                    error_message=instance.get("failureReason", {}).get("message"),
+                )
+
+            time.sleep(interval)
+
+    def _get_with_retry(self, item_id: str, job_instance_id: str, max_retries: int = 3) -> dict:
+        path = (
+            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances/{job_instance_id}"
+        )
+        for attempt in range(max_retries):
+            try:
+                return self._get(path).json()
+            except requests.exceptions.RequestException:
+                if attempt == max_retries - 1:
+                    raise
+                time.sleep(2 ** (attempt + 1))
+        return {}

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -11,6 +11,8 @@ from dbt.adapters.fabric.fabric_api_client import FabricApiClient, FabricApiErro
 
 @dataclass
 class SparkJobResult:
+    """Result of a Spark Job Definition execution."""
+
     status: str
     start_time: str | None
     end_time: str | None
@@ -19,6 +21,12 @@ class SparkJobResult:
 
 
 class SparkJobClient:
+    """Client for managing and running Spark Job Definitions via the Fabric REST API.
+
+    Args:
+        api_client: Authenticated FabricApiClient for HTTP communication.
+    """
+
     def __init__(self, api_client: FabricApiClient):
         self._api_client = api_client
 
@@ -31,6 +39,14 @@ class SparkJobClient:
         return self._api_client.get_workspace_id()
 
     def list_spark_job_definitions(self) -> list[dict]:
+        """List all Spark Job Definitions in the workspace, following pagination.
+
+        Returns:
+            List of Spark Job Definition metadata dicts.
+
+        Raises:
+            FabricApiError: If the API request fails.
+        """
         items = []
         url: str | None = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions"
         while url:
@@ -41,6 +57,17 @@ class SparkJobClient:
         return items
 
     def find_by_name(self, name: str) -> dict | None:
+        """Find a Spark Job Definition by its display name.
+
+        Args:
+            name: The display name to search for.
+
+        Returns:
+            The matching item dict, or None if not found.
+
+        Raises:
+            FabricApiError: If the API request fails.
+        """
         for item in self.list_spark_job_definitions():
             if item.get("displayName") == name:
                 return item
@@ -49,6 +76,19 @@ class SparkJobClient:
     def create_spark_job_definition(
         self, name: str, lakehouse_id: str, executable_path: str
     ) -> str:
+        """Create a new Spark Job Definition in the workspace.
+
+        Args:
+            name: Display name for the new job definition.
+            lakehouse_id: ID of the default lakehouse to attach.
+            executable_path: abfss:// path to the Python entry point script.
+
+        Returns:
+            The ID of the newly created Spark Job Definition.
+
+        Raises:
+            FabricApiError: If the API request fails.
+        """
         payload_json = json.dumps(
             {
                 "executableFile": executable_path,
@@ -77,6 +117,18 @@ class SparkJobClient:
         return resp.json()["id"]
 
     def run_on_demand(self, item_id: str, command_line_args: list[str]) -> tuple[str, str]:
+        """Submit an on-demand run of a Spark Job Definition.
+
+        Args:
+            item_id: ID of the Spark Job Definition to run.
+            command_line_args: Command-line arguments to pass to the job.
+
+        Returns:
+            Tuple of (item_id, job_instance_id) for tracking the run.
+
+        Raises:
+            FabricApiError: If the API request fails.
+        """
         url = (
             f"{self._base_url}/workspaces/{self._workspace_id}"
             f"/items/{item_id}/jobs/instances?jobType=sparkjob"
@@ -90,6 +142,18 @@ class SparkJobClient:
         return item_id, job_instance_id
 
     def get_job_instance(self, item_id: str, job_instance_id: str) -> dict:
+        """Get the current state of a job instance.
+
+        Args:
+            item_id: ID of the Spark Job Definition.
+            job_instance_id: ID of the specific job run instance.
+
+        Returns:
+            Job instance metadata dict including status, timestamps, and failure info.
+
+        Raises:
+            FabricApiError: If the API request fails.
+        """
         url = (
             f"{self._base_url}/workspaces/{self._workspace_id}"
             f"/items/{item_id}/jobs/instances/{job_instance_id}"
@@ -99,6 +163,19 @@ class SparkJobClient:
     def poll_until_done(
         self, item_id: str, job_instance_id: str, interval: int = 10, timeout: int = 1800
     ) -> SparkJobResult:
+        """Poll a job instance until it reaches a terminal state.
+
+        Prints status updates to stdout when the status changes.
+
+        Args:
+            item_id: ID of the Spark Job Definition.
+            job_instance_id: ID of the specific job run instance.
+            interval: Seconds between polling attempts.
+            timeout: Maximum seconds to wait before returning a Timeout result.
+
+        Returns:
+            SparkJobResult with final status, timestamps, and any error message.
+        """
         workspace_id = self._workspace_id
         job_url = (
             f"https://app.fabric.microsoft.com/groups/{workspace_id}"
@@ -139,6 +216,19 @@ class SparkJobClient:
             time.sleep(interval)
 
     def _get_with_retry(self, item_id: str, job_instance_id: str, max_retries: int = 3) -> dict:
+        """Fetch job instance state with retry on transient API errors.
+
+        Args:
+            item_id: ID of the Spark Job Definition.
+            job_instance_id: ID of the specific job run instance.
+            max_retries: Maximum number of attempts before raising.
+
+        Returns:
+            Job instance metadata dict.
+
+        Raises:
+            FabricApiError: If all retry attempts fail.
+        """
         url = (
             f"{self._base_url}/workspaces/{self._workspace_id}"
             f"/items/{item_id}/jobs/instances/{job_instance_id}"

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -5,12 +5,8 @@ import json
 import shlex
 import time
 from dataclasses import dataclass
-from typing import Callable
 
-import requests
-
-FABRIC_API_BASE = "https://api.fabric.microsoft.com"
-FABRIC_CREDENTIAL_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+from dbt.adapters.fabric.fabric_api_client import FabricApiClient, FabricApiError
 
 
 @dataclass
@@ -23,39 +19,25 @@ class SparkJobResult:
 
 
 class SparkJobClient:
-    def __init__(self, workspace_id: str, token_provider_fn: Callable[[], str]):
-        self._workspace_id = workspace_id
-        self._token_provider_fn = token_provider_fn
+    def __init__(self, api_client: FabricApiClient):
+        self._api_client = api_client
 
-    def _headers(self) -> dict[str, str]:
-        token = self._token_provider_fn()
-        return {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
+    @property
+    def _base_url(self) -> str:
+        return self._api_client._credentials.fabric_base_api_uri
 
-    def _get(self, url_or_path: str, **kwargs) -> requests.Response:
-        url = url_or_path if url_or_path.startswith("http") else f"{FABRIC_API_BASE}{url_or_path}"
-        resp = requests.get(url, headers=self._headers(), **kwargs)
-        resp.raise_for_status()
-        return resp
-
-    def _post(
-        self, url_or_path: str, json_data: dict | None = None, **kwargs
-    ) -> requests.Response:
-        url = url_or_path if url_or_path.startswith("http") else f"{FABRIC_API_BASE}{url_or_path}"
-        resp = requests.post(url, headers=self._headers(), json=json_data, **kwargs)
-        resp.raise_for_status()
-        return resp
+    @property
+    def _workspace_id(self) -> str:
+        return self._api_client.get_workspace_id()
 
     def list_spark_job_definitions(self) -> list[dict]:
         items = []
-        path = f"/v1/workspaces/{self._workspace_id}/sparkJobDefinitions"
-        while path:
-            resp = self._get(path)
+        url: str | None = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions"
+        while url:
+            resp = self._api_client._api_get(url)
             data = resp.json()
             items.extend(data.get("value", []))
-            path = data.get("continuationUri")
+            url = data.get("continuationUri")
         return items
 
     def find_by_name(self, name: str) -> dict | None:
@@ -90,34 +72,36 @@ class SparkJobClient:
             },
         }
 
-        path = f"/v1/workspaces/{self._workspace_id}/sparkJobDefinitions"
-        resp = self._post(path, json_data=body)
+        url = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions"
+        resp = self._api_client._api_post(url, body)
         return resp.json()["id"]
 
     def run_on_demand(self, item_id: str, command_line_args: list[str]) -> tuple[str, str]:
-        path = (
-            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances?jobType=sparkjob"
+        url = (
+            f"{self._base_url}/workspaces/{self._workspace_id}"
+            f"/items/{item_id}/jobs/instances?jobType=sparkjob"
         )
         body = {"executionData": {"commandLineArguments": shlex.join(command_line_args)}}
-        resp = self._post(path, json_data=body)
+        resp = self._api_client._api_post(url, body)
 
         location = resp.headers.get("Location", "")
-        # Location header format: .../items/{item_id}/jobs/instances/{job_instance_id}
         parts = location.rstrip("/").split("/")
         job_instance_id = parts[-1] if parts else ""
         return item_id, job_instance_id
 
     def get_job_instance(self, item_id: str, job_instance_id: str) -> dict:
-        path = (
-            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances/{job_instance_id}"
+        url = (
+            f"{self._base_url}/workspaces/{self._workspace_id}"
+            f"/items/{item_id}/jobs/instances/{job_instance_id}"
         )
-        return self._get(path).json()
+        return self._api_client._api_get(url).json()
 
     def poll_until_done(
         self, item_id: str, job_instance_id: str, interval: int = 10, timeout: int = 1800
     ) -> SparkJobResult:
+        workspace_id = self._workspace_id
         job_url = (
-            f"https://app.fabric.microsoft.com/groups/{self._workspace_id}"
+            f"https://app.fabric.microsoft.com/groups/{workspace_id}"
             f"/sparkJobDefinitions/{item_id}/runs/{job_instance_id}"
         )
         start = time.time()
@@ -155,13 +139,14 @@ class SparkJobClient:
             time.sleep(interval)
 
     def _get_with_retry(self, item_id: str, job_instance_id: str, max_retries: int = 3) -> dict:
-        path = (
-            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances/{job_instance_id}"
+        url = (
+            f"{self._base_url}/workspaces/{self._workspace_id}"
+            f"/items/{item_id}/jobs/instances/{job_instance_id}"
         )
         for attempt in range(max_retries):
             try:
-                return self._get(path).json()
-            except requests.exceptions.RequestException:
+                return self._api_client._api_get(url).json()
+            except FabricApiError:
                 if attempt == max_retries - 1:
                     raise
                 time.sleep(2 ** (attempt + 1))

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -141,6 +141,18 @@ class SparkJobClient:
         job_instance_id = parts[-1] if parts else ""
         return item_id, job_instance_id
 
+    def delete_spark_job_definition(self, item_id: str) -> None:
+        """Delete a Spark Job Definition by ID.
+
+        Args:
+            item_id: ID of the Spark Job Definition to delete.
+
+        Raises:
+            FabricApiError: If the API request fails.
+        """
+        url = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions/{item_id}"
+        self._api_client._api_delete(url)
+
     def get_job_instance(self, item_id: str, job_instance_id: str) -> dict:
         """Get the current state of a job instance.
 

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import shlex
 import time
 from dataclasses import dataclass
 from typing import Callable
@@ -33,14 +34,16 @@ class SparkJobClient:
             "Content-Type": "application/json",
         }
 
-    def _get(self, path: str, **kwargs) -> requests.Response:
-        url = f"{FABRIC_API_BASE}{path}"
+    def _get(self, url_or_path: str, **kwargs) -> requests.Response:
+        url = url_or_path if url_or_path.startswith("http") else f"{FABRIC_API_BASE}{url_or_path}"
         resp = requests.get(url, headers=self._headers(), **kwargs)
         resp.raise_for_status()
         return resp
 
-    def _post(self, path: str, json_data: dict | None = None, **kwargs) -> requests.Response:
-        url = f"{FABRIC_API_BASE}{path}"
+    def _post(
+        self, url_or_path: str, json_data: dict | None = None, **kwargs
+    ) -> requests.Response:
+        url = url_or_path if url_or_path.startswith("http") else f"{FABRIC_API_BASE}{url_or_path}"
         resp = requests.post(url, headers=self._headers(), json=json_data, **kwargs)
         resp.raise_for_status()
         return resp
@@ -95,7 +98,7 @@ class SparkJobClient:
         path = (
             f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances?jobType=sparkjob"
         )
-        body = {"executionData": {"commandLineArguments": " ".join(command_line_args)}}
+        body = {"executionData": {"commandLineArguments": shlex.join(command_line_args)}}
         resp = self._post(path, json_data=body)
 
         location = resp.headers.get("Location", "")

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -32,7 +32,7 @@ class SparkJobClient:
 
     @property
     def _base_url(self) -> str:
-        return self._api_client._credentials.fabric_base_api_uri
+        return self._api_client.base_url
 
     @property
     def _workspace_id(self) -> str:
@@ -50,7 +50,7 @@ class SparkJobClient:
         items = []
         url: str | None = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions"
         while url:
-            resp = self._api_client._api_get(url)
+            resp = self._api_client.api_get(url)
             data = resp.json()
             items.extend(data.get("value", []))
             url = data.get("continuationUri")
@@ -113,7 +113,7 @@ class SparkJobClient:
         }
 
         url = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions"
-        resp = self._api_client._api_post(url, body)
+        resp = self._api_client.api_post(url, body)
         return resp.json()["id"]
 
     def run_on_demand(self, item_id: str, command_line_args: list[str]) -> tuple[str, str]:
@@ -134,11 +134,21 @@ class SparkJobClient:
             f"/items/{item_id}/jobs/instances?jobType=sparkjob"
         )
         body = {"executionData": {"commandLineArguments": shlex.join(command_line_args)}}
-        resp = self._api_client._api_post(url, body)
+        resp = self._api_client.api_post(url, body)
 
         location = resp.headers.get("Location", "")
-        parts = location.rstrip("/").split("/")
-        job_instance_id = parts[-1] if parts else ""
+        if not location:
+            raise FabricApiError(
+                "POST", url, resp.status_code, "No Location header in run_on_demand response"
+            )
+        job_instance_id = location.rstrip("/").split("/")[-1]
+        if not job_instance_id:
+            raise FabricApiError(
+                "POST",
+                url,
+                resp.status_code,
+                f"Could not parse job instance ID from Location: {location}",
+            )
         return item_id, job_instance_id
 
     def delete_spark_job_definition(self, item_id: str) -> None:
@@ -151,7 +161,7 @@ class SparkJobClient:
             FabricApiError: If the API request fails.
         """
         url = f"{self._base_url}/workspaces/{self._workspace_id}/sparkJobDefinitions/{item_id}"
-        self._api_client._api_delete(url)
+        self._api_client.api_delete(url)
 
     def get_job_instance(self, item_id: str, job_instance_id: str) -> dict:
         """Get the current state of a job instance.
@@ -170,7 +180,7 @@ class SparkJobClient:
             f"{self._base_url}/workspaces/{self._workspace_id}"
             f"/items/{item_id}/jobs/instances/{job_instance_id}"
         )
-        return self._api_client._api_get(url).json()
+        return self._api_client.api_get(url).json()
 
     def poll_until_done(
         self, item_id: str, job_instance_id: str, interval: int = 10, timeout: int = 1800
@@ -247,7 +257,7 @@ class SparkJobClient:
         )
         for attempt in range(max_retries):
             try:
-                return self._api_client._api_get(url).json()
+                return self._api_client.api_get(url).json()
             except FabricApiError:
                 if attempt == max_retries - 1:
                     raise

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -113,7 +113,16 @@ class ProjectSync:
             RuntimeError: If uv export fails.
         """
         result = subprocess.run(
-            ["uv", "export", "--format", "requirements.txt", "--all-extras", "--group", "dev"],
+            [
+                "uv",
+                "export",
+                "--format",
+                "requirements.txt",
+                "--all-extras",
+                "--group",
+                "dev",
+                "--no-emit-project",
+            ],
             capture_output=True,
             text=True,
             cwd=self._project_root,

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -13,30 +13,43 @@ EXCLUDE_PATTERNS = "*.pyc;*.pyo;*.egg-info"
 
 
 class ProjectSync:
-    """Syncs the local project to/from a per-run lakehouse directory via azcopy.
+    """Syncs the local project to/from OneLake via azcopy.
 
-    Each run gets isolated paths on OneLake to allow concurrent execution:
-    ``dbt-remote-runs/{run_id}/project/`` for the project and
-    ``dbt-remote-runs/{run_id}/artifacts/`` for test results.
+    Uses a two-level namespace for concurrent execution:
+
+    - ``dbt-remote-runs/projects/{worktree_key}/`` — project files, synced
+      incrementally per worktree (only changed files are transferred on
+      subsequent runs from the same worktree).
+    - ``dbt-remote-runs/artifacts/{run_id}/`` — test results, isolated per run.
 
     Args:
         workspace_id: Fabric workspace GUID.
         lakehouse_id: Lakehouse item GUID.
         project_root: Local path to the dbt-fabric project root.
+        worktree_key: Stable identifier for this worktree (hash of project root path).
         run_id: Unique identifier for this test run.
     """
 
-    def __init__(self, workspace_id: str, lakehouse_id: str, project_root: Path, run_id: str):
+    def __init__(
+        self,
+        workspace_id: str,
+        lakehouse_id: str,
+        project_root: Path,
+        worktree_key: str,
+        run_id: str,
+    ):
         self._project_root = project_root
+        self._worktree_key = worktree_key
         self._run_id = run_id
         self._onelake_base = (
             f"https://onelake.dfs.fabric.microsoft.com/{workspace_id}/{lakehouse_id}/Files"
         )
 
     def upload(self) -> None:
-        """Upload the project directory to a per-run lakehouse path.
+        """Upload the project directory to a per-worktree lakehouse path.
 
-        Generates a requirements file and sanitized test.env before syncing.
+        Uses incremental sync — only files that differ from the previous upload
+        of this worktree are transferred.
 
         Raises:
             RuntimeError: If azcopy sync or uv export fails.
@@ -44,7 +57,7 @@ class ProjectSync:
         self._generate_requirements()
         self._generate_test_env_remote()
 
-        target = f"{self._onelake_base}/dbt-remote-runs/{self._run_id}/project"
+        target = f"{self._onelake_base}/dbt-remote-runs/projects/{self._worktree_key}"
         print(f"  Syncing: {self._project_root} -> {target}")
 
         cmd = [
@@ -64,7 +77,7 @@ class ProjectSync:
         print("  Sync complete.")
 
     def download_artifacts(self, local_dir: Path) -> Path | None:
-        """Download test artifacts (junitxml) from the per-run lakehouse path.
+        """Download test artifacts (junitxml) from the per-run artifacts path.
 
         Args:
             local_dir: Local directory to sync artifacts into.
@@ -75,7 +88,7 @@ class ProjectSync:
         Raises:
             RuntimeError: If azcopy sync fails.
         """
-        source = f"{self._onelake_base}/dbt-remote-runs/{self._run_id}/artifacts"
+        source = f"{self._onelake_base}/dbt-remote-runs/artifacts/{self._run_id}"
         local_dir.mkdir(parents=True, exist_ok=True)
 
         cmd = [

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -7,28 +7,34 @@ from pathlib import Path
 EXCLUDE_PATHS = (
     ".venv;.git;__pycache__;.cache;.claude;logs;.ruff_cache;"
     ".pytest_cache;.eggs;dist;build;site;.vscode;node_modules;"
-    "remote-test-results;dbt-test-artifacts"
+    "remote-test-results"
 )
 EXCLUDE_PATTERNS = "*.pyc;*.pyo;*.egg-info"
 
 
 class ProjectSync:
-    """Syncs the local project to/from a lakehouse on OneLake via azcopy.
+    """Syncs the local project to/from a per-run lakehouse directory via azcopy.
+
+    Each run gets isolated paths on OneLake to allow concurrent execution:
+    ``dbt-remote-runs/{run_id}/project/`` for the project and
+    ``dbt-remote-runs/{run_id}/artifacts/`` for test results.
 
     Args:
         workspace_id: Fabric workspace GUID.
         lakehouse_id: Lakehouse item GUID.
         project_root: Local path to the dbt-fabric project root.
+        run_id: Unique identifier for this test run.
     """
 
-    def __init__(self, workspace_id: str, lakehouse_id: str, project_root: Path):
+    def __init__(self, workspace_id: str, lakehouse_id: str, project_root: Path, run_id: str):
         self._project_root = project_root
+        self._run_id = run_id
         self._onelake_base = (
             f"https://onelake.dfs.fabric.microsoft.com/{workspace_id}/{lakehouse_id}/Files"
         )
 
     def upload(self) -> None:
-        """Upload the project directory to the lakehouse, excluding build artifacts.
+        """Upload the project directory to a per-run lakehouse path.
 
         Generates a requirements file and sanitized test.env before syncing.
 
@@ -38,7 +44,7 @@ class ProjectSync:
         self._generate_requirements()
         self._generate_test_env_remote()
 
-        target = f"{self._onelake_base}/dbt-fabric-tests"
+        target = f"{self._onelake_base}/dbt-remote-runs/{self._run_id}/project"
         print(f"  Syncing: {self._project_root} -> {target}")
 
         cmd = [
@@ -58,7 +64,7 @@ class ProjectSync:
         print("  Sync complete.")
 
     def download_artifacts(self, local_dir: Path) -> Path | None:
-        """Download test artifacts (junitxml) from the lakehouse.
+        """Download test artifacts (junitxml) from the per-run lakehouse path.
 
         Args:
             local_dir: Local directory to sync artifacts into.
@@ -69,7 +75,7 @@ class ProjectSync:
         Raises:
             RuntimeError: If azcopy sync fails.
         """
-        source = f"{self._onelake_base}/dbt-test-artifacts"
+        source = f"{self._onelake_base}/dbt-remote-runs/{self._run_id}/artifacts"
         local_dir.mkdir(parents=True, exist_ok=True)
 
         cmd = [

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -13,6 +13,14 @@ EXCLUDE_PATTERNS = "*.pyc;*.pyo;*.egg-info"
 
 
 class ProjectSync:
+    """Syncs the local project to/from a lakehouse on OneLake via azcopy.
+
+    Args:
+        workspace_id: Fabric workspace GUID.
+        lakehouse_id: Lakehouse item GUID.
+        project_root: Local path to the dbt-fabric project root.
+    """
+
     def __init__(self, workspace_id: str, lakehouse_id: str, project_root: Path):
         self._project_root = project_root
         self._onelake_base = (
@@ -20,6 +28,13 @@ class ProjectSync:
         )
 
     def upload(self) -> None:
+        """Upload the project directory to the lakehouse, excluding build artifacts.
+
+        Generates a requirements file and sanitized test.env before syncing.
+
+        Raises:
+            RuntimeError: If azcopy sync or uv export fails.
+        """
         self._generate_requirements()
         self._generate_test_env_remote()
 
@@ -43,6 +58,17 @@ class ProjectSync:
         print("  Sync complete.")
 
     def download_artifacts(self, local_dir: Path) -> Path | None:
+        """Download test artifacts (junitxml) from the lakehouse.
+
+        Args:
+            local_dir: Local directory to sync artifacts into.
+
+        Returns:
+            Path to results.xml if it exists after download, otherwise None.
+
+        Raises:
+            RuntimeError: If azcopy sync fails.
+        """
         source = f"{self._onelake_base}/dbt-test-artifacts"
         local_dir.mkdir(parents=True, exist_ok=True)
 
@@ -62,6 +88,11 @@ class ProjectSync:
         return results_xml if results_xml.exists() else None
 
     def _generate_requirements(self) -> None:
+        """Export pinned requirements via uv for remote pip install.
+
+        Raises:
+            RuntimeError: If uv export fails.
+        """
         result = subprocess.run(
             ["uv", "export", "--format", "requirements.txt", "--all-extras", "--group", "dev"],
             capture_output=True,
@@ -75,6 +106,11 @@ class ProjectSync:
         reqs_path.write_text(result.stdout)
 
     def _generate_test_env_remote(self) -> None:
+        """Create a sanitized test.env.remote with secrets stripped and auth overridden.
+
+        Reads the local test.env, removes sensitive variables (client secrets,
+        federated tokens), and overrides authentication to use notebookutils.
+        """
         test_env_path = self._project_root / "test.env"
         remote_env_path = self._project_root / "test.env.remote"
 
@@ -111,6 +147,11 @@ class ProjectSync:
 
 
 def check_prerequisites() -> list[str]:
+    """Verify that required CLI tools (azcopy, az) are available and authenticated.
+
+    Returns:
+        List of human-readable error messages. Empty if all prerequisites are met.
+    """
     errors = []
 
     if not shutil.which("azcopy"):

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -114,8 +114,15 @@ def check_prerequisites() -> list[str]:
             "?WT.mc_id=MVP_310840"
         )
 
-    result = subprocess.run(["az", "account", "show"], capture_output=True, text=True)
-    if result.returncode != 0:
-        errors.append("Azure CLI not logged in. Run: az login")
+    try:
+        result = subprocess.run(["az", "account", "show"], capture_output=True, text=True)
+        if result.returncode != 0:
+            errors.append("Azure CLI not logged in. Run: az login")
+    except FileNotFoundError:
+        errors.append(
+            "Azure CLI (az) not found on PATH. Install from: "
+            "https://learn.microsoft.com/en-us/cli/azure/install-azure-cli"
+            "?WT.mc_id=MVP_310840"
+        )
 
     return errors

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -13,13 +13,10 @@ EXCLUDE_PATTERNS = "*.pyc;*.pyo;*.egg-info"
 
 
 class ProjectSync:
-    def __init__(self, workspace_name: str, lakehouse_name: str, project_root: Path):
-        self._workspace_name = workspace_name
-        self._lakehouse_name = lakehouse_name
+    def __init__(self, workspace_id: str, lakehouse_id: str, project_root: Path):
         self._project_root = project_root
         self._onelake_base = (
-            f"https://onelake.dfs.fabric.microsoft.com"
-            f"/{workspace_name}/{lakehouse_name}.Lakehouse/Files"
+            f"https://onelake.dfs.fabric.microsoft.com/{workspace_id}/{lakehouse_id}/Files"
         )
 
     def upload(self) -> None:

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -83,6 +83,13 @@ class ProjectSync:
             "FABRIC_TEST_SPARK_EXEC_MODE": "remote",
         }
 
+        secret_prefixes = (
+            "FABRIC_TEST_CLIENT_SECRET",
+            "FABRIC_TEST_FEDERATED_TOKEN",
+            "FABRIC_TEST_TENANT_ID",
+            "FABRIC_TEST_CLIENT_ID",
+        )
+
         lines = []
         if test_env_path.exists():
             for line in test_env_path.read_text().splitlines():
@@ -92,6 +99,8 @@ class ProjectSync:
                     continue
                 key = stripped.split("=", 1)[0]
                 if key in overrides:
+                    continue
+                if key.startswith(secret_prefixes):
                     continue
                 lines.append(line)
 

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+EXCLUDE_PATHS = (
+    ".venv;.git;__pycache__;.cache;.claude;logs;.ruff_cache;"
+    ".pytest_cache;.eggs;dist;build;site;.vscode;node_modules;"
+    "remote-test-results;dbt-test-artifacts"
+)
+EXCLUDE_PATTERNS = "*.pyc;*.pyo;*.egg-info"
+
+
+class ProjectSync:
+    def __init__(self, workspace_name: str, lakehouse_name: str, project_root: Path):
+        self._workspace_name = workspace_name
+        self._lakehouse_name = lakehouse_name
+        self._project_root = project_root
+        self._onelake_base = (
+            f"https://onelake.dfs.fabric.microsoft.com"
+            f"/{workspace_name}/{lakehouse_name}.Lakehouse/Files"
+        )
+
+    def upload(self) -> None:
+        self._generate_requirements()
+        self._generate_test_env_remote()
+
+        target = f"{self._onelake_base}/dbt-fabric-tests"
+        print(f"  Syncing: {self._project_root} -> {target}")
+
+        cmd = [
+            "azcopy",
+            "sync",
+            str(self._project_root),
+            target,
+            "--login-type=azcli",
+            f"--exclude-path={EXCLUDE_PATHS}",
+            f"--exclude-pattern={EXCLUDE_PATTERNS}",
+            "--delete-destination=true",
+            "--put-md5",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"azcopy sync failed:\n{result.stderr}")
+        print("  Sync complete.")
+
+    def download_artifacts(self, local_dir: Path) -> Path | None:
+        source = f"{self._onelake_base}/dbt-test-artifacts"
+        local_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "azcopy",
+            "sync",
+            source,
+            str(local_dir),
+            "--login-type=azcli",
+            "--delete-destination=true",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"azcopy artifact download failed:\n{result.stderr}")
+
+        results_xml = local_dir / "results.xml"
+        return results_xml if results_xml.exists() else None
+
+    def _generate_requirements(self) -> None:
+        result = subprocess.run(
+            ["uv", "export", "--format", "requirements.txt", "--all-extras", "--group", "dev"],
+            capture_output=True,
+            text=True,
+            cwd=self._project_root,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"uv export failed:\n{result.stderr}")
+
+        reqs_path = self._project_root / "requirements-remote.txt"
+        reqs_path.write_text(result.stdout)
+
+    def _generate_test_env_remote(self) -> None:
+        test_env_path = self._project_root / "test.env"
+        remote_env_path = self._project_root / "test.env.remote"
+
+        overrides = {
+            "FABRIC_TEST_AUTH": "notebookutils",
+            "FABRIC_TEST_SPARK_EXEC_MODE": "remote",
+        }
+
+        lines = []
+        if test_env_path.exists():
+            for line in test_env_path.read_text().splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    lines.append(line)
+                    continue
+                key = stripped.split("=", 1)[0]
+                if key in overrides:
+                    continue
+                lines.append(line)
+
+        for key, value in overrides.items():
+            lines.append(f"{key}={value}")
+
+        remote_env_path.write_text("\n".join(lines) + "\n")
+
+
+def check_prerequisites() -> list[str]:
+    errors = []
+
+    if not shutil.which("azcopy"):
+        errors.append(
+            "azcopy not found on PATH. Install from: "
+            "https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10"
+            "?WT.mc_id=MVP_310840"
+        )
+
+    result = subprocess.run(["az", "account", "show"], capture_output=True, text=True)
+    if result.returncode != 0:
+        errors.append("Azure CLI not logged in. Run: az login")
+
+    return errors

--- a/tests/unit/test_fabric_api_client.py
+++ b/tests/unit/test_fabric_api_client.py
@@ -113,7 +113,7 @@ class TestApiRequest:
     def test_post_sends_json_body(self, mock_request, client):
         mock_request.return_value = _make_response(200)
 
-        client._api_post("https://example.com/api", {"key": "value"})
+        client.api_post("https://example.com/api", {"key": "value"})
 
         call_kwargs = mock_request.call_args[1]
         assert call_kwargs["json"] == {"key": "value"}

--- a/tests/unit/test_result_reporter.py
+++ b/tests/unit/test_result_reporter.py
@@ -3,54 +3,61 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+from junitparser import TestCase
+
 from tests.spark_remote.result_reporter import _parse_junitxml, _reconstruct_nodeid
 
 
-def _make_testcase_element(**attrs):
-    import xml.etree.ElementTree as ET
-
-    return ET.fromstring("<testcase " + " ".join(f'{k}="{v}"' for k, v in attrs.items()) + " />")
+def _make_testcase(**attrs) -> TestCase:
+    case = TestCase()
+    case.name = attrs.get("name", "")
+    case.classname = attrs.get("classname", "")
+    if "file" in attrs:
+        case._elem.set("file", attrs["file"])
+    return case
 
 
 class TestReconstructNodeid:
     def test_simple_file_and_name(self):
-        el = _make_testcase_element(
+        case = _make_testcase(
             file="tests/unit/test_foo.py",
             classname="tests.unit.test_foo.TestFoo",
             name="test_bar",
         )
-        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestFoo::test_bar"
+        assert _reconstruct_nodeid(case) == "tests/unit/test_foo.py::TestFoo::test_bar"
 
     def test_no_class_in_classname(self):
-        el = _make_testcase_element(
+        case = _make_testcase(
             file="tests/unit/test_foo.py",
             classname="tests.unit.test_foo",
             name="test_standalone",
         )
-        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::test_standalone"
+        assert _reconstruct_nodeid(case) == "tests/unit/test_foo.py::test_standalone"
 
     def test_parametrized_name(self):
-        el = _make_testcase_element(
+        case = _make_testcase(
             file="tests/unit/test_foo.py",
             classname="tests.unit.test_foo.TestParams",
             name="test_add[1-2-3]",
         )
-        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestParams::test_add[1-2-3]"
+        assert _reconstruct_nodeid(case) == "tests/unit/test_foo.py::TestParams::test_add[1-2-3]"
 
     def test_nested_class(self):
-        el = _make_testcase_element(
+        case = _make_testcase(
             file="tests/unit/test_foo.py",
             classname="tests.unit.test_foo.TestOuter.TestInner",
             name="test_deep",
         )
-        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestOuter::TestInner::test_deep"
+        assert (
+            _reconstruct_nodeid(case) == "tests/unit/test_foo.py::TestOuter::TestInner::test_deep"
+        )
 
     def test_fallback_no_file_attr(self):
-        el = _make_testcase_element(
+        case = _make_testcase(
             classname="tests.unit.test_foo.TestClass",
             name="test_method",
         )
-        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestClass::test_method"
+        assert _reconstruct_nodeid(case) == "tests/unit/test_foo.py::TestClass::test_method"
 
 
 class TestParseJunitxml:

--- a/tests/unit/test_result_reporter.py
+++ b/tests/unit/test_result_reporter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from tests.spark_remote.result_reporter import _parse_junitxml, _reconstruct_nodeid
+
+
+def _make_testcase_element(**attrs):
+    import xml.etree.ElementTree as ET
+
+    return ET.fromstring("<testcase " + " ".join(f'{k}="{v}"' for k, v in attrs.items()) + " />")
+
+
+class TestReconstructNodeid:
+    def test_simple_file_and_name(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo.TestFoo",
+            name="test_bar",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestFoo::test_bar"
+
+    def test_no_class_in_classname(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo",
+            name="test_standalone",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::test_standalone"
+
+    def test_parametrized_name(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo.TestParams",
+            name="test_add[1-2-3]",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestParams::test_add[1-2-3]"
+
+    def test_nested_class(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo.TestOuter.TestInner",
+            name="test_deep",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestOuter::TestInner::test_deep"
+
+    def test_fallback_no_file_attr(self):
+        el = _make_testcase_element(
+            classname="tests.unit.test_foo.TestClass",
+            name="test_method",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestClass::test_method"
+
+
+class TestParseJunitxml:
+    def test_passed(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_one" time="0.5"/>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].nodeid == "tests/test_a.py::TestA::test_one"
+        assert results[0].outcome == "passed"
+        assert results[0].duration == 0.5
+
+    def test_failed(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_fail" time="1.2">
+                <failure message="assert False">Traceback here</failure>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].outcome == "failed"
+        assert results[0].failure_message == "Traceback here"
+
+    def test_skipped(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_skip" time="0.0">
+                <skipped message="not supported"/>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].outcome == "skipped"
+        assert results[0].skip_reason == "not supported"
+
+    def test_error(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_err" time="0.1">
+                <error message="setup failed">Error details</error>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].outcome == "failed"
+        assert results[0].failure_message == "Error details"
+
+    def test_captures_stdout_stderr(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_output" time="0.3">
+                <system-out>hello stdout</system-out>
+                <system-err>hello stderr</system-err>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert ("Captured stdout (remote)", "hello stdout") in results[0].sections
+        assert ("Captured stderr (remote)", "hello stderr") in results[0].sections
+
+    def test_multiple_testcases(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a" name="test_one" time="0.1"/>
+              <testcase file="tests/test_a.py" classname="tests.test_a" name="test_two" time="0.2"/>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 2
+        assert results[0].nodeid == "tests/test_a.py::test_one"
+        assert results[1].nodeid == "tests/test_a.py::test_two"

--- a/uv.lock
+++ b/uv.lock
@@ -383,6 +383,7 @@ spark = [
 dev = [
     { name = "dbt-core" },
     { name = "dbt-tests-adapter" },
+    { name = "junitparser" },
     { name = "pytest" },
     { name = "pytest-dotenv" },
     { name = "ruff" },
@@ -406,6 +407,7 @@ provides-extras = ["spark"]
 dev = [
     { name = "dbt-core", specifier = ">=1.9.6,<1.13.0" },
     { name = "dbt-tests-adapter", specifier = ">=1.19.7,<2.0" },
+    { name = "junitparser", specifier = ">=5.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-dotenv", specifier = ">=0.5.2" },
     { name = "ruff", specifier = ">=0.15.1" },
@@ -584,6 +586,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "junitparser"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/61/1685f940545177c553683c10114f5bb5bc093996fe651b29b8bee07f63e9/junitparser-5.0.0.tar.gz", hash = "sha256:f15e292877258d7c5755d672ce86f82c3622c7ea4c2f44f55de44ed7518484d3", size = 26259, upload-time = "2026-03-29T01:59:15.864Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/e6/54c543336cc49aadc50fea1b66835903afbdcff9eeb8a9d26a475b2d9c47/junitparser-5.0.0-py3-none-any.whl", hash = "sha256:9e279f2214dc74b6a86b22db757abda2e8e66e819fe882dad5b392d57024cd26", size = 14801, upload-time = "2026-03-29T01:59:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a native `--remote` pytest flag that transparently delegates FabricSpark test execution to a Spark Job Definition on Fabric infrastructure
- Adds Mode B (mounted lakehouse) support that redirects test artifacts to OneLake-accessible paths
- The developer experience is simply `pytest --de --remote -k "TestFoo"` — no separate CLI needed

## How it works

1. Local pytest collects tests normally
2. `pytest_runtestloop` hook intercepts when `--remote` is set
3. Syncs project to lakehouse via azcopy
4. Triggers a Spark Job Definition with forwarded pytest args + `--junitxml`
5. Polls for completion, downloads results
6. Parses junitxml and reports results back to local pytest session

## New files

- `tests/spark_remote/conftest_plugin.py` — pytest_runtestloop hook implementation
- `tests/spark_remote/result_reporter.py` — junitxml → TestReport mapping
- `tests/spark_remote/orchestrator.py` — coordinates sync + job client
- `tests/spark_remote/spark_job_client.py` — Fabric REST API wrapper
- `tests/spark_remote/sync.py` — azcopy sync wrapper
- `tests/spark_remote/spark_entry_point.py` — runs inside Spark job

## Test plan

- [ ] Verify `pytest --de` still works without `--remote` (no regression)
- [ ] Verify `--remote` without `--de` exits with error
- [ ] Test Mode B dry-run with `FABRIC_TEST_SPARK_EXEC_MODE=mounted`
- [ ] End-to-end test with real Fabric workspace

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)