### PR TITLE
Add integration tests for dbt-codegen package

### DIFF
--- a/docs/packages/dbt-codegen.md
+++ b/docs/packages/dbt-codegen.md
@@ -1,0 +1,37 @@
+# dbt-codegen
+
+**Tested version:** 0.14.1 | **Integration tested:** Yes
+
+[dbt-codegen](https://github.com/dbt-labs/dbt-codegen) generates dbt model YAML, source YAML, base models, and unit test templates from your existing database schema.
+
+## Dispatch configuration
+
+```yaml
+dispatch:
+  - macro_namespace: codegen
+    search_order: ['your_project_name', 'dbt', 'codegen']
+```
+
+## Macro compatibility
+
+All dbt-codegen macros work on Fabric without adapter-specific overrides. The package queries `INFORMATION_SCHEMA` views which Fabric supports natively.
+
+| Macro | Status | Notes |
+|---|---|---|
+| `generate_source` | ✅ | |
+| `generate_model_yaml` | ✅ | |
+| `generate_base_model` | ✅ | |
+| `generate_model_import_ctes` | ✅ | |
+| `generate_unit_test_template` | ✅ | |
+
+## Notes
+
+dbt-codegen depends on [dbt-utils](dbt-utils.md). Make sure you include the dbt-utils dispatch configuration as well:
+
+```yaml
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order: ['your_project_name', 'dbt', 'dbt_utils']
+  - macro_namespace: codegen
+    search_order: ['your_project_name', 'dbt', 'codegen']
+```

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -36,6 +36,7 @@ The `dbt` entry in the search order tells dbt to check the adapter's built-in ma
 |---|---|---|
 | [dbt-utils](dbt-utils.md) | 1.3.3 | Yes |
 | [dbt-date](dbt-date.md) | 0.17.2 | Yes |
+| [dbt-codegen](dbt-codegen.md) | 0.14.1 | Yes |
 | [dbt-expectations](dbt-expectations.md) | 0.10.10 | Yes |
 | [dbt-audit-helper](dbt-audit-helper.md) | -- | No |
 | [dbt-external-tables](dbt-external-tables.md) | 0.11.0 | Yes |

--- a/tests/fabric/packages/test_dbt_codegen.py
+++ b/tests/fabric/packages/test_dbt_codegen.py
@@ -1,0 +1,138 @@
+import pytest
+
+from dbt.tests.util import run_dbt
+from tests.fabric.packages.base_package_test import BaseDbtPackageTests
+
+
+class TestDbtCodegen(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "dbt_codegen"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "https://github.com/dbt-labs/dbt-codegen"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "0.14.1"
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "create_source_table.sql": _CREATE_SOURCE_TABLE_SQL,
+            "assert_equal.sql": _ASSERT_EQUAL_SQL,
+            "integer_type_value.sql": _INTEGER_TYPE_VALUE_SQL,
+            "text_type_value.sql": _TEXT_TYPE_VALUE_SQL,
+        }
+
+    @pytest.fixture(scope="class")
+    def extra_dispatches(self):
+        return [
+            {
+                "macro_namespace": "codegen_integration_tests",
+                "search_order": [
+                    "test_dbt_package",
+                    "dbt",
+                    "codegen_integration_tests",
+                ],
+            }
+        ]
+
+    def test_package(self, project, dbt_core_bug_workaround):
+        run_dbt(["deps"])
+        run_dbt(["seed"])
+        run_dbt(["run-operation", "create_source_table"])
+        run_dbt(["run"])
+        run_dbt(["test"])
+
+
+_CREATE_SOURCE_TABLE_SQL = """
+{% macro create_source_table() %}
+
+{% set target_schema=api.Relation.create(
+    database=target.database,
+    schema=target.schema ~ "__data_source_schema"
+) %}
+
+{% do adapter.create_schema(target_schema) %}
+
+{% set drop_table_sql %}
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table
+{% endset %}
+
+{{ run_query(drop_table_sql) }}
+
+{% set create_table_sql %}
+create table {{ target_schema }}.codegen_integration_tests__data_source_table
+as select
+    1 as my_integer_col,
+    cast(1 as bit) as my_bool_col
+{% endset %}
+
+{{ run_query(create_table_sql) }}
+
+{% set drop_table_sql_case_sensitive %}
+drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive
+{% endset %}
+
+{{ run_query(drop_table_sql_case_sensitive) }}
+
+{% set create_table_sql_case_sensitive %}
+create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive
+as select
+    1 as {{ adapter.quote("My_Integer_Col") }},
+    cast(1 as bit) as {{ adapter.quote("My_Bool_Col") }}
+{% endset %}
+
+{{ run_query(create_table_sql_case_sensitive) }}
+
+{% endmacro %}
+""".strip()
+
+_ASSERT_EQUAL_SQL = """
+{% macro assert_equal(actual_object, expected_object) %}
+{% if not execute %}
+
+    {# pass #}
+
+{% elif actual_object != expected_object %}
+
+    {% set msg %}
+    Expected did not match actual
+
+    -----------
+    Actual:
+    -----------
+    --->{{ actual_object }}<---
+
+    -----------
+    Expected:
+    -----------
+    --->{{ expected_object }}<---
+
+    {% endset %}
+
+    {{ log(msg, info=True) }}
+
+    select 'fail'
+
+{% else %}
+
+    select top 0 'ok'
+
+{% endif %}
+{% endmacro %}
+""".strip()
+
+_INTEGER_TYPE_VALUE_SQL = """
+{%- macro integer_type_value() -%}
+bigint
+{%- endmacro -%}
+""".strip()
+
+_TEXT_TYPE_VALUE_SQL = """
+{%- macro text_type_value() -%}
+varchar
+{%- endmacro -%}
+""".strip()

--- a/tests/fabric/packages/test_dbt_codegen.py
+++ b/tests/fabric/packages/test_dbt_codegen.py
@@ -18,6 +18,15 @@ class TestDbtCodegen(BaseDbtPackageTests):
         return "0.14.1"
 
     @pytest.fixture(scope="class")
+    def packages(self, package_repo, package_revision, dbt_utils_version):
+        return {
+            "packages": [
+                {"git": package_repo, "revision": package_revision},
+                {"package": "dbt-labs/dbt_utils", "version": dbt_utils_version},
+            ]
+        }
+
+    @pytest.fixture(scope="class")
     def models(self):
         return {
             "model_data_a.sql": "select * from {{ ref('data__a_relation') }}",
@@ -32,6 +41,10 @@ class TestDbtCodegen(BaseDbtPackageTests):
             "data__a_relation.csv": "col_a,col_b\n1,a\n2,b\n",
             "data__b_relation.csv": "col_a,col_b\n3,c\n4,d\n",
         }
+
+    @pytest.fixture(scope="class")
+    def seeds_config(self):
+        return {"+schema": "raw_data"}
 
     @pytest.fixture(scope="class")
     def tests(self):
@@ -52,31 +65,13 @@ class TestDbtCodegen(BaseDbtPackageTests):
         }
 
     @pytest.fixture(scope="class")
