### PR TITLE
Fix docs: auth method is notebookutils, not FabricSpark/SynapseSpark

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -279,9 +279,9 @@ default:
       client_secret: "{{ env_var('AZURE_CLIENT_SECRET') }}"
 ```
 
-!!! warning "`FabricSpark` is currently broken"
+!!! warning "`notebookutils` is currently broken"
 
-    The adapter also has a `FabricSpark` (alias `SynapseSpark`) authentication method that uses [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebook-utilities?WT.mc_id=MVP_310840) to obtain an access token from the notebook session. However, this method is **not working** at the moment because Microsoft's Runtime in the Notebooks returns a credential with a scope that is not allowed to access Data Warehouses and SQL Endpoints. Use one of the alternatives above instead.
+    The adapter also has a `notebookutils` authentication method that uses [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebook-utilities?WT.mc_id=MVP_310840) to obtain an access token from the notebook session. However, this method is **not working** at the moment because Microsoft's Runtime in the Notebooks returns a credential with a scope that is not allowed to access Data Warehouses and SQL Endpoints. Use one of the alternatives above instead.
 
 ---
 
@@ -369,4 +369,4 @@ dbt debug
 | `AADSTS700016: Application not found` | Wrong `client_id` or the app isn't registered in the correct tenant | Verify the app registration in Microsoft Entra ID |
 | `DefaultAzureCredential failed` | No valid credential source found | Make sure you are logged in (`az login` / `Connect-AzAccount`) or that environment variables are set |
 | `Token expired` when using `access_token` | The pre-acquired token has expired | Refresh the token before running dbt |
-| `notebookutils not found` | Using `FabricSpark` outside of a Fabric/Synapse notebook | Switch to a different authentication method |
+| `notebookutils not found` | Using `notebookutils` auth outside of a Fabric notebook | Switch to a different authentication method |

--- a/docs/comparison-dbt-fabric.md
+++ b/docs/comparison-dbt-fabric.md
@@ -49,8 +49,8 @@ Both Python model support for Fabric DW (via Livy sessions writing through `syna
 | Environment credentials | Yes | Yes |
 | Device Code Flow | Yes | No |
 | Managed Identity (MSI) | Yes | No |
-| Fabric Notebook (notebookutils) | Yes | Yes (`fabricnotebook`) |
-| Synapse Spark (mssparkutils) | Removed (Synapse-specific, not applicable to Fabric) | Yes (`synapsespark`) |
+| Fabric Notebook (`notebookutils`) | Yes (currently broken) | Yes (`fabricnotebook`) |
+| Synapse Spark (mssparkutils) | No (Synapse-specific, not applicable to Fabric) | Yes (`synapsespark`) |
 | ActiveDirectoryAccessToken | No (removed) | Yes |
 | Windows Login | Yes | Yes |
 | `token_credential` (custom class) | Yes | No |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,7 @@ Possible values (case insensitive):
 - [`environment`](#environment)
 - [`notebookutils`](#notebookutils)
 - [`token_credential`](#token_credential)
+- [`workload_identity`](#workload_identity)
 
 The adapter supports an authentication method for every use case. The default is `auto`, which will try to use the best available method depending on your environment.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,7 +160,7 @@ Possible values (case insensitive):
 - [`auto`](#auto) (default)
 - [`CLI`](#cli)
 - [`environment`](#environment)
-- [`FabricSpark` / `SynapseSpark`](#fabricspark)
+- [`notebookutils`](#notebookutils)
 - [`token_credential`](#token_credential)
 
 The adapter supports an authentication method for every use case. The default is `auto`, which will try to use the best available method depending on your environment.
@@ -223,11 +223,13 @@ Since the Azure CLI supports [a variety of authentication methods](https://learn
 
 Authenticate using environment variables. This works similarly to the `auto` method, but only uses environment variables. See [Microsoft Learn](https://learn.microsoft.com/python/api/azure-identity/azure.identity.environmentcredential?view=azure-python&WT.mc_id=MVP_310840) for the list of supported environment variables.
 
-#### `FabricSpark`
+#### `notebookutils`
 
-Alias: `SynapseSpark`
+This authentication method works inside a Fabric notebook. It uses [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebook-utilities?WT.mc_id=MVP_310840) to get an access token for the current user.
 
-This authentication methods works inside a Fabric or Synapse notebook. It uses [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebook-utilities?WT.mc_id=MVP_310840) to get an access token for the current user.
+!!! warning "Currently broken"
+
+    This method is **not working** at the moment because Microsoft's Runtime in the Notebooks returns a credential with a scope that is not allowed to access Data Warehouses and SQL Endpoints. Use [`environment`](#environment) or [`ActiveDirectoryServicePrincipal`](#activedirectoryserviceprincipal) inside notebooks instead.
 
 #### `workload_identity`
 


### PR DESCRIPTION
## Summary

- The docs listed `FabricSpark` / `SynapseSpark` as valid authentication values, but the code (`FabricTokenProvider`) only accepts `notebookutils` — using the documented values would raise `ValueError: Unsupported authentication method`
- Renamed the auth method to `notebookutils` in configuration.md, authentication.md, and comparison-dbt-fabric.md
- Added "currently broken" warning to the configuration reference (was only in the authentication guide)
- Updated comparison table to show `notebookutils` as the actual config value and mark it as currently broken

## Test plan

- [x] Verify docs build without warnings
- [x] Check that anchor links from the auth list to `#notebookutils` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)