### PR TITLE
Add remote Spark test orchestration framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,10 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,linux,visualstudiocode,python
 test.env
+test.env.remote
+requirements-remote.txt
+dbt-test-artifacts/
+remote-test-results/
 docs_build/site
 .claude/*
 !.claude/skills/

--- a/test.env.sample
+++ b/test.env.sample
@@ -21,3 +21,8 @@ FABRIC_TEST_HOST=your-endpoint.datawarehouse.fabric.microsoft.com
 DBT_TEST_USER_1=dbo
 DBT_TEST_USER_2=dbo
 DBT_TEST_USER_3=dbo
+# Remote Spark test execution (optional, use with pytest --remote --de)
+#FABRIC_TEST_SPARK_EXEC_MODE=        # "remote" or "mounted"; empty = local (default)
+#FABRIC_TEST_ONELAKE_PATH=           # required for "mounted" mode (local mount path)
+#FABRIC_TEST_SPARK_JOB_NAME=dbt-fabric-tests  # Spark Job Definition display name
+#FABRIC_TEST_REMOTE_LAKEHOUSE_ID=00000000-0000-0000-0000-000000000000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import importlib.util
 import os
 from pathlib import Path
 
+import py
 import pytest
 import yaml
 
@@ -96,6 +97,12 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--dw", action="store_true", default=False, help="run only Fabric T-SQL tests"
+    )
+    parser.addoption(
+        "--remote",
+        action="store_true",
+        default=False,
+        help="Run FabricSpark tests as a remote Spark job on Fabric infrastructure",
     )
 
 
@@ -191,6 +198,51 @@ def pytest_collection_modifyitems(config, items):
             )
 
 
+def _on_fabric_project_base() -> Path | None:
+    mode = os.getenv("FABRIC_TEST_SPARK_EXEC_MODE", "").lower()
+    if mode == "remote":
+        return Path("/lakehouse/default/Files/dbt-test-artifacts")
+    elif mode == "mounted":
+        path = os.getenv("FABRIC_TEST_ONELAKE_PATH")
+        if not path:
+            raise ValueError("FABRIC_TEST_ONELAKE_PATH required when SPARK_EXEC_MODE=mounted")
+        return Path(path) / "dbt-test-artifacts"
+    return None
+
+
+def pytest_runtestloop(session):
+    if not session.config.getoption("--remote", default=False):
+        return None
+    if not session.config.getoption("--de", default=False):
+        pytest.exit("--remote requires --de (FabricSpark tests only)", returncode=4)
+    from tests.spark_remote.conftest_plugin import remote_runtestloop
+
+    return remote_runtestloop(session)
+
+
+@pytest.fixture(scope="class")
+def project_root(tmpdir_factory, prefix):
+    base = _on_fabric_project_base()
+    if base is None:
+        project_root = tmpdir_factory.mktemp("project")
+        print(f"\n=== Test project_root: {project_root}")
+        return project_root
+    path = base / prefix / "project"
+    path.mkdir(parents=True, exist_ok=True)
+    print(f"\n=== Test project_root: {path}")
+    return py.path.local(path)
+
+
+@pytest.fixture(scope="class")
+def profiles_root(tmpdir_factory, prefix):
+    base = _on_fabric_project_base()
+    if base is None:
+        return tmpdir_factory.mktemp("profile")
+    path = base / prefix / "profile"
+    path.mkdir(parents=True, exist_ok=True)
+    return py.path.local(path)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def livy_session_lifecycle():
     session_name = os.getenv("FABRIC_TEST_LIVY_SESSION_NAME")
@@ -229,10 +281,15 @@ def livy_session_lifecycle():
 
 @pytest.fixture(scope="class")
 def logs_dir(request, prefix):
-    dbt_log_dir = os.path.join(request.config.rootdir, "logs", prefix)
+    base = _on_fabric_project_base()
+    if base is not None:
+        dbt_log_dir = str(base / prefix / "logs")
+    else:
+        dbt_log_dir = os.path.join(request.config.rootdir, "logs", prefix)
+    os.makedirs(dbt_log_dir, exist_ok=True)
     print(f"\n=== Test logs_dir: {dbt_log_dir}\n")
-    os.environ["DBT_LOG_PATH"] = str(dbt_log_dir)
-    yield str(Path(dbt_log_dir))
+    os.environ["DBT_LOG_PATH"] = dbt_log_dir
+    yield dbt_log_dir
     del os.environ["DBT_LOG_PATH"]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,9 @@ def _on_fabric_project_base() -> Path | None:
     elif mode == "mounted":
         path = os.getenv("FABRIC_TEST_ONELAKE_PATH")
         if not path:
-            raise ValueError("FABRIC_TEST_ONELAKE_PATH required when SPARK_EXEC_MODE=mounted")
+            raise ValueError(
+                "FABRIC_TEST_ONELAKE_PATH required when FABRIC_TEST_SPARK_EXEC_MODE=mounted"
+            )
         return Path(path) / "dbt-test-artifacts"
     return None
 

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -29,21 +29,6 @@ def remote_runtestloop(session: pytest.Session) -> bool:
     return True
 
 
-_FORWARDED_OPTIONS = (
-    "-k",
-    "-v",
-    "--verbose",
-    "-s",
-    "--capture",
-    "--with-grants",
-    "--with-python",
-    "--de",
-    "--dw",
-    "-x",
-    "--exitfirst",
-)
-
-
 def _build_remote_args(session: pytest.Session) -> list[str]:
     args: list[str] = []
     config = session.config

--- a/tests/spark_remote/conftest_plugin.py
+++ b/tests/spark_remote/conftest_plugin.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.spark_remote.orchestrator import RemoteTestOrchestrator
+from tests.spark_remote.result_reporter import report_remote_results
+
+
+def remote_runtestloop(session: pytest.Session) -> bool:
+    if session.config.option.collectonly:
+        return True
+
+    if not session.items:
+        return True
+
+    remote_args = _build_remote_args(session)
+
+    print("\nRemote execution: syncing project to lakehouse...")
+    orchestrator = RemoteTestOrchestrator.from_env()
+    orchestrator.sync_project()
+
+    print("\nRemote execution: submitting Spark job...")
+    job_result = orchestrator.run_spark_job(remote_args)
+
+    print(f"\n  {job_result.status} — downloading results...")
+    results_path = orchestrator.download_results()
+    report_remote_results(session, results_path, job_result)
+
+    return True
+
+
+_FORWARDED_OPTIONS = (
+    "-k",
+    "-v",
+    "--verbose",
+    "-s",
+    "--capture",
+    "--with-grants",
+    "--with-python",
+    "--de",
+    "--dw",
+    "-x",
+    "--exitfirst",
+)
+
+
+def _build_remote_args(session: pytest.Session) -> list[str]:
+    args: list[str] = []
+    config = session.config
+
+    if config.getoption("-k"):
+        args.extend(["-k", config.getoption("-k")])
+
+    if config.getoption("verbose", 0) > 0:
+        args.append("-" + "v" * config.getoption("verbose"))
+
+    if config.getoption("--de", default=False):
+        args.append("--de")
+
+    if config.getoption("--dw", default=False):
+        args.append("--dw")
+
+    if config.getoption("--with-grants", default=False):
+        args.append("--with-grants")
+
+    if config.getoption("--with-python", default=False):
+        args.append("--with-python")
+
+    if config.getoption("-x", default=False):
+        args.append("-x")
+
+    args.append("--junitxml=/lakehouse/default/Files/dbt-test-artifacts/results.xml")
+
+    return args

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from tests.spark_remote.spark_job_client import SparkJobClient, SparkJobResult
+from tests.spark_remote.sync import ProjectSync, check_prerequisites
+
+
+class RemoteTestOrchestrator:
+    def __init__(
+        self,
+        workspace_id: str,
+        workspace_name: str,
+        lakehouse_name: str,
+        lakehouse_id: str,
+        project_root: Path,
+        job_name: str = "dbt-fabric-tests",
+    ):
+        self._workspace_id = workspace_id
+        self._workspace_name = workspace_name
+        self._lakehouse_name = lakehouse_name
+        self._lakehouse_id = lakehouse_id
+        self._project_root = project_root
+        self._job_name = job_name
+
+        self._sync = ProjectSync(workspace_name, lakehouse_name, project_root)
+        self._job_client = SparkJobClient(workspace_id, self._get_token)
+        self._local_results_dir = project_root / "remote-test-results"
+
+    @classmethod
+    def from_env(cls) -> RemoteTestOrchestrator:
+        errors = check_prerequisites()
+        if errors:
+            for error in errors:
+                print(f"ERROR: {error}", file=sys.stderr)
+            raise SystemExit(1)
+
+        workspace_id = os.environ.get("FABRIC_TEST_WORKSPACE_ID", "")
+        workspace_name = os.environ.get("FABRIC_TEST_WORKSPACE_NAME", "")
+        lakehouse_name = os.environ.get("FABRIC_TEST_LAKEHOUSE_NAME", "")
+        lakehouse_id = os.environ.get("FABRIC_TEST_REMOTE_LAKEHOUSE_ID", "")
+        job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
+
+        if not workspace_id and not workspace_name:
+            raise ValueError("FABRIC_TEST_WORKSPACE_ID or FABRIC_TEST_WORKSPACE_NAME must be set")
+        if not lakehouse_name:
+            raise ValueError("FABRIC_TEST_LAKEHOUSE_NAME must be set")
+
+        project_root = Path(__file__).resolve().parent.parent.parent
+        return cls(
+            workspace_id=workspace_id,
+            workspace_name=workspace_name,
+            lakehouse_name=lakehouse_name,
+            lakehouse_id=lakehouse_id,
+            project_root=project_root,
+            job_name=job_name,
+        )
+
+    def sync_project(self) -> None:
+        self._sync.upload()
+
+    def run_spark_job(self, pytest_args: list[str]) -> SparkJobResult:
+        existing = self._job_client.find_by_name(self._job_name)
+        if existing:
+            item_id = existing["id"]
+            print(f"  Reusing Spark Job Definition: {self._job_name} ({item_id})")
+        else:
+            executable_path = (
+                f"abfss://{self._workspace_id}@onelake.dfs.fabric.microsoft.com"
+                f"/{self._lakehouse_id}/Files/dbt-fabric-tests"
+                f"/tests/spark_remote/spark_entry_point.py"
+            )
+            item_id = self._job_client.create_spark_job_definition(
+                name=self._job_name,
+                lakehouse_id=self._lakehouse_id,
+                executable_path=executable_path,
+            )
+            print(f"  Created Spark Job Definition: {self._job_name} ({item_id})")
+
+        print(f"  Remote pytest args: {' '.join(pytest_args)}")
+        item_id, job_instance_id = self._job_client.run_on_demand(item_id, pytest_args)
+
+        job_url = (
+            f"https://app.fabric.microsoft.com/groups/{self._workspace_id}"
+            f"/sparkJobDefinitions/{item_id}/runs/{job_instance_id}"
+        )
+        print(f"  Job URL: {job_url}")
+        print("\nWaiting for Spark job...")
+
+        return self._job_client.poll_until_done(item_id, job_instance_id)
+
+    def download_results(self) -> Path | None:
+        return self._sync.download_artifacts(self._local_results_dir)
+
+    def _get_token(self) -> str:
+        from azure.identity import AzureCliCredential
+
+        credential = AzureCliCredential()
+        token = credential.get_token("https://analysis.windows.net/powerbi/api/.default")
+        return token.token

--- a/tests/spark_remote/orchestrator.py
+++ b/tests/spark_remote/orchestrator.py
@@ -43,10 +43,17 @@ class RemoteTestOrchestrator:
         lakehouse_id = os.environ.get("FABRIC_TEST_REMOTE_LAKEHOUSE_ID", "")
         job_name = os.environ.get("FABRIC_TEST_SPARK_JOB_NAME", "dbt-fabric-tests")
 
-        if not workspace_id and not workspace_name:
-            raise ValueError("FABRIC_TEST_WORKSPACE_ID or FABRIC_TEST_WORKSPACE_NAME must be set")
+        missing = []
+        if not workspace_id:
+            missing.append("FABRIC_TEST_WORKSPACE_ID")
+        if not workspace_name:
+            missing.append("FABRIC_TEST_WORKSPACE_NAME")
         if not lakehouse_name:
-            raise ValueError("FABRIC_TEST_LAKEHOUSE_NAME must be set")
+            missing.append("FABRIC_TEST_LAKEHOUSE_NAME")
+        if not lakehouse_id:
+            missing.append("FABRIC_TEST_REMOTE_LAKEHOUSE_ID")
+        if missing:
+            raise ValueError(f"Required env vars not set: {', '.join(missing)}")
 
         project_root = Path(__file__).resolve().parent.parent.parent
         return cls(

--- a/tests/spark_remote/result_reporter.py
+++ b/tests/spark_remote/result_reporter.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from _pytest.reports import TestReport
+
+from tests.spark_remote.spark_job_client import SparkJobResult
+
+
+@dataclass
+class JunitTestResult:
+    nodeid: str
+    outcome: str
+    duration: float
+    failure_message: str | None = None
+    skip_reason: str | None = None
+    sections: list[tuple[str, str]] = field(default_factory=list)
+
+
+def report_remote_results(
+    session: pytest.Session, results_path: Path | None, job_result: SparkJobResult
+) -> None:
+    if results_path is None:
+        msg = f"Remote job {job_result.status}"
+        if job_result.error_message:
+            msg += f": {job_result.error_message}"
+        msg += f"\nJob URL: {job_result.job_url}"
+        _report_all_as_error(session, msg)
+        return
+
+    results = _parse_junitxml(results_path)
+    result_map = {r.nodeid: r for r in results}
+
+    for item in session.items:
+        ihook = item.ihook
+        ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+
+        result = result_map.get(item.nodeid)
+        if result is None:
+            _report_item_as_error(item, "Test not found in remote execution results")
+        else:
+            _report_item_result(item, result)
+
+        ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+
+
+def _report_all_as_error(session: pytest.Session, message: str) -> None:
+    for item in session.items:
+        ihook = item.ihook
+        ihook.pytest_runtest_logstart(nodeid=item.nodeid, location=item.location)
+        _report_item_as_error(item, message)
+        ihook.pytest_runtest_logfinish(nodeid=item.nodeid, location=item.location)
+
+
+def _report_item_as_error(item: pytest.Item, message: str) -> None:
+    ihook = item.ihook
+    for when in ("setup", "call", "teardown"):
+        report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="failed" if when == "call" else "passed",
+            longrepr=message if when == "call" else None,
+            when=when,
+            duration=0,
+        )
+        ihook.pytest_runtest_logreport(report=report)
+
+
+def _report_item_result(item: pytest.Item, result: JunitTestResult) -> None:
+    ihook = item.ihook
+
+    setup_report = TestReport(
+        nodeid=item.nodeid,
+        location=item.location,
+        keywords={x: 1 for x in item.keywords},
+        outcome="passed",
+        longrepr=None,
+        when="setup",
+        duration=0,
+    )
+    ihook.pytest_runtest_logreport(report=setup_report)
+
+    if result.outcome == "passed":
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="passed",
+            longrepr=None,
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    elif result.outcome == "failed":
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="failed",
+            longrepr=result.failure_message,
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    elif result.outcome == "skipped":
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="skipped",
+            longrepr=("", 0, result.skip_reason or "Skipped"),
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    else:
+        call_report = TestReport(
+            nodeid=item.nodeid,
+            location=item.location,
+            keywords={x: 1 for x in item.keywords},
+            outcome="failed",
+            longrepr=f"Unknown outcome: {result.outcome}",
+            when="call",
+            duration=result.duration,
+            sections=result.sections,
+        )
+    ihook.pytest_runtest_logreport(report=call_report)
+
+    teardown_report = TestReport(
+        nodeid=item.nodeid,
+        location=item.location,
+        keywords={x: 1 for x in item.keywords},
+        outcome="passed",
+        longrepr=None,
+        when="teardown",
+        duration=0,
+    )
+    ihook.pytest_runtest_logreport(report=teardown_report)
+
+
+def _parse_junitxml(path: Path) -> list[JunitTestResult]:
+    tree = ET.parse(path)
+    root = tree.getroot()
+
+    results = []
+    for testcase in root.iter("testcase"):
+        nodeid = _reconstruct_nodeid(testcase)
+        duration = float(testcase.get("time", "0"))
+
+        failure_el = testcase.find("failure")
+        error_el = testcase.find("error")
+        skipped_el = testcase.find("skipped")
+
+        sections: list[tuple[str, str]] = []
+        stdout_el = testcase.find("system-out")
+        if stdout_el is not None and stdout_el.text:
+            sections.append(("Captured stdout (remote)", stdout_el.text))
+        stderr_el = testcase.find("system-err")
+        if stderr_el is not None and stderr_el.text:
+            sections.append(("Captured stderr (remote)", stderr_el.text))
+
+        if failure_el is not None:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="failed",
+                    duration=duration,
+                    failure_message=failure_el.text or failure_el.get("message", ""),
+                    sections=sections,
+                )
+            )
+        elif error_el is not None:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="failed",
+                    duration=duration,
+                    failure_message=error_el.text or error_el.get("message", ""),
+                    sections=sections,
+                )
+            )
+        elif skipped_el is not None:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="skipped",
+                    duration=duration,
+                    skip_reason=skipped_el.get("message", "Skipped"),
+                    sections=sections,
+                )
+            )
+        else:
+            results.append(
+                JunitTestResult(
+                    nodeid=nodeid,
+                    outcome="passed",
+                    duration=duration,
+                    sections=sections,
+                )
+            )
+
+    return results
+
+
+def _reconstruct_nodeid(testcase: ET.Element) -> str:
+    file_attr = testcase.get("file")
+    classname = testcase.get("classname", "")
+    name = testcase.get("name", "")
+
+    if file_attr:
+        file_module = file_attr.replace("/", ".").removesuffix(".py")
+        remaining = classname.removeprefix(file_module + ".")
+        if remaining and remaining != classname:
+            return f"{file_attr}::{remaining.replace('.', '::')}::{name}"
+        return f"{file_attr}::{name}"
+
+    # Fallback: split classname on first uppercase component (class name boundary)
+    parts = classname.split(".")
+    file_parts = []
+    class_parts = []
+    for i, part in enumerate(parts):
+        if part and part[0].isupper():
+            class_parts = parts[i:]
+            break
+        file_parts.append(part)
+
+    file_path = "/".join(file_parts) + ".py" if file_parts else ""
+    node_parts = class_parts + [name]
+    node_path = "::".join(node_parts)
+
+    if file_path:
+        return f"{file_path}::{node_path}"
+    return node_path

--- a/tests/spark_remote/spark_entry_point.py
+++ b/tests/spark_remote/spark_entry_point.py
@@ -1,0 +1,59 @@
+"""Entry point for remote pytest execution on Fabric Spark.
+
+This script is submitted as a Spark Job Definition. It installs the project
+and its dependencies, then runs pytest with the provided arguments. Results
+are written to junitxml on the lakehouse filesystem for the local pytest
+session to parse.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+LAKEHOUSE_ROOT = "/lakehouse/default"
+PROJECT_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-fabric-tests"
+ARTIFACTS_DIR = f"{LAKEHOUSE_ROOT}/Files/dbt-test-artifacts"
+
+
+def main() -> None:
+    os.makedirs(ARTIFACTS_DIR, exist_ok=True)
+
+    requirements_file = f"{PROJECT_DIR}/requirements-remote.txt"
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-r", requirements_file, "--quiet"],
+    )
+
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-e", PROJECT_DIR, "--no-deps", "--quiet"],
+    )
+
+    env_file = f"{PROJECT_DIR}/test.env.remote"
+    if os.path.exists(env_file):
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file, override=True)
+
+    os.environ["FABRIC_TEST_SPARK_EXEC_MODE"] = "remote"
+
+    pytest_args = sys.argv[1:]
+
+    has_junitxml = any(arg.startswith("--junitxml") for arg in pytest_args)
+    if not has_junitxml:
+        pytest_args.extend(["--junitxml", f"{ARTIFACTS_DIR}/results.xml"])
+
+    exit_code = subprocess.call(
+        [sys.executable, "-m", "pytest"] + pytest_args,
+        cwd=PROJECT_DIR,
+    )
+
+    exit_code_file = f"{ARTIFACTS_DIR}/exit_code.txt"
+    with open(exit_code_file, "w") as f:
+        f.write(str(exit_code))
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import base64
+import json
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import requests
+
+FABRIC_API_BASE = "https://api.fabric.microsoft.com"
+FABRIC_CREDENTIAL_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+
+
+@dataclass
+class SparkJobResult:
+    status: str
+    start_time: str | None
+    end_time: str | None
+    job_url: str
+    error_message: str | None
+
+
+class SparkJobClient:
+    def __init__(self, workspace_id: str, token_provider_fn: Callable[[], str]):
+        self._workspace_id = workspace_id
+        self._token_provider_fn = token_provider_fn
+
+    def _headers(self) -> dict[str, str]:
+        token = self._token_provider_fn()
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def _get(self, path: str, **kwargs) -> requests.Response:
+        url = f"{FABRIC_API_BASE}{path}"
+        resp = requests.get(url, headers=self._headers(), **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def _post(self, path: str, json_data: dict | None = None, **kwargs) -> requests.Response:
+        url = f"{FABRIC_API_BASE}{path}"
+        resp = requests.post(url, headers=self._headers(), json=json_data, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def list_spark_job_definitions(self) -> list[dict]:
+        items = []
+        path = f"/v1/workspaces/{self._workspace_id}/sparkJobDefinitions"
+        while path:
+            resp = self._get(path)
+            data = resp.json()
+            items.extend(data.get("value", []))
+            path = data.get("continuationUri")
+        return items
+
+    def find_by_name(self, name: str) -> dict | None:
+        for item in self.list_spark_job_definitions():
+            if item.get("displayName") == name:
+                return item
+        return None
+
+    def create_spark_job_definition(
+        self, name: str, lakehouse_id: str, executable_path: str
+    ) -> str:
+        payload_json = json.dumps(
+            {
+                "executableFile": executable_path,
+                "defaultLakehouseArtifactId": lakehouse_id,
+                "language": "Python",
+                "environmentArtifactId": None,
+            }
+        )
+        payload_b64 = base64.b64encode(payload_json.encode()).decode()
+
+        body = {
+            "displayName": name,
+            "definition": {
+                "parts": [
+                    {
+                        "path": "SparkJobDefinitionV1.json",
+                        "payload": payload_b64,
+                        "payloadType": "InlineBase64",
+                    }
+                ]
+            },
+        }
+
+        path = f"/v1/workspaces/{self._workspace_id}/sparkJobDefinitions"
+        resp = self._post(path, json_data=body)
+        return resp.json()["id"]
+
+    def run_on_demand(self, item_id: str, command_line_args: list[str]) -> tuple[str, str]:
+        path = (
+            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances?jobType=sparkjob"
+        )
+        body = {"executionData": {"commandLineArguments": " ".join(command_line_args)}}
+        resp = self._post(path, json_data=body)
+
+        location = resp.headers.get("Location", "")
+        # Location header format: .../items/{item_id}/jobs/instances/{job_instance_id}
+        parts = location.rstrip("/").split("/")
+        job_instance_id = parts[-1] if parts else ""
+        return item_id, job_instance_id
+
+    def get_job_instance(self, item_id: str, job_instance_id: str) -> dict:
+        path = (
+            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances/{job_instance_id}"
+        )
+        return self._get(path).json()
+
+    def poll_until_done(
+        self, item_id: str, job_instance_id: str, interval: int = 10, timeout: int = 1800
+    ) -> SparkJobResult:
+        job_url = (
+            f"https://app.fabric.microsoft.com/groups/{self._workspace_id}"
+            f"/sparkJobDefinitions/{item_id}/runs/{job_instance_id}"
+        )
+        start = time.time()
+        last_status = ""
+
+        while True:
+            elapsed = time.time() - start
+            if elapsed > timeout:
+                return SparkJobResult(
+                    status="Timeout",
+                    start_time=None,
+                    end_time=None,
+                    job_url=job_url,
+                    error_message=f"Job timed out after {timeout}s. Check: {job_url}",
+                )
+
+            instance = self._get_with_retry(item_id, job_instance_id)
+            status = instance.get("status", "Unknown")
+
+            if status != last_status:
+                minutes = int(elapsed) // 60
+                seconds = int(elapsed) % 60
+                print(f"  [{minutes}:{seconds:02d}] {status}...")
+                last_status = status
+
+            if status in ("Completed", "Failed", "Cancelled", "Deduped"):
+                return SparkJobResult(
+                    status=status,
+                    start_time=instance.get("startTimeUtc"),
+                    end_time=instance.get("endTimeUtc"),
+                    job_url=job_url,
+                    error_message=instance.get("failureReason", {}).get("message"),
+                )
+
+            time.sleep(interval)
+
+    def _get_with_retry(self, item_id: str, job_instance_id: str, max_retries: int = 3) -> dict:
+        path = (
+            f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances/{job_instance_id}"
+        )
+        for attempt in range(max_retries):
+            try:
+                return self._get(path).json()
+            except requests.exceptions.RequestException:
+                if attempt == max_retries - 1:
+                    raise
+                time.sleep(2 ** (attempt + 1))
+        return {}

--- a/tests/spark_remote/spark_job_client.py
+++ b/tests/spark_remote/spark_job_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import shlex
 import time
 from dataclasses import dataclass
 from typing import Callable
@@ -33,14 +34,16 @@ class SparkJobClient:
             "Content-Type": "application/json",
         }
 
-    def _get(self, path: str, **kwargs) -> requests.Response:
-        url = f"{FABRIC_API_BASE}{path}"
+    def _get(self, url_or_path: str, **kwargs) -> requests.Response:
+        url = url_or_path if url_or_path.startswith("http") else f"{FABRIC_API_BASE}{url_or_path}"
         resp = requests.get(url, headers=self._headers(), **kwargs)
         resp.raise_for_status()
         return resp
 
-    def _post(self, path: str, json_data: dict | None = None, **kwargs) -> requests.Response:
-        url = f"{FABRIC_API_BASE}{path}"
+    def _post(
+        self, url_or_path: str, json_data: dict | None = None, **kwargs
+    ) -> requests.Response:
+        url = url_or_path if url_or_path.startswith("http") else f"{FABRIC_API_BASE}{url_or_path}"
         resp = requests.post(url, headers=self._headers(), json=json_data, **kwargs)
         resp.raise_for_status()
         return resp
@@ -95,7 +98,7 @@ class SparkJobClient:
         path = (
             f"/v1/workspaces/{self._workspace_id}/items/{item_id}/jobs/instances?jobType=sparkjob"
         )
-        body = {"executionData": {"commandLineArguments": " ".join(command_line_args)}}
+        body = {"executionData": {"commandLineArguments": shlex.join(command_line_args)}}
         resp = self._post(path, json_data=body)
 
         location = resp.headers.get("Location", "")

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -114,8 +114,15 @@ def check_prerequisites() -> list[str]:
             "?WT.mc_id=MVP_310840"
         )
 
-    result = subprocess.run(["az", "account", "show"], capture_output=True, text=True)
-    if result.returncode != 0:
-        errors.append("Azure CLI not logged in. Run: az login")
+    try:
+        result = subprocess.run(["az", "account", "show"], capture_output=True, text=True)
+        if result.returncode != 0:
+            errors.append("Azure CLI not logged in. Run: az login")
+    except FileNotFoundError:
+        errors.append(
+            "Azure CLI (az) not found on PATH. Install from: "
+            "https://learn.microsoft.com/en-us/cli/azure/install-azure-cli"
+            "?WT.mc_id=MVP_310840"
+        )
 
     return errors

--- a/tests/spark_remote/sync.py
+++ b/tests/spark_remote/sync.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+EXCLUDE_PATHS = (
+    ".venv;.git;__pycache__;.cache;.claude;logs;.ruff_cache;"
+    ".pytest_cache;.eggs;dist;build;site;.vscode;node_modules;"
+    "remote-test-results;dbt-test-artifacts"
+)
+EXCLUDE_PATTERNS = "*.pyc;*.pyo;*.egg-info"
+
+
+class ProjectSync:
+    def __init__(self, workspace_name: str, lakehouse_name: str, project_root: Path):
+        self._workspace_name = workspace_name
+        self._lakehouse_name = lakehouse_name
+        self._project_root = project_root
+        self._onelake_base = (
+            f"https://onelake.dfs.fabric.microsoft.com"
+            f"/{workspace_name}/{lakehouse_name}.Lakehouse/Files"
+        )
+
+    def upload(self) -> None:
+        self._generate_requirements()
+        self._generate_test_env_remote()
+
+        target = f"{self._onelake_base}/dbt-fabric-tests"
+        print(f"  Syncing: {self._project_root} -> {target}")
+
+        cmd = [
+            "azcopy",
+            "sync",
+            str(self._project_root),
+            target,
+            "--login-type=azcli",
+            f"--exclude-path={EXCLUDE_PATHS}",
+            f"--exclude-pattern={EXCLUDE_PATTERNS}",
+            "--delete-destination=true",
+            "--put-md5",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"azcopy sync failed:\n{result.stderr}")
+        print("  Sync complete.")
+
+    def download_artifacts(self, local_dir: Path) -> Path | None:
+        source = f"{self._onelake_base}/dbt-test-artifacts"
+        local_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "azcopy",
+            "sync",
+            source,
+            str(local_dir),
+            "--login-type=azcli",
+            "--delete-destination=true",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"azcopy artifact download failed:\n{result.stderr}")
+
+        results_xml = local_dir / "results.xml"
+        return results_xml if results_xml.exists() else None
+
+    def _generate_requirements(self) -> None:
+        result = subprocess.run(
+            ["uv", "export", "--format", "requirements.txt", "--all-extras", "--group", "dev"],
+            capture_output=True,
+            text=True,
+            cwd=self._project_root,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"uv export failed:\n{result.stderr}")
+
+        reqs_path = self._project_root / "requirements-remote.txt"
+        reqs_path.write_text(result.stdout)
+
+    def _generate_test_env_remote(self) -> None:
+        test_env_path = self._project_root / "test.env"
+        remote_env_path = self._project_root / "test.env.remote"
+
+        overrides = {
+            "FABRIC_TEST_AUTH": "notebookutils",
+            "FABRIC_TEST_SPARK_EXEC_MODE": "remote",
+        }
+
+        lines = []
+        if test_env_path.exists():
+            for line in test_env_path.read_text().splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    lines.append(line)
+                    continue
+                key = stripped.split("=", 1)[0]
+                if key in overrides:
+                    continue
+                lines.append(line)
+
+        for key, value in overrides.items():
+            lines.append(f"{key}={value}")
+
+        remote_env_path.write_text("\n".join(lines) + "\n")
+
+
+def check_prerequisites() -> list[str]:
+    errors = []
+
+    if not shutil.which("azcopy"):
+        errors.append(
+            "azcopy not found on PATH. Install from: "
+            "https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10"
+            "?WT.mc_id=MVP_310840"
+        )
+
+    result = subprocess.run(["az", "account", "show"], capture_output=True, text=True)
+    if result.returncode != 0:
+        errors.append("Azure CLI not logged in. Run: az login")
+
+    return errors

--- a/tests/unit/test_result_reporter.py
+++ b/tests/unit/test_result_reporter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from tests.spark_remote.result_reporter import _parse_junitxml, _reconstruct_nodeid
+
+
+def _make_testcase_element(**attrs):
+    import xml.etree.ElementTree as ET
+
+    return ET.fromstring("<testcase " + " ".join(f'{k}="{v}"' for k, v in attrs.items()) + " />")
+
+
+class TestReconstructNodeid:
+    def test_simple_file_and_name(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo.TestFoo",
+            name="test_bar",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestFoo::test_bar"
+
+    def test_no_class_in_classname(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo",
+            name="test_standalone",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::test_standalone"
+
+    def test_parametrized_name(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo.TestParams",
+            name="test_add[1-2-3]",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestParams::test_add[1-2-3]"
+
+    def test_nested_class(self):
+        el = _make_testcase_element(
+            file="tests/unit/test_foo.py",
+            classname="tests.unit.test_foo.TestOuter.TestInner",
+            name="test_deep",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestOuter::TestInner::test_deep"
+
+    def test_fallback_no_file_attr(self):
+        el = _make_testcase_element(
+            classname="tests.unit.test_foo.TestClass",
+            name="test_method",
+        )
+        assert _reconstruct_nodeid(el) == "tests/unit/test_foo.py::TestClass::test_method"
+
+
+class TestParseJunitxml:
+    def test_passed(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_one" time="0.5"/>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].nodeid == "tests/test_a.py::TestA::test_one"
+        assert results[0].outcome == "passed"
+        assert results[0].duration == 0.5
+
+    def test_failed(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_fail" time="1.2">
+                <failure message="assert False">Traceback here</failure>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].outcome == "failed"
+        assert results[0].failure_message == "Traceback here"
+
+    def test_skipped(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_skip" time="0.0">
+                <skipped message="not supported"/>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].outcome == "skipped"
+        assert results[0].skip_reason == "not supported"
+
+    def test_error(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_err" time="0.1">
+                <error message="setup failed">Error details</error>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert results[0].outcome == "failed"
+        assert results[0].failure_message == "Error details"
+
+    def test_captures_stdout_stderr(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a.TestA"
+                        name="test_output" time="0.3">
+                <system-out>hello stdout</system-out>
+                <system-err>hello stderr</system-err>
+              </testcase>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 1
+        assert ("Captured stdout (remote)", "hello stdout") in results[0].sections
+        assert ("Captured stderr (remote)", "hello stderr") in results[0].sections
+
+    def test_multiple_testcases(self, tmp_path: Path):
+        xml_content = textwrap.dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <testsuite>
+              <testcase file="tests/test_a.py" classname="tests.test_a" name="test_one" time="0.1"/>
+              <testcase file="tests/test_a.py" classname="tests.test_a" name="test_two" time="0.2"/>
+            </testsuite>
+        """)
+        xml_file = tmp_path / "results.xml"
+        xml_file.write_text(xml_content)
+
+        results = _parse_junitxml(xml_file)
+        assert len(results) == 2
+        assert results[0].nodeid == "tests/test_a.py::test_one"
+        assert results[1].nodeid == "tests/test_a.py::test_two"


### PR DESCRIPTION
## Summary

- Adds a native `--remote` pytest flag that transparently delegates FabricSpark test execution to a Spark Job Definition on Fabric infrastructure
- Adds Mode B (mounted lakehouse) support that redirects test artifacts to OneLake-accessible paths
- The developer experience is simply `pytest --de --remote -k "TestFoo"` — no separate CLI needed

## How it works

1. Local pytest collects tests normally
2. `pytest_runtestloop` hook intercepts when `--remote` is set
3. Syncs project to lakehouse via azcopy
4. Triggers a Spark Job Definition with forwarded pytest args + `--junitxml`
5. Polls for completion, downloads results
6. Parses junitxml and reports results back to local pytest session

## New files

- `tests/spark_remote/conftest_plugin.py` — pytest_runtestloop hook implementation
- `tests/spark_remote/result_reporter.py` — junitxml → TestReport mapping
- `tests/spark_remote/orchestrator.py` — coordinates sync + job client
- `tests/spark_remote/spark_job_client.py` — Fabric REST API wrapper
- `tests/spark_remote/sync.py` — azcopy sync wrapper
- `tests/spark_remote/spark_entry_point.py` — runs inside Spark job

## Test plan

- [ ] Verify `pytest --de` still works without `--remote` (no regression)
- [ ] Verify `--remote` without `--de` exits with error
- [ ] Test Mode B dry-run with `FABRIC_TEST_SPARK_EXEC_MODE=mounted`
- [ ] End-to-end test with real Fabric workspace

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)