-    def packages(self, package_repo, package_revision):
-        return {
-            "packages": [
-                {"git": package_repo, "revision": package_revision},
-                {"package": "dbt-labs/dbt_utils", "version": "1.3.0"},
-            ]
-        }
-
-    @pytest.fixture(scope="class")
-    def project_config_update(self, project_vars):
-        return {
-            "name": "test_dbt_package",
-            "vars": project_vars,
-            "seeds": {"+schema": "raw_data"},
-            "dispatch": [
-                {
-                    "macro_namespace": "dbt_utils",
-                    "search_order": ["test_dbt_package", "dbt", "dbt_utils"],
-                },
-                {
-                    "macro_namespace": "codegen",
-                    "search_order": ["test_dbt_package", "dbt", "codegen"],
-                },
-            ],
-        }
+    def extra_dispatches(self):
+        return [
+            {
+                "macro_namespace": "codegen",
+                "search_order": ["test_dbt_package", "dbt", "codegen"],
+            }
+        ]
 
     def test_package(self, project, dbt_core_bug_workaround):
         run_dbt(["deps"])
@@ -179,7 +174,7 @@ models:
         description: ""
 
       - name: col_b
-        data_type: varchar
+        data_type: varchar(16)
         description: ""
 
 {% endset %}

--- a/tests/fabric/packages/test_dbt_codegen.py
+++ b/tests/fabric/packages/test_dbt_codegen.py
@@ -147,6 +147,8 @@ sources:
 {{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}
 """.strip()
 
+# Upstream expects "integer" and "text"; Fabric returns "int" and "varchar"
+# (codegen's default__format_column uses column.dtype which is the base type name)
 _TEST_GENERATE_MODEL_YAML = """
 {% set actual_model_yaml = codegen.generate_model_yaml(
     model_names=['data__a_relation']
@@ -257,6 +259,7 @@ unit_tests:
 {{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}
 """.strip()
 
+# Upstream uses `true as my_bool_col`; Fabric has no boolean literal, use BIT
 _CREATE_SOURCE_TABLE_SQL = """
 {% macro create_source_table() %}
 
@@ -285,6 +288,9 @@ as select
 {% endmacro %}
 """.strip()
 
+# Upstream uses `select 'ok' limit 0` and `select 'fail'` (no alias).
+# Fabric needs TOP instead of LIMIT, and column aliases for CTE compatibility.
+# Added _strip_trailing_ws: codegen Jinja templates produce trailing whitespace.
 _ASSERT_EQUAL_SQL = """
 {% macro _strip_trailing_ws(text) %}
     {% set lines = text.split('\\n') %}

--- a/tests/fabric/packages/test_dbt_codegen.py
+++ b/tests/fabric/packages/test_dbt_codegen.py
@@ -7,7 +7,7 @@ from tests.fabric.packages.base_package_test import BaseDbtPackageTests
 class TestDbtCodegen(BaseDbtPackageTests):
     @pytest.fixture(scope="class")
     def package_name(self) -> str:
-        return "dbt_codegen"
+        return "codegen"
 
     @pytest.fixture(scope="class")
     def package_repo(self) -> str:
@@ -63,15 +63,6 @@ class TestDbtCodegen(BaseDbtPackageTests):
             "create_source_table.sql": _CREATE_SOURCE_TABLE_SQL,
             "assert_equal.sql": _ASSERT_EQUAL_SQL,
         }
-
-    @pytest.fixture(scope="class")
-    def extra_dispatches(self):
-        return [
-            {
-                "macro_namespace": "codegen",
-                "search_order": ["test_dbt_package", "dbt", "codegen"],
-            }
-        ]
 
     def test_package(self, project, dbt_core_bug_workaround):
         run_dbt(["deps"])
@@ -174,7 +165,7 @@ models:
         description: ""
 
       - name: col_b
-        data_type: varchar(16)
+        data_type: varchar
         description: ""
 
 {% endset %}

--- a/tests/fabric/packages/test_dbt_codegen.py
+++ b/tests/fabric/packages/test_dbt_codegen.py
@@ -18,26 +18,65 @@ class TestDbtCodegen(BaseDbtPackageTests):
         return "0.14.1"
 
     @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_data_a.sql": "select * from {{ ref('data__a_relation') }}",
+            "child_model.sql": "select * from {{ ref('model_data_a') }}",
+            "schema.yml": _SCHEMA_YML,
+            "source.yml": _SOURCE_YML,
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "data__a_relation.csv": "col_a,col_b\n1,a\n2,b\n",
+            "data__b_relation.csv": "col_a,col_b\n3,c\n4,d\n",
+        }
+
+    @pytest.fixture(scope="class")
+    def tests(self):
+        return {
+            "test_generate_source.sql": _TEST_GENERATE_SOURCE,
+            "test_generate_source_some_tables.sql": _TEST_GENERATE_SOURCE_SOME_TABLES,
+            "test_generate_model_yaml.sql": _TEST_GENERATE_MODEL_YAML,
+            "test_generate_base_model.sql": _TEST_GENERATE_BASE_MODEL,
+            "test_generate_model_import_ctes.sql": _TEST_GENERATE_MODEL_IMPORT_CTES,
+            "test_generate_unit_test_template.sql": _TEST_GENERATE_UNIT_TEST_TEMPLATE,
+        }
+
+    @pytest.fixture(scope="class")
     def macros(self):
         return {
             "create_source_table.sql": _CREATE_SOURCE_TABLE_SQL,
             "assert_equal.sql": _ASSERT_EQUAL_SQL,
-            "integer_type_value.sql": _INTEGER_TYPE_VALUE_SQL,
-            "text_type_value.sql": _TEXT_TYPE_VALUE_SQL,
         }
 
     @pytest.fixture(scope="class")
-    def extra_dispatches(self):
-        return [
-            {
-                "macro_namespace": "codegen_integration_tests",
-                "search_order": [
-                    "test_dbt_package",
-                    "dbt",
-                    "codegen_integration_tests",
-                ],
-            }
-        ]
+    def packages(self, package_repo, package_revision):
+        return {
+            "packages": [
+                {"git": package_repo, "revision": package_revision},
+                {"package": "dbt-labs/dbt_utils", "version": "1.3.0"},
+            ]
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self, project_vars):
+        return {
+            "name": "test_dbt_package",
+            "vars": project_vars,
+            "seeds": {"+schema": "raw_data"},
+            "dispatch": [
+                {
+                    "macro_namespace": "dbt_utils",
+                    "search_order": ["test_dbt_package", "dbt", "dbt_utils"],
+                },
+                {
+                    "macro_namespace": "codegen",
+                    "search_order": ["test_dbt_package", "dbt", "codegen"],
+                },
+            ],
+        }
 
     def test_package(self, project, dbt_core_bug_workaround):
         run_dbt(["deps"])
@@ -46,6 +85,191 @@ class TestDbtCodegen(BaseDbtPackageTests):
         run_dbt(["run"])
         run_dbt(["test"])
 
+
+_SCHEMA_YML = """
+version: 2
+
+models:
+  - name: model_data_a
+    columns:
+      - name: col_a
+        description: 'description column "a"'
+""".strip()
+
+_SOURCE_YML = """
+version: 2
+
+sources:
+  - name: codegen_test_source
+    schema: "{{ target.schema ~ '__data_source_schema' }}"
+    tables:
+      - name: codegen_integration_tests__data_source_table
+        columns:
+          - name: my_integer_col
+            description: My Integer Column
+          - name: my_bool_col
+            description: My Boolean Column
+""".strip()
+
+_TEST_GENERATE_SOURCE = """
+{% set raw_schema = generate_schema_name('raw_data') %}
+
+{% set actual_source_yaml = codegen.generate_source(raw_schema) %}
+
+{% set expected_source_yaml %}
+version: 2
+
+sources:
+  - name: {{ raw_schema | trim | lower }}
+    tables:
+      - name: data__a_relation
+      - name: data__b_relation
+{% endset %}
+
+{{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}
+""".strip()
+
+_TEST_GENERATE_SOURCE_SOME_TABLES = """
+{% set raw_schema = generate_schema_name('raw_data') %}
+
+{% set actual_source_yaml = codegen.generate_source(
+    schema_name=raw_schema,
+    database_name=target.database,
+    table_names=['data__a_relation'],
+    generate_columns=True,
+    include_descriptions=True,
+    include_data_types=False
+) %}
+
+{% set expected_source_yaml %}
+version: 2
+
+sources:
+  - name: {{ raw_schema | trim | lower }}
+    description: ""
+    tables:
+      - name: data__a_relation
+        description: ""
+        columns:
+          - name: col_a
+            description: ""
+          - name: col_b
+            description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_source_yaml | trim, expected_source_yaml | trim) }}
+""".strip()
+
+_TEST_GENERATE_MODEL_YAML = """
+{% set actual_model_yaml = codegen.generate_model_yaml(
+    model_names=['data__a_relation']
+  )
+%}
+
+{% set expected_model_yaml %}
+version: 2
+
+models:
+  - name: data__a_relation
+    description: ""
+    columns:
+      - name: col_a
+        data_type: int
+        description: ""
+
+      - name: col_b
+        data_type: varchar
+        description: ""
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}
+""".strip()
+
+_TEST_GENERATE_BASE_MODEL = """
+{% set actual_base_model = codegen.generate_base_model(
+    source_name='codegen_test_source',
+    table_name='codegen_integration_tests__data_source_table'
+  )
+%}
+
+{% set expected_base_model %}
+
+with source as (
+
+    select * from {{ "{{" }} source('codegen_test_source', 'codegen_integration_tests__data_source_table') {{ "}}" }}
+
+),
+
+renamed as (
+
+    select
+        my_integer_col,
+        my_bool_col
+
+    from source
+
+)
+
+select * from renamed
+{% endset %}
+
+{{ assert_equal (actual_base_model | trim, expected_base_model | trim) }}
+""".strip()
+
+_TEST_GENERATE_MODEL_IMPORT_CTES = """
+-- depends_on: {{ ref('model_data_a') }}
+-- depends_on: {{ ref('child_model') }}
+
+{% set actual_model_yaml = codegen.generate_model_import_ctes(
+    model_name='child_model'
+  )
+%}
+
+{% set expected_model_yaml %}
+with model_data_a as (
+
+    select * from {{ "{{" }} ref('model_data_a') {{ "}}" }}
+
+)
+
+select * from model_data_a
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}
+""".strip()
+
+_TEST_GENERATE_UNIT_TEST_TEMPLATE = """
+-- depends_on: {{ ref('model_data_a') }}
+-- depends_on: {{ ref('child_model') }}
+
+{% set actual_model_yaml = codegen.generate_unit_test_template(
+    model_name='child_model',
+    inline_columns=False
+  )
+%}
+
+{% set expected_model_yaml %}
+unit_tests:
+  - name: unit_test_child_model
+    model: child_model
+
+    given:
+      - input: ref("model_data_a")
+        rows:
+          - col_a:\x20
+            col_b:\x20
+
+    expect:
+      rows:
+        - col_a:\x20
+          col_b:\x20
+
+{% endset %}
+
+{{ assert_equal (actual_model_yaml | trim, expected_model_yaml | trim) }}
+""".strip()
 
 _CREATE_SOURCE_TABLE_SQL = """
 {% macro create_source_table() %}
@@ -71,21 +295,6 @@ as select
 {% endset %}
 
 {{ run_query(create_table_sql) }}
-
-{% set drop_table_sql_case_sensitive %}
-drop table if exists {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive
-{% endset %}
-
-{{ run_query(drop_table_sql_case_sensitive) }}
-
-{% set create_table_sql_case_sensitive %}
-create table {{ target_schema }}.codegen_integration_tests__data_source_table_case_sensitive
-as select
-    1 as {{ adapter.quote("My_Integer_Col") }},
-    cast(1 as bit) as {{ adapter.quote("My_Bool_Col") }}
-{% endset %}
-
-{{ run_query(create_table_sql_case_sensitive) }}
 
 {% endmacro %}
 """.strip()
@@ -115,24 +324,12 @@ _ASSERT_EQUAL_SQL = """
 
     {{ log(msg, info=True) }}
 
-    select 'fail'
+    select 'fail' as result
 
 {% else %}
 
-    select top 0 'ok'
+    select top 0 'ok' as result
 
 {% endif %}
 {% endmacro %}
-""".strip()
-
-_INTEGER_TYPE_VALUE_SQL = """
-{%- macro integer_type_value() -%}
-bigint
-{%- endmacro -%}
-""".strip()
-
-_TEXT_TYPE_VALUE_SQL = """
-{%- macro text_type_value() -%}
-varchar
-{%- endmacro -%}
 """.strip()

--- a/tests/fabric/packages/test_dbt_codegen.py
+++ b/tests/fabric/packages/test_dbt_codegen.py
@@ -300,12 +300,23 @@ as select
 """.strip()
 
 _ASSERT_EQUAL_SQL = """
+{% macro _strip_trailing_ws(text) %}
+    {% set lines = text.split('\\n') %}
+    {% set stripped = [] %}
+    {% for line in lines %}
+        {% do stripped.append(line.rstrip()) %}
+    {% endfor %}
+    {{ return(stripped | join('\\n')) }}
+{% endmacro %}
+
 {% macro assert_equal(actual_object, expected_object) %}
+{% set actual_clean = _strip_trailing_ws(actual_object | string) %}
+{% set expected_clean = _strip_trailing_ws(expected_object | string) %}
 {% if not execute %}
 
     {# pass #}
 
-{% elif actual_object != expected_object %}
+{% elif actual_clean != expected_clean %}
 
     {% set msg %}
     Expected did not match actual
@@ -313,12 +324,12 @@ _ASSERT_EQUAL_SQL = """
     -----------
     Actual:
     -----------
-    --->{{ actual_object }}<---
+    --->{{ actual_clean }}<---
 
     -----------
     Expected:
     -----------
-    --->{{ expected_object }}<---
+    --->{{ expected_clean }}<---
 
     {% endset %}
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -44,6 +44,7 @@ nav = [
     { "Overview" = "packages/index.md" },
     { "dbt-utils" = "packages/dbt-utils.md" },
     { "dbt-date" = "packages/dbt-date.md" },
+    { "dbt-codegen" = "packages/dbt-codegen.md" },
     { "dbt-expectations" = "packages/dbt-expectations.md" },
     { "dbt-audit-helper" = "packages/dbt-audit-helper.md" },
     { "dbt-external-tables" = "packages/dbt-external-tables.md" },


### PR DESCRIPTION
## Summary

- Adds integration tests for the dbt-codegen community package against Fabric Data Warehouse
- Tests exercise `generate_source`, `generate_model_yaml`, `generate_base_model`, `generate_model_import_ctes`, and `generate_unit_test_template` macros
- Provides Fabric-compatible helper macros for `create_source_table` (T-SQL CTAS) and `assert_equal` (TOP instead of LIMIT, column aliases, trailing whitespace normalization)
- Adds documentation page for dbt-codegen compatibility

### Key design decisions

- Does **not** include the upstream `integration_tests` subdirectory package because its `assert_equal` macro cannot be overridden from the root project. dbt resolves non-dispatched macro calls from the **calling package first** — since `assert_equal` is both defined in and called from within `codegen_integration_tests`, the root project's override is never reached. (Verified empirically: including integration_tests + root project override results in PASS=6 ERROR=22 — the upstream `LIMIT 0` syntax still executes.)
- Instead, writes own test SQL files that directly invoke codegen macros from the root project, where our `assert_equal` override is the local definition and is always used.
- Uses `package_name = "codegen"` (matching the actual dbt project name), so the base class creates the correct dispatch config for the `codegen` namespace automatically.

Closes #171

## Test plan

- [x] `uv run pytest --dw -k "TestDbtCodegen"` passes (6 dbt test assertions within one pytest test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)