### PR TITLE
Allow configuring Fabric API base URLs for non-production tenants

### DIFF
--- a/src/dbt/adapters/fabric/fabric_livy_session.py
+++ b/src/dbt/adapters/fabric/fabric_livy_session.py
@@ -51,7 +51,11 @@ class LivySession:
 
     def get_logs_url(self) -> str:
         """Build the Fabric Portal URL to the Spark monitor logs for this session."""
-        return f"https://app.fabric.microsoft.com/workloads/de-ds/sparkmonitor/{self._fabric_api_client.get_lakehouse_id()}/{self._fabric_api_client.get_livy_session_id()}"
+        api_uri = self._fabric_api_client._credentials.fabric_base_api_uri
+        portal_host = api_uri.replace("://api.", "://app.").split("/v")[0]
+        lakehouse_id = self._fabric_api_client.get_lakehouse_id()
+        session_id = self._fabric_api_client.get_livy_session_id()
+        return f"{portal_host}/workloads/de-ds/sparkmonitor/{lakehouse_id}/{session_id}"
 
     def wait_for_session_ready(self) -> None:
         """Poll until the Livy session reaches the idle state.

--- a/test.env.sample
+++ b/test.env.sample
@@ -17,6 +17,9 @@ FABRIC_TEST_HOST=your-endpoint.datawarehouse.fabric.microsoft.com
 #FABRIC_TEST_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token
 # Purview endpoint for integration tests (optional, tests are skipped without it)
 #FABRIC_TEST_PURVIEW_ENDPOINT=https://your-account.purview.azure.com
+# Custom Fabric API base URLs (optional, for non-production tenants like MSIT)
+#FABRIC_TEST_BASE_API_URI=https://api.msit.fabric.microsoft.com/v1
+#FABRIC_TEST_POWERBI_BASE_API_URI=https://api.msit.powerbi.com/v1.0
 # Extra users in your data warehouse to run authorization & grant tests with
 DBT_TEST_USER_1=dbo
 DBT_TEST_USER_2=dbo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,11 @@ def dbt_profile_target(dbt_profile_target_update, adapter_type: str, prefix: str
         **_auth_kwargs_from_env(),
     }
 
+    if base_api_uri := os.getenv("FABRIC_TEST_BASE_API_URI"):
+        target["fabric_base_api_uri"] = base_api_uri
+    if powerbi_api_uri := os.getenv("FABRIC_TEST_POWERBI_BASE_API_URI"):
+        target["powerbi_base_api_uri"] = powerbi_api_uri
+
     if adapter_type == "fabric":
         adapter_settings = {
             "type": "fabric",

--- a/tests/unit/test_livy_session.py
+++ b/tests/unit/test_livy_session.py
@@ -30,6 +30,30 @@ def session(fabric_api_client):
     return LivySession(fabric_api_client)
 
 
+class TestGetLogsUrl:
+    @pytest.mark.parametrize(
+        ("api_uri", "expected_host"),
+        [
+            (
+                "https://api.fabric.microsoft.com/v1",
+                "https://app.fabric.microsoft.com",
+            ),
+            (
+                "https://api.msit.fabric.microsoft.com/v1",
+                "https://app.msit.fabric.microsoft.com",
+            ),
+        ],
+    )
+    def test_derives_portal_url_from_base_api_uri(
+        self, api_uri, expected_host, session, credentials
+    ):
+        credentials.fabric_base_api_uri = api_uri
+
+        url = session.get_logs_url()
+
+        assert url == f"{expected_host}/workloads/de-ds/sparkmonitor/lakehouse-id/session-id"
+
+
 class TestWaitForSessionReady:
     @patch("dbt.adapters.fabric.fabric_livy_session.time.sleep")
     def test_returns_immediately_when_idle(self, mock_sleep, session, fabric_api_client):


### PR DESCRIPTION
## Summary

- Adds `FABRIC_TEST_BASE_API_URI` and `FABRIC_TEST_POWERBI_BASE_API_URI` env vars to the test harness so integration tests can target non-production Fabric tenants (e.g. MSIT at `api.msit.fabric.microsoft.com`)
- Derives the Spark monitor portal URL from the configured `fabric_base_api_uri` instead of hardcoding `app.fabric.microsoft.com`
- Documents the new optional vars in `test.env.sample`

Closes #224

## Test plan

- [x] Run integration tests against MSIT tenant with `FABRIC_TEST_BASE_API_URI` set in `test.env`
- [x] Verify Spark monitor URL is correctly derived (logs show `app.msit.fabric.microsoft.com` instead of `app.fabric.microsoft.com`)
- [x] Verify default behavior is unchanged when env vars are not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)