### PR TITLE
Add integration tests for dbt_artifacts package

### DIFF
--- a/src/dbt/include/fabric/dbt_project.yml
+++ b/src/dbt/include/fabric/dbt_project.yml
@@ -4,3 +4,8 @@ version: 1.0
 config-version: 2
 
 macro-paths: ["macros"]
+model-paths: ["models"]
+
+models:
+  dbt_artifacts:
+    +enabled: false

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/get_column_name_lists.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/get_column_name_lists.sql
@@ -1,0 +1,216 @@
+{% macro fabric__get_column_name_list(dataset) -%}
+
+    {% if dataset == "exposures" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            type,
+            owner,
+            maturity,
+            path,
+            description,
+            url,
+            package_name,
+            depends_on_nodes,
+            tags,
+            all_results
+        )
+
+    {% elif dataset == "invocations" %}
+
+        (
+            command_invocation_id,
+            dbt_version,
+            project_name,
+            run_started_at,
+            dbt_command,
+            full_refresh_flag,
+            target_profile_name,
+            target_name,
+            target_schema,
+            target_threads,
+            dbt_cloud_project_id,
+            dbt_cloud_job_id,
+            dbt_cloud_run_id,
+            dbt_cloud_run_reason_category,
+            dbt_cloud_run_reason,
+            env_vars,
+            dbt_vars,
+            invocation_args,
+            dbt_custom_envs
+        )
+
+    {% elif dataset == "model_executions" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message,
+            adapter_response
+        )
+
+    {% elif dataset == "models" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            name,
+            depends_on_nodes,
+            package_name,
+            path,
+            checksum,
+            materialization,
+            tags,
+            meta,
+            alias,
+            all_results
+        )
+
+    {% elif dataset == "seed_executions" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message,
+            adapter_response
+        )
+
+    {% elif dataset == "seeds" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            name,
+            package_name,
+            path,
+            checksum,
+            meta,
+            alias,
+            all_results
+        )
+
+    {% elif dataset == "snapshot_executions" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message,
+            adapter_response
+        )
+
+    {% elif dataset == "snapshots" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            name,
+            depends_on_nodes,
+            package_name,
+            path,
+            checksum,
+            strategy,
+            meta,
+            alias,
+            all_results
+        )
+
+    {% elif dataset == "sources" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            source_name,
+            loader,
+            name,
+            identifier,
+            loaded_at_field,
+            freshness,
+            all_results
+        )
+
+    {% elif dataset == "test_executions" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            failures,
+            message,
+            adapter_response
+        )
+
+    {% elif dataset == "tests" %}
+
+        (
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            depends_on_nodes,
+            package_name,
+            test_path,
+            tags,
+            all_results
+        )
+
+    {% endif %}
+
+{%- endmacro %}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/insert_into_metadata_table.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/insert_into_metadata_table.sql
@@ -1,0 +1,10 @@
+{% macro fabric__insert_into_metadata_table(relation, fields, content) -%}
+
+    {% set insert_into_table_query %}
+    insert into {{ relation }} {{ fields }}
+    {{ content }}
+    {% endset %}
+
+    {% do run_query(insert_into_table_query) %}
+
+{%- endmacro %}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/type_helpers.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/type_helpers.sql
@@ -1,0 +1,7 @@
+{% macro fabric__type_json() %}
+    varchar(max)
+{% endmacro %}
+
+{% macro fabric__type_array() %}
+    varchar(max)
+{% endmacro %}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_exposures.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_exposures.sql
@@ -1,0 +1,37 @@
+{% macro fabric__get_exposures_dml_sql(exposures) -%}
+
+    {% if exposures != [] %}
+        {% set exposure_values %}
+        select "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"
+        from ( values
+        {% for exposure in exposures -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ exposure.unique_id | replace("'","''") }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+                '{{ exposure.name | replace("'","''") }}', {# name #}
+                '{{ exposure.type }}', {# type #}
+                '{{ tojson(exposure.owner) }}', {# owner #}
+                '{{ exposure.maturity }}', {# maturity #}
+                '{{ exposure.original_file_path }}', {# path #}
+                '{{ exposure.description | replace("'","''") }}', {# description #}
+                '{{ exposure.url }}', {# url #}
+                '{{ exposure.package_name }}', {# package_name #}
+                '{{ tojson(exposure.depends_on.nodes) }}', {# depends_on_nodes #}
+                '{{ tojson(exposure.tags) }}', {# tags #}
+                {% if var('dbt_artifacts_exclude_all_results', false) %}
+                    null
+                {% else %}
+                    '{{ tojson(exposure) | replace("'", "''") }}' {# all_results #}
+                {% endif %}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14")
+
+        {% endset %}
+        {{ exposure_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_invocations.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_invocations.sql
@@ -1,0 +1,74 @@
+{% macro fabric__get_invocations_dml_sql(invocation_args=invocation_args_dict) -%}
+    {% set invocation_values %}
+    select
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        nullif("11", ''),
+        nullif("12", ''),
+        nullif("13", ''),
+        nullif("14", ''),
+        nullif("15", ''),
+        "16",
+        "17",
+        "18",
+        "19"
+    from (values
+    (
+        '{{ invocation_id }}', {# command_invocation_id #}
+        '{{ dbt_version }}', {# dbt_version #}
+        '{{ project_name }}', {# project_name #}
+        '{{ run_started_at }}', {# run_started_at #}
+        '{{ flags.WHICH }}', {# dbt_command #}
+        '{{ flags.FULL_REFRESH }}', {# full_refresh_flag #}
+        '{{ target.profile_name }}', {# target_profile_name #}
+        '{{ target.name }}', {# target_name #}
+        '{{ target.schema }}', {# target_schema #}
+        {{ target.threads }}, {# target_threads #}
+
+        '{{ env_var('DBT_CLOUD_PROJECT_ID', '') }}', {# dbt_cloud_project_id #}
+        '{{ env_var('DBT_CLOUD_JOB_ID', '') }}', {# dbt_cloud_job_id #}
+        '{{ env_var('DBT_CLOUD_RUN_ID', '') }}', {# dbt_cloud_run_id #}
+        '{{ env_var('DBT_CLOUD_RUN_REASON_CATEGORY', '') }}', {# dbt_cloud_run_reason_category #}
+        '{{ env_var('DBT_CLOUD_RUN_REASON', '') | replace("'","''") }}', {# dbt_cloud_run_reason #}
+        {% if var('env_vars', none) %}
+            {% set env_vars_dict = {} %}
+            {% for env_variable in var('env_vars') %}
+                {% do env_vars_dict.update({env_variable: (env_var(env_variable, '') | replace("'", "''"))}) %}
+            {% endfor %}
+            '{{ tojson(env_vars_dict) }}', {# env_vars #}
+        {% else %}
+            null, {# env_vars #}
+        {% endif %}
+        {% if var('dbt_vars', none) %}
+            {% set dbt_vars_dict = {} %}
+            {% for dbt_var in var('dbt_vars') %}
+                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, '') | replace("'", "''"))}) %}
+            {% endfor %}
+            '{{ tojson(dbt_vars_dict) }}', {# dbt_vars #}
+        {% else %}
+            null, {# dbt_vars #}
+        {% endif %}
+        '{{ tojson(invocation_args) | replace("'", "''") }}', {# invocation_args #}
+
+        {% set metadata_env = {} %}
+        {% for key, value in dbt_metadata_envs.items() %}
+            {% do metadata_env.update({key: (value | replace("'", "''"))}) %}
+        {% endfor %}
+        '{{ tojson(metadata_env) }}' {# dbt_custom_envs #}
+
+    )
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19")
+
+    {% endset %}
+    {{ invocation_values }}
+
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_model_executions.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_model_executions.sql
@@ -1,0 +1,44 @@
+{% macro fabric__get_model_executions_dml_sql(models) -%}
+    {% if models != [] %}
+        {% set model_execution_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"
+        from ( values
+        {% for model in models -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ model.node.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+
+                {% set config_full_refresh = model.node.config.full_refresh %}
+                {% if config_full_refresh is none %}
+                    {% set config_full_refresh = flags.FULL_REFRESH %}
+                {% endif %}
+                '{{ config_full_refresh }}', {# was_full_refresh #}
+
+                '{{ model.thread_id }}', {# thread_id #}
+                '{{ model.status }}', {# status #}
+
+                {% set compile_started_at = (model.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
+                {% set query_completed_at = (model.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
+
+                {{ model.execution_time }}, {# total_node_runtime #}
+                null, {# rows_affected - not available #}
+                '{{ model.node.config.materialized }}', {# materialization #}
+                '{{ model.node.schema }}', {# schema #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}', {# alias #}
+                '{{ model.message | replace("'", "''") }}', {# message #}
+                '{{ tojson(model.adapter_response) | replace("'", "''") }}' {# adapter_response #}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16")
+
+        {% endset %}
+        {{ model_execution_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_models.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_models.sql
@@ -1,0 +1,40 @@
+{% macro fabric__get_models_dml_sql(models) -%}
+
+    {% if models != [] %}
+        {% set model_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"
+        from ( values
+        {% for model in models -%}
+                {% set model_copy = dbt_artifacts.safe_copy_mapping(model) -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ model_copy.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+                '{{ model_copy.database }}', {# database #}
+                '{{ model_copy.schema }}', {# schema #}
+                '{{ model_copy.name }}', {# name #}
+                '{{ tojson(model_copy.depends_on.nodes) }}', {# depends_on_nodes #}
+                '{{ model_copy.package_name }}', {# package_name #}
+                '{{ model_copy.original_file_path }}', {# path #}
+                '{{ model_copy.checksum.checksum }}', {# checksum #}
+                '{{ model_copy.config.materialized }}', {# materialization #}
+                '{{ tojson(model_copy.tags) }}', {# tags #}
+                '{{ tojson(model_copy.config.meta) | replace("'","''") }}', {# meta #}
+                '{{ model_copy.alias }}', {# alias #}
+                {% if var('dbt_artifacts_exclude_all_results', false) %}
+                    null
+                {% else %}
+                    '{{ tojson(model_copy) | replace("'","''") }}' {# all_results #}
+                {% endif %}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15")
+
+        {% endset %}
+        {{ model_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_results.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_results.sql
@@ -1,0 +1,38 @@
+{%- macro fabric__upload_results(results) -%}
+
+    {% if execute %}
+
+        {% set datasets_to_load = ['exposures', 'seeds', 'snapshots', 'invocations', 'sources', 'tests', 'models'] %}
+        {% if results != [] %}
+            {% set datasets_to_load = ['model_executions', 'seed_executions', 'test_executions', 'snapshot_executions'] + datasets_to_load %}
+        {% endif %}
+
+        {% for dataset in datasets_to_load %}
+
+            {% do log("Uploading " ~ dataset.replace("_", " "), true) %}
+
+            {% set objects = dbt_artifacts.get_dataset_content(dataset) %}
+
+            {% set upload_limit = 5000 %}
+            {% if dataset == 'models' %}
+                {% set upload_limit = 100 %}
+            {% endif %}
+
+            {% for i in range(0, objects | length, upload_limit) -%}
+
+                {% set content = dbt_artifacts.get_table_content_values(dataset, objects[i: i + upload_limit]) %}
+
+                {{ dbt_artifacts.insert_into_metadata_table(
+                    dataset=dataset,
+                    fields=fabric__get_column_name_list(dataset),
+                    content=content
+                    )
+                }}
+
+            {% endfor %}
+
+        {% endfor %}
+
+    {% endif %}
+
+{%- endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_seed_executions.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_seed_executions.sql
@@ -1,0 +1,45 @@
+{% macro fabric__get_seed_executions_dml_sql(seeds) -%}
+    {% if seeds != [] %}
+        {% set seed_execution_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"
+        from ( values
+        {% for model in seeds -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ model.node.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+
+                {% set config_full_refresh = model.node.config.full_refresh %}
+                {% if config_full_refresh is none %}
+                    {% set config_full_refresh = flags.FULL_REFRESH %}
+                {% endif %}
+                '{{ config_full_refresh }}', {# was_full_refresh #}
+
+                '{{ model.thread_id }}', {# thread_id #}
+                '{{ model.status }}', {# status #}
+
+                {% set compile_started_at = (model.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
+                {% set query_completed_at = (model.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
+
+                {{ model.execution_time }}, {# total_node_runtime #}
+                null, {# rows_affected - not available #}
+                '{{ model.node.config.materialized }}', {# materialization #}
+                '{{ model.node.schema }}', {# schema #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}', {# alias #}
+                '{{ model.message | replace("'", "''") }}', {# message #}
+                '{{ tojson(model.adapter_response) | replace("'", "''") }}' {# adapter_response #}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16")
+
+        {% endset %}
+        {{ seed_execution_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_seeds.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_seeds.sql
@@ -1,0 +1,35 @@
+{% macro fabric__get_seeds_dml_sql(seeds) -%}
+
+    {% if seeds != [] %}
+        {% set seed_values %}
+        select "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"
+        from ( values
+        {% for seed in seeds -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ seed.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+                '{{ seed.database }}', {# database #}
+                '{{ seed.schema }}', {# schema #}
+                '{{ seed.name }}', {# name #}
+                '{{ seed.package_name }}', {# package_name #}
+                '{{ seed.original_file_path }}', {# path #}
+                '{{ seed.checksum.checksum }}', {# checksum #}
+                '{{ tojson(seed.config.meta) | replace("'","''") }}', {# meta #}
+                '{{ seed.alias }}', {# alias #}
+                {% if var('dbt_artifacts_exclude_all_results', false) %}
+                    null
+                {% else %}
+                    '{{ tojson(seed) | replace("'","''") }}' {# all_results #}
+                {% endif %}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12")
+
+        {% endset %}
+        {{ seed_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_snapshot_executions.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_snapshot_executions.sql
@@ -1,0 +1,45 @@
+{% macro fabric__get_snapshot_executions_dml_sql(snapshots) -%}
+    {% if snapshots != [] %}
+        {% set snapshot_execution_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16"
+        from ( values
+        {% for model in snapshots -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ model.node.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+
+                {% set config_full_refresh = model.node.config.full_refresh %}
+                {% if config_full_refresh is none %}
+                    {% set config_full_refresh = flags.FULL_REFRESH %}
+                {% endif %}
+                '{{ config_full_refresh }}', {# was_full_refresh #}
+
+                '{{ model.thread_id }}', {# thread_id #}
+                '{{ model.status }}', {# status #}
+
+                {% set compile_started_at = (model.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
+                {% set query_completed_at = (model.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
+
+                {{ model.execution_time }}, {# total_node_runtime #}
+                null, {# rows_affected - not available #}
+                '{{ model.node.config.materialized }}', {# materialization #}
+                '{{ model.node.schema }}', {# schema #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}', {# alias #}
+                '{{ model.message | replace("'", "''") }}', {# message #}
+                '{{ tojson(model.adapter_response) | replace("'", "''") }}' {# adapter_response #}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16")
+
+        {% endset %}
+        {{ snapshot_execution_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_snapshots.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_snapshots.sql
@@ -1,0 +1,38 @@
+{% macro fabric__get_snapshots_dml_sql(snapshots) -%}
+
+    {% if snapshots != [] %}
+        {% set snapshot_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"
+        from ( values
+        {% for snapshot in snapshots -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ snapshot.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+                '{{ snapshot.database }}', {# database #}
+                '{{ snapshot.schema }}', {# schema #}
+                '{{ snapshot.name }}', {# name #}
+                '{{ tojson(snapshot.depends_on.nodes) }}', {# depends_on_nodes #}
+                '{{ snapshot.package_name }}', {# package_name #}
+                '{{ snapshot.original_file_path }}', {# path #}
+                '{{ snapshot.checksum.checksum }}', {# checksum #}
+                '{{ snapshot.config.strategy }}', {# strategy #}
+                '{{ tojson(snapshot.config.meta) | replace("'","''") }}', {# meta #}
+                '{{ snapshot.alias }}', {# alias #}
+                {% if var('dbt_artifacts_exclude_all_results', false) %}
+                    null
+                {% else %}
+                    '{{ tojson(snapshot) | replace("'","''") }}' {# all_results #}
+                {% endif %}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14")
+
+        {% endset %}
+        {{ snapshot_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_sources.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_sources.sql
@@ -1,0 +1,34 @@
+{% macro fabric__get_sources_dml_sql(sources) -%}
+
+    {% if sources != [] %}
+        {% set source_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"
+        from ( values
+        {% for source in sources -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ source.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+                '{{ source.database }}', {# database #}
+                '{{ source.schema }}', {# schema #}
+                '{{ source.source_name }}', {# source_name #}
+                '{{ source.loader }}', {# loader #}
+                '{{ source.name }}', {# name #}
+                '{{ source.identifier }}', {# identifier #}
+                '{{ source.loaded_at_field | replace("'","''") }}', {# loaded_at_field #}
+                '{{ tojson(source.freshness) | replace("'","''") }}', {# freshness #}
+                {% if var('dbt_artifacts_exclude_all_results', false) %}
+                    null
+                {% else %}
+                    '{{ tojson(source) | replace("'", "''") }}' {# all_results #}
+                {% endif %}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12")
+        {% endset %}
+        {{ source_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_test_executions.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_test_executions.sql
@@ -1,0 +1,42 @@
+{% macro fabric__get_test_executions_dml_sql(tests) -%}
+    {% if tests != [] %}
+        {% set test_execution_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"
+        from ( values
+        {% for test in tests -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ test.node.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+
+                {% set config_full_refresh = test.node.config.full_refresh %}
+                {% if config_full_refresh is none %}
+                    {% set config_full_refresh = flags.FULL_REFRESH %}
+                {% endif %}
+                '{{ config_full_refresh }}', {# was_full_refresh #}
+
+                '{{ test.thread_id }}', {# thread_id #}
+                '{{ test.status }}', {# status #}
+
+                {% set compile_started_at = (test.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
+                {% set query_completed_at = (test.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
+
+                {{ test.execution_time }}, {# total_node_runtime #}
+                null, {# rows_affected - not available #}
+                {{ 'null' if test.failures is none else test.failures }}, {# failures #}
+                '{{ test.message | replace("'", "''") }}', {# message #}
+                '{{ tojson(test.adapter_response) | replace("'", "''") }}' {# adapter_response #}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13")
+
+        {% endset %}
+        {{ test_execution_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_tests.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_artifacts/upload_tests.sql
@@ -1,0 +1,31 @@
+{% macro fabric__get_tests_dml_sql(tests) -%}
+
+    {% if tests != [] %}
+        {% set test_values %}
+        select
+            "1", "2", "3", "4", "5", "6", "7", "8", "9"
+        from ( values
+        {% for test in tests -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ test.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+                '{{ test.name }}', {# name #}
+                '{{ tojson(test.depends_on.nodes) }}', {# depends_on_nodes #}
+                '{{ test.package_name }}', {# package_name #}
+                '{{ test.original_file_path }}', {# test_path #}
+                '{{ tojson(test.tags) }}', {# tags #}
+                {% if var('dbt_artifacts_exclude_all_results', false) %}
+                    null
+                {% else %}
+                    '{{ tojson(test) | replace("'","''") }}' {# all_results #}
+                {% endif %}
+            )
+            {%- if not loop.last %},{%- endif %}
+        {%- endfor %}
+        ) v ("1", "2", "3", "4", "5", "6", "7", "8", "9")
+        {% endset %}
+        {{ test_values }}
+    {% else %} {{ return("") }}
+    {% endif %}
+{% endmacro -%}

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__current_models.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__current_models.sql
@@ -1,0 +1,102 @@
+with
+    base as (select * from {{ ref("stg_dbt__models") }}),
+    model_executions as (select * from {{ ref("stg_dbt__model_executions") }}),
+    latest_models as (
+
+        select * from base where run_started_at = (select max(run_started_at) from base)
+
+    ),
+
+    latest_models_runs as (
+
+        select
+            model_executions.node_id,
+            model_executions.was_full_refresh,
+            model_executions.query_completed_at,
+            model_executions.total_node_runtime,
+            model_executions.rows_affected,
+            row_number() over (
+                partition by latest_models.node_id, model_executions.was_full_refresh
+                order by model_executions.query_completed_at desc
+            ) as run_idx,
+            row_number() over (
+                partition by latest_models.node_id
+                order by model_executions.query_completed_at desc
+            ) as run_idx_id_only
+        from model_executions
+        inner join latest_models on model_executions.node_id = latest_models.node_id
+        where model_executions.status = 'success'
+
+    ),
+
+    latest_model_stats as (
+
+        select
+            node_id,
+            max(
+                case
+                    when was_full_refresh = 1
+                    then query_completed_at
+                end
+            ) as last_full_refresh_run_completed_at,
+            max(
+                case
+                    when was_full_refresh = 1
+                    then total_node_runtime
+                end
+            ) as last_full_refresh_run_total_runtime,
+            max(
+                case
+                    when was_full_refresh = 1
+                    then rows_affected
+                end
+            ) as last_full_refresh_run_rows_affected,
+            max(case when run_idx_id_only = 1 then query_completed_at end) as last_run_completed_at,
+            max(
+                case when run_idx_id_only = 1 then total_node_runtime end
+            ) as last_run_total_runtime,
+            max(case when run_idx_id_only = 1 then rows_affected end) as last_run_rows_affected,
+            max(
+                case
+                    when was_full_refresh = 0
+                    then query_completed_at
+                end
+            ) as last_incremental_run_completed_at,
+            max(
+                case
+                    when was_full_refresh = 0
+                    then total_node_runtime
+                end
+            ) as last_incremental_run_total_runtime,
+            max(
+                case
+                    when was_full_refresh = 0
+                    then rows_affected
+                end
+            ) as last_incremental_run_rows_affected
+        from latest_models_runs
+        where run_idx = 1
+        group by node_id
+
+    ),
+
+    final as (
+
+        select
+            latest_models.*,
+            latest_model_stats.last_full_refresh_run_completed_at,
+            latest_model_stats.last_full_refresh_run_total_runtime,
+            latest_model_stats.last_full_refresh_run_rows_affected,
+            latest_model_stats.last_run_completed_at,
+            latest_model_stats.last_run_total_runtime,
+            latest_model_stats.last_run_rows_affected,
+            latest_model_stats.last_incremental_run_completed_at,
+            latest_model_stats.last_incremental_run_total_runtime,
+            latest_model_stats.last_incremental_run_rows_affected
+        from latest_models
+        left join latest_model_stats on latest_models.node_id = latest_model_stats.node_id
+
+    )
+
+select *
+from final

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__exposures.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__exposures.sql
@@ -1,0 +1,25 @@
+with
+    base as (select * from {{ ref('stg_dbt__exposures') }}),
+
+    exposures as (
+
+        select
+            exposure_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            type,
+            owner,
+            maturity,
+            path,
+            description,
+            url,
+            package_name,
+            depends_on_nodes,
+            tags
+        from base
+
+    )
+
+select * from exposures

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__models.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__models.sql
@@ -1,0 +1,27 @@
+with
+    base as (select * from {{ ref("stg_dbt__models") }}),
+
+    models as (
+
+        select
+            model_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            "database",
+            "schema",
+            depends_on_nodes,
+            package_name,
+            path,
+            checksum,
+            materialization,
+            tags,
+            meta,
+            alias
+        from base
+
+    )
+
+select *
+from models

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__seeds.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__seeds.sql
@@ -1,0 +1,24 @@
+with
+    base as (select * from {{ ref("stg_dbt__seeds") }}),
+
+    seeds as (
+
+        select
+            seed_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            "database",
+            "schema",
+            package_name,
+            path,
+            checksum,
+            meta,
+            alias
+        from base
+
+    )
+
+select *
+from seeds

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__snapshots.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__snapshots.sql
@@ -1,0 +1,26 @@
+with
+    base as (select * from {{ ref("stg_dbt__snapshots") }}),
+
+    snapshots as (
+
+        select
+            snapshot_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            "database",
+            "schema",
+            depends_on_nodes,
+            package_name,
+            path,
+            checksum,
+            strategy,
+            meta,
+            alias
+        from base
+
+    )
+
+select *
+from snapshots

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__sources.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__sources.sql
@@ -1,0 +1,24 @@
+with
+    base as (select * from {{ ref("stg_dbt__sources") }}),
+
+    sources as (
+
+        select
+            source_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            source_name,
+            loader,
+            name,
+            identifier,
+            loaded_at_field,
+            freshness
+        from base
+
+    )
+
+select *
+from sources

--- a/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__tests.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/dim_dbt__tests.sql
@@ -1,0 +1,20 @@
+with
+    base as (select * from {{ ref('stg_dbt__tests') }}),
+
+    tests as (
+
+        select
+            test_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            depends_on_nodes,
+            package_name,
+            test_path,
+            tags
+        from base
+
+    )
+
+select * from tests

--- a/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__invocations.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__invocations.sql
@@ -1,0 +1,30 @@
+with
+    base as (select * from {{ ref('stg_dbt__invocations') }}),
+
+    invocations as (
+
+        select
+            command_invocation_id,
+            dbt_version,
+            project_name,
+            run_started_at,
+            dbt_command,
+            full_refresh_flag,
+            target_profile_name,
+            target_name,
+            target_schema,
+            target_threads,
+            dbt_cloud_project_id,
+            dbt_cloud_job_id,
+            dbt_cloud_run_id,
+            dbt_cloud_run_reason_category,
+            dbt_cloud_run_reason,
+            env_vars,
+            dbt_vars,
+            invocation_args,
+            dbt_custom_envs
+        from base
+
+    )
+
+select * from invocations

--- a/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__model_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__model_executions.sql
@@ -1,0 +1,28 @@
+with
+    base as (select * from {{ ref("stg_dbt__model_executions") }}),
+
+    model_executions as (
+
+        select
+            model_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message
+        from base
+
+    )
+
+select *
+from model_executions

--- a/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__seed_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__seed_executions.sql
@@ -1,0 +1,28 @@
+with
+    base as (select * from {{ ref("stg_dbt__seed_executions") }}),
+
+    seed_executions as (
+
+        select
+            seed_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message
+        from base
+
+    )
+
+select *
+from seed_executions

--- a/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__snapshot_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__snapshot_executions.sql
@@ -1,0 +1,28 @@
+with
+    base as (select * from {{ ref("stg_dbt__snapshot_executions") }}),
+
+    snapshot_executions as (
+
+        select
+            snapshot_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message
+        from base
+
+    )
+
+select *
+from snapshot_executions

--- a/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__test_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/fct_dbt__test_executions.sql
@@ -1,0 +1,25 @@
+with
+    base as (select * from {{ ref("stg_dbt__test_executions") }}),
+
+    test_executions as (
+
+        select
+            test_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            failures,
+            message
+        from base
+
+    )
+
+select *
+from test_executions

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/exposures.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/exposures.sql
@@ -1,0 +1,19 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as type,
+    cast(null as {{ type_json() }}) as owner,
+    cast(null as {{ type_string() }}) as maturity,
+    cast(null as {{ type_string() }}) as path,
+    cast(null as {{ type_string() }}) as description,
+    cast(null as {{ type_string() }}) as url,
+    cast(null as {{ type_string() }}) as package_name,
+    cast(null as {{ type_array() }}) as depends_on_nodes,
+    cast(null as {{ type_array() }}) as tags,
+    cast(null as {{ type_json() }}) as all_results
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/invocations.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/invocations.sql
@@ -1,0 +1,24 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as dbt_version,
+    cast(null as {{ type_string() }}) as project_name,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as dbt_command,
+    cast(null as {{ type_boolean() }}) as full_refresh_flag,
+    cast(null as {{ type_string() }}) as target_profile_name,
+    cast(null as {{ type_string() }}) as target_name,
+    cast(null as {{ type_string() }}) as target_schema,
+    cast(null as {{ type_int() }}) as target_threads,
+    cast(null as {{ type_string() }}) as dbt_cloud_project_id,
+    cast(null as {{ type_string() }}) as dbt_cloud_job_id,
+    cast(null as {{ type_string() }}) as dbt_cloud_run_id,
+    cast(null as {{ type_string() }}) as dbt_cloud_run_reason_category,
+    cast(null as {{ type_string() }}) as dbt_cloud_run_reason,
+    cast(null as {{ type_json() }}) as env_vars,
+    cast(null as {{ type_json() }}) as dbt_vars,
+    cast(null as {{ type_json() }}) as invocation_args,
+    cast(null as {{ type_json() }}) as dbt_custom_envs
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/model_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/model_executions.sql
@@ -1,0 +1,21 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_boolean() }}) as was_full_refresh,
+    cast(null as {{ type_string() }}) as thread_id,
+    cast(null as {{ type_string() }}) as status,
+    cast(null as {{ type_timestamp() }}) as compile_started_at,
+    cast(null as {{ type_timestamp() }}) as query_completed_at,
+    cast(null as {{ type_float() }}) as total_node_runtime,
+    cast(null as {{ type_int() }}) as rows_affected,
+    cast(null as {{ type_string() }}) as materialization,
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_string() }}) as message,
+    cast(null as {{ type_json() }}) as adapter_response
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/models.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/models.sql
@@ -1,0 +1,20 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as "database",
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_array() }}) as depends_on_nodes,
+    cast(null as {{ type_string() }}) as package_name,
+    cast(null as {{ type_string() }}) as path,
+    cast(null as {{ type_string() }}) as checksum,
+    cast(null as {{ type_string() }}) as materialization,
+    cast(null as {{ type_array() }}) as tags,
+    cast(null as {{ type_json() }}) as meta,
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_json() }}) as all_results
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/seed_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/seed_executions.sql
@@ -1,0 +1,21 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_boolean() }}) as was_full_refresh,
+    cast(null as {{ type_string() }}) as thread_id,
+    cast(null as {{ type_string() }}) as status,
+    cast(null as {{ type_timestamp() }}) as compile_started_at,
+    cast(null as {{ type_timestamp() }}) as query_completed_at,
+    cast(null as {{ type_float() }}) as total_node_runtime,
+    cast(null as {{ type_int() }}) as rows_affected,
+    cast(null as {{ type_string() }}) as materialization,
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_string() }}) as message,
+    cast(null as {{ type_json() }}) as adapter_response
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/seeds.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/seeds.sql
@@ -1,0 +1,17 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as "database",
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as package_name,
+    cast(null as {{ type_string() }}) as path,
+    cast(null as {{ type_string() }}) as checksum,
+    cast(null as {{ type_json() }}) as meta,
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_json() }}) as all_results
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/snapshot_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/snapshot_executions.sql
@@ -1,0 +1,21 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_boolean() }}) as was_full_refresh,
+    cast(null as {{ type_string() }}) as thread_id,
+    cast(null as {{ type_string() }}) as status,
+    cast(null as {{ type_timestamp() }}) as compile_started_at,
+    cast(null as {{ type_timestamp() }}) as query_completed_at,
+    cast(null as {{ type_float() }}) as total_node_runtime,
+    cast(null as {{ type_int() }}) as rows_affected,
+    cast(null as {{ type_string() }}) as materialization,
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_string() }}) as message,
+    cast(null as {{ type_json() }}) as adapter_response
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/snapshots.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/snapshots.sql
@@ -1,0 +1,19 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as "database",
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_array() }}) as depends_on_nodes,
+    cast(null as {{ type_string() }}) as package_name,
+    cast(null as {{ type_string() }}) as path,
+    cast(null as {{ type_string() }}) as checksum,
+    cast(null as {{ type_string() }}) as strategy,
+    cast(null as {{ type_json() }}) as meta,
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_json() }}) as all_results
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/sources.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/sources.sql
@@ -1,0 +1,17 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as "database",
+    cast(null as {{ type_string() }}) as "schema",
+    cast(null as {{ type_string() }}) as source_name,
+    cast(null as {{ type_string() }}) as loader,
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as identifier,
+    cast(null as {{ type_string() }}) as loaded_at_field,
+    cast(null as {{ type_json() }}) as freshness,
+    cast(null as {{ type_json() }}) as all_results
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/test_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/test_executions.sql
@@ -1,0 +1,18 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_boolean() }}) as was_full_refresh,
+    cast(null as {{ type_string() }}) as thread_id,
+    cast(null as {{ type_string() }}) as status,
+    cast(null as {{ type_timestamp() }}) as compile_started_at,
+    cast(null as {{ type_timestamp() }}) as query_completed_at,
+    cast(null as {{ type_float() }}) as total_node_runtime,
+    cast(null as {{ type_int() }}) as rows_affected,
+    cast(null as {{ type_int() }}) as failures,
+    cast(null as {{ type_string() }}) as message,
+    cast(null as {{ type_json() }}) as adapter_response
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/sources/tests.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/sources/tests.sql
@@ -1,0 +1,14 @@
+with dummy_cte as (select 1 as foo)
+
+select
+    cast(null as {{ type_string() }}) as command_invocation_id,
+    cast(null as {{ type_string() }}) as node_id,
+    cast(null as {{ type_timestamp() }}) as run_started_at,
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_array() }}) as depends_on_nodes,
+    cast(null as {{ type_string() }}) as package_name,
+    cast(null as {{ type_string() }}) as test_path,
+    cast(null as {{ type_array() }}) as tags,
+    cast(null as {{ type_json() }}) as all_results
+from dummy_cte
+where 1 = 0

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__exposures.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__exposures.sql
@@ -1,0 +1,25 @@
+with
+    base as (select * from {{ ref('exposures') }}),
+
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(['command_invocation_id', 'node_id']) }} as exposure_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            type,
+            owner,
+            maturity,
+            path,
+            description,
+            url,
+            package_name,
+            depends_on_nodes,
+            tags
+        from base
+
+    )
+
+select * from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__invocations.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__invocations.sql
@@ -1,0 +1,30 @@
+with
+    base as (select * from {{ ref('invocations') }}),
+
+    enhanced as (
+
+        select
+            command_invocation_id,
+            dbt_version,
+            project_name,
+            run_started_at,
+            dbt_command,
+            full_refresh_flag,
+            target_profile_name,
+            target_name,
+            target_schema,
+            target_threads,
+            dbt_cloud_project_id,
+            dbt_cloud_job_id,
+            dbt_cloud_run_id,
+            dbt_cloud_run_reason_category,
+            dbt_cloud_run_reason,
+            env_vars,
+            dbt_vars,
+            invocation_args,
+            dbt_custom_envs
+        from base
+
+    )
+
+select * from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__model_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__model_executions.sql
@@ -1,0 +1,29 @@
+with
+    base as (select * from {{ ref("model_executions") }}),
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as model_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            {{ split_part("thread_id", "'-'", 2) }} as thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message,
+            adapter_response
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__models.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__models.sql
@@ -1,0 +1,27 @@
+with
+    base as (select * from {{ ref("models") }}),
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as model_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            name,
+            depends_on_nodes,
+            package_name,
+            path,
+            checksum,
+            materialization,
+            tags,
+            meta,
+            alias
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__seed_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__seed_executions.sql
@@ -1,0 +1,29 @@
+with
+    base as (select * from {{ ref("seed_executions") }}),
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as seed_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            {{ split_part("thread_id", "'-'", 2) }} as thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message,
+            adapter_response
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__seeds.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__seeds.sql
@@ -1,0 +1,24 @@
+with
+    base as (select * from {{ ref("seeds") }}),
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as seed_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            name,
+            package_name,
+            path,
+            checksum,
+            meta,
+            alias
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__snapshot_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__snapshot_executions.sql
@@ -1,0 +1,29 @@
+with
+    base as (select * from {{ ref("snapshot_executions") }}),
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as snapshot_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            {{ split_part("thread_id", "'-'", 2) }} as thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            materialization,
+            "schema",
+            name,
+            alias,
+            message,
+            adapter_response
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__snapshots.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__snapshots.sql
@@ -1,0 +1,27 @@
+with
+    base as (select * from {{ ref("snapshots") }}),
+
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as snapshot_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            name,
+            depends_on_nodes,
+            package_name,
+            path,
+            checksum,
+            strategy,
+            meta,
+            alias
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__sources.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__sources.sql
@@ -1,0 +1,24 @@
+with
+    base as (select * from {{ ref("sources") }}),
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(["command_invocation_id", "node_id"]) }}
+            as source_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            "database",
+            "schema",
+            source_name,
+            loader,
+            name,
+            identifier,
+            loaded_at_field,
+            freshness
+        from base
+
+    )
+
+select *
+from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__test_executions.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__test_executions.sql
@@ -1,0 +1,24 @@
+with
+    base as (select * from {{ ref('test_executions') }}),
+
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(['command_invocation_id', 'node_id']) }} as test_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            was_full_refresh,
+            {{ split_part('thread_id', "'-'", 2) }} as thread_id,
+            status,
+            compile_started_at,
+            query_completed_at,
+            total_node_runtime,
+            rows_affected,
+            failures,
+            message
+        from base
+
+    )
+
+select * from enhanced

--- a/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__tests.sql
+++ b/src/dbt/include/fabric/models/dbt_artifacts/staging/stg_dbt__tests.sql
@@ -1,0 +1,20 @@
+with
+    base as (select * from {{ ref('tests') }}),
+
+    enhanced as (
+
+        select
+            {{ dbt_artifacts.generate_surrogate_key(['command_invocation_id', 'node_id']) }} as test_execution_id,
+            command_invocation_id,
+            node_id,
+            run_started_at,
+            name,
+            depends_on_nodes,
+            package_name,
+            test_path,
+            tags
+        from base
+
+    )
+
+select * from enhanced

--- a/tests/fabric/packages/test_dbt_artifacts.py
+++ b/tests/fabric/packages/test_dbt_artifacts.py
@@ -1,0 +1,109 @@
+from typing import Any
+
+import pytest
+
+from dbt.tests.util import run_dbt
+from tests.fabric.packages.base_package_test import BaseDbtPackageTests
+
+
+class TestDbtArtifacts(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "dbt_artifacts"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "https://github.com/brooklyn-data/dbt_artifacts"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "2.10.1"
+
+    @pytest.fixture(scope="class")
+    def packages(
+        self, package_name: str, package_repo: str, package_revision: str
+    ) -> dict[str, list]:
+        return {
+            "packages": [
+                {"git": package_repo, "revision": package_revision},
+                {
+                    "git": package_repo,
+                    "revision": package_revision,
+                    "subdirectory": "integration_test_project",
+                },
+            ]
+        }
+
+    @pytest.fixture(scope="class")
+    def models_config(self) -> dict[str, Any]:
+        return {
+            "dbt_artifacts": {
+                "+materialized": "table",
+                "+persist_docs": {"relation": False, "columns": False},
+                "+as_columnstore": False,
+            },
+            "artifacts_integration_tests": {
+                "+persist_docs": {"relation": False, "columns": False},
+            },
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds_config(self) -> dict[str, Any]:
+        return {
+            "artifacts_integration_tests": {
+                "freshness": {"+column_types": {"load_timestamp": "datetime2(6)"}}
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def project_vars(self) -> dict[str, Any]:
+        return {
+            "dbt_artifacts_exclude_all_results": True,
+        }
+
+    @pytest.fixture(scope="class")
+    def extra_dispatches(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "macro_namespace": "dbt_artifacts",
+                "search_order": ["test_dbt_package", "dbt", "dbt_artifacts"],
+            },
+        ]
+
+    @pytest.fixture(scope="class")
+    def project_config_update(
+        self,
+        package_name: str,
+        models_config: dict,
+        seeds_config: dict,
+        tests_config: dict,
+        project_vars: dict,
+        extra_dispatches: list,
+    ) -> dict[str, Any]:
+        dispatches = [
+            {
+                "macro_namespace": package_name,
+                "search_order": ["test_dbt_package", "dbt", package_name],
+            },
+            {
+                "macro_namespace": "dbt_utils",
+                "search_order": ["test_dbt_package", "dbt", "dbt_utils"],
+            },
+        ]
+        dispatches.extend(extra_dispatches)
+
+        return {
+            "name": "test_dbt_package",
+            "vars": project_vars,
+            "dispatch": dispatches,
+            "seeds": seeds_config,
+            "models": models_config,
+            "tests": tests_config,
+            "on-run-end": ["{{ fabric__upload_results(results) }}"],
+        }
+
+    def test_package(self, project, dbt_core_bug_workaround):
+        run_dbt(["deps"])
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        run_dbt(["test"])

--- a/tests/fabric/packages/test_dbt_artifacts.py
+++ b/tests/fabric/packages/test_dbt_artifacts.py
@@ -37,10 +37,8 @@ class TestDbtArtifacts(BaseDbtPackageTests):
     @pytest.fixture(scope="class")
     def models_config(self) -> dict[str, Any]:
         return {
-            "dbt_artifacts": {
-                "+materialized": "table",
-                "+persist_docs": {"relation": False, "columns": False},
-                "+as_columnstore": False,
+            "dbt_fabric": {
+                "dbt_artifacts": {"+enabled": True, "+materialized": "table"},
             },
             "artifacts_integration_tests": {
                 "+persist_docs": {"relation": False, "columns": False},


### PR DESCRIPTION
## Summary

- Adds `fabric__` dispatch overrides for all dbt_artifacts upload macros (modeled on the existing `sqlserver__` variants in the package)
- Adds `fabric__type_json` and `fabric__type_array` returning `varchar(max)`
- Adds `fabric__insert_into_metadata_table` for Fabric DW
- Adds a custom `fabric__get_column_name_list` that quotes T-SQL reserved words (`schema`, `database`)
- Adds `fabric__upload_results` as the on-run-end entry point (needed because the package's `get_column_name_list` is not dispatched and hardcodes `target.type == "sqlserver"` checks)
- Integration test using `BaseDbtPackageTests`

## Known issues / TODOs

- The package's downstream models (staging, dims, facts) have `target.type == "sqlserver"` conditionals for quoting reserved words and boolean comparisons. Since our adapter type is `fabric`, these don't trigger. The test currently enables all models with `+materialized: table` — some may fail and need to be disabled or overridden.
- The `microbatch` incremental strategy in the integration test project may not be supported on Fabric DW.

## Test plan

- [ ] Run `uv run pytest --dw -k "TestDbtArtifacts"` against Fabric DW
- [ ] Verify on-run-end upload populates source tables
- [ ] Identify and document which downstream models fail

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)