### PR TITLE
Add Spark SQL view support for FabricSpark adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,8 +202,6 @@ When a test fails, always investigate before skipping. The macro inheritance cha
 
 - **Base test fixtures assume PostgreSQL syntax** -- dbt-tests-adapter base classes are written for PostgreSQL. Their SQL fixtures commonly contain PG-specific syntax that fails on both Fabric and Spark: `::text` casts, `TEXT`/`INTEGER`/`TIMESTAMP WITHOUT TIME ZONE` types, double-quoted identifiers, multi-statement strings separated by `;`, and `VACUUM`/`BEGIN`/`COMMIT` transaction commands. Fix: override the relevant fixture (`models`, `seeds`, `macros`, or `seeds__expected_sql`) to replace PG syntax with the target dialect. For FabricSpark: use `STRING` not `TEXT`, `TIMESTAMP` not `TIMESTAMP WITHOUT TIME ZONE`, `INT`/`BIGINT` not `INTEGER`, backtick-quoted identifiers not double-quoted, and split multi-statement SQL into individual executions. For Fabric (T-SQL): use `varchar`/`datetime2(6)` and bracket-quoted identifiers. Note that test fixture macros dispatched with `macro_namespace='test'` do not search adapter macros -- per-test overrides via the `macros` fixture are required even when the adapter provides a production version.
 
-- **Base test classes hardcode `view` as materialization or relation type** -- Many base classes use `config(materialized="view")` in model SQL, `store_failures_as="view"` in test configs, or fall back to `view` in materialization logic (e.g., clone). FabricSpark now supports views (`CREATE OR REPLACE VIEW`), so `materialized="view"` works. However, the default materialization remains `materialized_view` (lake view). The `conftest.py` project-level default (`+materialized: materialized_view`) only applies when `config()` is not explicitly set in the model SQL, so fixture-level overrides are often still needed for tests that expect a specific materialization.
-
 - **Spark's `spark_catalog` rejects 3-part names in certain DML statements** -- `INSERT INTO TABLE` and some other DML trigger `REQUIRES_SINGLE_PART_NAMESPACE` with 3-part names (`database.schema.table`), even though `CREATE TABLE`, `MERGE INTO`, and `CREATE OR REPLACE MATERIALIZED LAKE VIEW` handle 3-part names fine. Additionally, if *any* temporary view exists in the Livy session, even normally-working 3-part DML breaks. Fix: strip the database component with `.include(database=false)` in affected macros, drop the `TABLE` keyword from `INSERT INTO`, avoid temporary views (use real staging tables instead), and override parent macros that call DML helpers without `adapter.dispatch()`. When `INSERT INTO` cannot be fixed, `MERGE INTO ... ON false WHEN NOT MATCHED THEN INSERT *` is a workaround.
 
 - **Delta Lake DDL has stricter limitations than T-SQL** -- Delta tables in Fabric Lakehouse do not support `DEFAULT` clauses in `ALTER TABLE ADD COLUMN`, and dropping a source table does not automatically drop dependent materialized views (no cascading drops). Fix: strip `DEFAULT ...` from column definitions in test helpers. For features that appear unsupported (e.g., `CREATE FUNCTION`), first verify by running test queries against Fabric and checking how dbt-spark/dbt-databricks handle it -- Fabric's Spark variant may support more than expected. Only skip after confirming the limitation with actual queries.
@@ -332,13 +330,6 @@ Fabric (T-SQL) and FabricSpark (Spark SQL) use fundamentally different SQL diale
 | Default materialization | `table` | `materialized_view` (lake view) |
 | Connection | mssql-python (TDS) | Livy sessions (HTTP/REST) |
 | Catalog queries | `sys.tables`, `sys.views`, `sys.columns` | `SHOW TABLES`, `SHOW COLUMNS`, `DESCRIBE` |
-
-### Spark SQL views in Fabric Lakehouse
-
-Spark SQL views (`CREATE OR REPLACE VIEW`) are supported in schema-enabled Fabric Lakehouses. The adapter supports all three relation types: tables, materialized lake views, and views.
-- `FabricSparkRelationType` has `Table`, `View`, and `MaterializedView` variants
-- FabricSpark's default materialization is `materialized_view` (set in `dbt_project.yml` and `conftest.py`) — views are opt-in via `materialized='view'` in model config
-- The `conftest.py` fixture `dbt_project_yml` sets `+materialized: materialized_view` for FabricSpark, but this can be lost if a test's `project_config_update` replaces the `models` key (shallow merge)
 
 ### Materialized lake views in FabricSpark
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ When a test fails, always investigate before skipping. The macro inheritance cha
 
 - **Base test fixtures assume PostgreSQL syntax** -- dbt-tests-adapter base classes are written for PostgreSQL. Their SQL fixtures commonly contain PG-specific syntax that fails on both Fabric and Spark: `::text` casts, `TEXT`/`INTEGER`/`TIMESTAMP WITHOUT TIME ZONE` types, double-quoted identifiers, multi-statement strings separated by `;`, and `VACUUM`/`BEGIN`/`COMMIT` transaction commands. Fix: override the relevant fixture (`models`, `seeds`, `macros`, or `seeds__expected_sql`) to replace PG syntax with the target dialect. For FabricSpark: use `STRING` not `TEXT`, `TIMESTAMP` not `TIMESTAMP WITHOUT TIME ZONE`, `INT`/`BIGINT` not `INTEGER`, backtick-quoted identifiers not double-quoted, and split multi-statement SQL into individual executions. For Fabric (T-SQL): use `varchar`/`datetime2(6)` and bracket-quoted identifiers. Note that test fixture macros dispatched with `macro_namespace='test'` do not search adapter macros -- per-test overrides via the `macros` fixture are required even when the adapter provides a production version.
 
-- **Base test classes hardcode `view` as materialization or relation type** -- Many base classes use `config(materialized="view")` in model SQL, `store_failures_as="view"` in test configs, or fall back to `view` in materialization logic (e.g., clone). Since FabricSpark has no `View` relation type, all of these fail. Fix: override fixtures and test methods to replace `view` with `materialized_view` (for read-only derived data) or `table` (for DML-heavy tests). This applies anywhere a base class references views -- models, schema.yml, project config, expected relation types, and materialization macros. Note: the `conftest.py` project-level default (`+materialized: materialized_view`) only applies when `config()` is not explicitly set in the model SQL, so fixture-level overrides are often still needed.
+- **Base test classes hardcode `view` as materialization or relation type** -- Many base classes use `config(materialized="view")` in model SQL, `store_failures_as="view"` in test configs, or fall back to `view` in materialization logic (e.g., clone). FabricSpark now supports views (`CREATE OR REPLACE VIEW`), so `materialized="view"` works. However, the default materialization remains `materialized_view` (lake view). The `conftest.py` project-level default (`+materialized: materialized_view`) only applies when `config()` is not explicitly set in the model SQL, so fixture-level overrides are often still needed for tests that expect a specific materialization.
 
 - **Spark's `spark_catalog` rejects 3-part names in certain DML statements** -- `INSERT INTO TABLE` and some other DML trigger `REQUIRES_SINGLE_PART_NAMESPACE` with 3-part names (`database.schema.table`), even though `CREATE TABLE`, `MERGE INTO`, and `CREATE OR REPLACE MATERIALIZED LAKE VIEW` handle 3-part names fine. Additionally, if *any* temporary view exists in the Livy session, even normally-working 3-part DML breaks. Fix: strip the database component with `.include(database=false)` in affected macros, drop the `TABLE` keyword from `INSERT INTO`, avoid temporary views (use real staging tables instead), and override parent macros that call DML helpers without `adapter.dispatch()`. When `INSERT INTO` cannot be fixed, `MERGE INTO ... ON false WHEN NOT MATCHED THEN INSERT *` is a workaround.
 
@@ -333,12 +333,11 @@ Fabric (T-SQL) and FabricSpark (Spark SQL) use fundamentally different SQL diale
 | Connection | mssql-python (TDS) | Livy sessions (HTTP/REST) |
 | Catalog queries | `sys.tables`, `sys.views`, `sys.columns` | `SHOW TABLES`, `SHOW COLUMNS`, `DESCRIBE` |
 
-### No Spark SQL views in Fabric Lakehouse
+### Spark SQL views in Fabric Lakehouse
 
-Microsoft Fabric Lakehouse with schemas enabled does not support Spark SQL views — only tables and materialized lake views. This means:
-- `FabricSparkRelationType` has no `View` variant — only `Table`, `MaterializedView`, `CTE`, `Ephemeral`, etc.
-- FabricSpark's default materialization is `materialized_view` (set in `dbt_project.yml` and `conftest.py`)
-- dbt's default materialization is `view`, which will fail on FabricSpark — every test that uses the default must be configured to use `materialized_view` or `table` instead
+Spark SQL views (`CREATE OR REPLACE VIEW`) are supported in schema-enabled Fabric Lakehouses. The adapter supports all three relation types: tables, materialized lake views, and views.
+- `FabricSparkRelationType` has `Table`, `View`, and `MaterializedView` variants
+- FabricSpark's default materialization is `materialized_view` (set in `dbt_project.yml` and `conftest.py`) — views are opt-in via `materialized='view'` in model config
 - The `conftest.py` fixture `dbt_project_yml` sets `+materialized: materialized_view` for FabricSpark, but this can be lost if a test's `project_config_update` replaces the `models` key (shallow merge)
 
 ### Materialized lake views in FabricSpark

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,17 +327,13 @@ Fabric (T-SQL) and FabricSpark (Spark SQL) use fundamentally different SQL diale
 | String type | `varchar(MAX)` | `string` |
 | Timestamp | `datetime2(6)` | `timestamp` |
 | Identifier quoting | `[brackets]` | `` `backticks` `` |
-| Default materialization | `table` | `materialized_view` (lake view) |
+| Default materialization | `table` | `view` |
 | Connection | mssql-python (TDS) | Livy sessions (HTTP/REST) |
 | Catalog queries | `sys.tables`, `sys.views`, `sys.columns` | `SHOW TABLES`, `SHOW COLUMNS`, `DESCRIBE` |
 
 ### Materialized lake views in FabricSpark
 
-FabricSpark's default materialization is `materialized_view`, which creates Fabric "lake views". These support:
-- `PARTITIONED BY` clauses
-- `TBLPROPERTIES` (Spark table properties)
-- `CHECK` constraints with `ON MISMATCH` behavior
-- `CREATE OR REPLACE` semantics
+FabricSpark supports `materialized_view` as a materialization, which creates Fabric "lake views". These support `PARTITIONED BY`, `TBLPROPERTIES`, `CHECK` constraints with `ON MISMATCH`, and `CREATE OR REPLACE` semantics.
 
 ### mssql-python driver
 

--- a/docs/comparison-dbt-fabricspark.md
+++ b/docs/comparison-dbt-fabricspark.md
@@ -47,7 +47,7 @@ The upstream is **fully standalone**: `FabricSparkAdapter(SQLAdapter)`. No dbt-s
 | Materialization | dbt-fabric-samdebruyn | microsoft/dbt-fabricspark |
 |---|---|---|
 | **Table** | Yes (via dbt-spark) | Yes (custom implementation) |
-| **View** | Not yet (Spark SQL views are not yet supported in schema-enabled Lakehouses) | Yes |
+| **View** | Yes | Yes |
 | **Incremental** | append, merge, insert_overwrite, microbatch | append, merge, insert_overwrite, microbatch |
 | **Snapshot** | Yes | Yes |
 | **Ephemeral** | Yes | Yes |
@@ -57,7 +57,6 @@ The upstream is **fully standalone**: `FabricSparkAdapter(SQLAdapter)`. No dbt-s
 
 Notable differences:
 
-- **View**: The upstream supports Spark SQL views, but these are [not yet supported in schema-enabled Lakehouses](https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-schemas?WT.mc_id=MVP_310840). Schema-enabled Lakehouses are [the default when creating new Lakehouses](https://blog.fabric.microsoft.com/en-US/blog/lakehouse-schemas-generally-available/). Microsoft has [announced](https://community.fabric.microsoft.com/t5/Fabric-Updates-Blog/Lakehouse-Schemas-Generally-Available/ba-p/5172416) that Spark SQL view support is coming. This adapter will add view support once it becomes available ([#163](https://github.com/sdebruyn/dbt-fabric/issues/163)).
 - **Materialized Lake View**: The upstream uses Fabric REST API for on-demand and scheduled refresh. This adapter uses standard `CREATE OR REPLACE` without REST API calls.
 
 ### Authentication methods
@@ -104,7 +103,6 @@ Notable differences:
 | **OneLake shortcuts** | `ShortcutClient` for shortcut CRUD |
 | **Fabric Notebook auth** | Ambient auth inside notebooks |
 | **Local Livy mode** | Connect to local Livy for development |
-| **Spark SQL views** | `CREATE OR REPLACE VIEW` support (not yet available in schema-enabled Lakehouses) |
 | **Cross-workspace 4-part naming** | Full read+write for `workspace.lakehouse.schema.table` |
 | **Credential validation** | UUID format, HTTPS domain whitelist |
 
@@ -219,8 +217,6 @@ The upstream mixes camelCase (`tokenPrint`, `accessToken`, `_submitLivyCode`, `_
 ---
 
 ## Summary
-
-This adapter deliberately targets **schema-enabled Lakehouses**, which is [the default when creating new Lakehouses](https://blog.fabric.microsoft.com/en-US/blog/lakehouse-schemas-generally-available/) in the Fabric portal ([schemas are enabled by default](https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-schemas?WT.mc_id=MVP_310840)). This means some upstream features that only work without schemas (e.g., Spark SQL views) are not yet supported. Microsoft has [announced](https://community.fabric.microsoft.com/t5/Fabric-Updates-Blog/Lakehouse-Schemas-Generally-Available/ba-p/5172416) that Spark SQL views are coming to schema-enabled Lakehouses, and this adapter will add support when they become available ([#163](https://github.com/sdebruyn/dbt-fabric/issues/163)).
 
 This adapter takes a **code-reuse approach** (thin adapter on dbt-spark), while the upstream takes a **self-contained approach** (everything reimplemented). The fork's approach results in dramatically less code (749 LOC vs 4,387 LOC) with proper instance-based lifecycle management and no global mutable state.
 

--- a/docs/lakehouse.md
+++ b/docs/lakehouse.md
@@ -100,13 +100,9 @@ Lake views support:
 | --- | --- | --- |
 | `materialized_view` | Yes | Default. Creates a Fabric lake view. |
 | `table` | Yes | Creates a managed Delta table. |
-| `view` | No | Fabric Lakehouse with schemas does not support Spark SQL views. |
+| `view` | Yes | Creates a Spark SQL view (`CREATE OR REPLACE VIEW`). |
 | `incremental` | Yes | Supports `append` and `insert_overwrite` strategies. `merge` and `delete+insert` are not supported. |
 | `ephemeral` | Yes | Standard CTE-based ephemeral models. |
-
-!!! warning "No Spark SQL views"
-
-    Fabric Lakehouse with schemas enabled does not support Spark SQL views. If a model or package uses `materialized='view'`, you will see the error `'view' is not a valid FabricSparkRelationType`. Change the materialization to `materialized_view` or `table`.
 
 ---
 
@@ -192,7 +188,7 @@ A dbt run with many models will be significantly slower on FabricSpark than on F
 | Connection | mssql-python (TDS protocol) | Livy sessions (HTTP REST) |
 | Identifier quoting | `[brackets]` | `` `backticks` `` |
 | Default materialization | `table` | `materialized_view` (lake view) |
-| Views | Supported | Not supported |
+| Views | Supported | Supported |
 | String type | `varchar(MAX)` | `string` |
 | Timestamp type | `datetime2(6)` | `timestamp` |
 | Pagination | `SELECT TOP N` | `LIMIT N` |
@@ -218,7 +214,6 @@ See the [Python models guide](python-models.md) for writing and debugging Python
 
 ## Limitations
 
-- **No Spark SQL views** -- only tables and materialized lake views (Fabric lake views) are supported.
 - **No incremental merge strategy** -- the Spark SQL `MERGE` syntax in Fabric Lakehouse is not supported by the adapter. Use `append` or `insert_overwrite` instead.
 - **API rate limiting** -- can slow down large runs with many models.
 - **Session startup time** -- creating a new Spark session adds latency to the first statement in a run.
@@ -232,7 +227,6 @@ See the [Python models guide](python-models.md) for writing and debugging Python
 | --- | --- | --- |
 | `Livy session did not become idle in time` | Session startup took too long | Increase [`spark_session_timeout`](configuration.md#spark_session_timeout), retry, or check Fabric capacity |
 | `HTTP 429` in logs | API rate limiting | Automatic -- the adapter retries. Reduce `threads` if excessive. |
-| `'view' is not a valid FabricSparkRelationType` | Model uses `view` materialization | Change to `materialized_view` or `table` |
 | Slow execution | Livy polling overhead | Expected behavior. Use higher thread count. |
 | Statement timeout | Long-running Spark query | Increase [`query_timeout`](configuration.md#query_timeout) |
 | `Either workspace_id or workspace_name must be provided` | Missing workspace configuration | Add [`workspace`](configuration.md#workspace_name) or [`workspace_id`](configuration.md#workspace_id) to your profile |

--- a/docs/lakehouse.md
+++ b/docs/lakehouse.md
@@ -83,26 +83,9 @@ Key technical details:
 
 ## Materializations
 
-### Default materialization: `materialized_view`
+In addition to the standard dbt materializations, FabricSpark supports `materialized_view`, which creates Fabric [lake views](https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint?WT.mc_id=MVP_310840). Lake views support `PARTITIONED BY`, `TBLPROPERTIES`, and `CHECK` constraints with `ON MISMATCH` behavior.
 
-Unlike most dbt adapters where the default materialization is `view` or `table`, the FabricSpark adapter defaults to **`materialized_view`**. This creates Fabric [lake views](https://learn.microsoft.com/fabric/data-engineering/lakehouse-sql-analytics-endpoint?WT.mc_id=MVP_310840), a Fabric-specific concept.
-
-Lake views support:
-
-- `CREATE OR REPLACE` semantics
-- `PARTITIONED BY` clauses
-- `TBLPROPERTIES` (Spark table properties)
-- `CHECK` constraints with `ON MISMATCH` behavior
-
-### Supported materializations
-
-| Materialization | Supported | Notes |
-| --- | --- | --- |
-| `materialized_view` | Yes | Default. Creates a Fabric lake view. |
-| `table` | Yes | Creates a managed Delta table. |
-| `view` | Yes | Creates a Spark SQL view (`CREATE OR REPLACE VIEW`). |
-| `incremental` | Yes | Supports `append` and `insert_overwrite` strategies. `merge` and `delete+insert` are not supported. |
-| `ephemeral` | Yes | Standard CTE-based ephemeral models. |
+The incremental materialization supports `append` and `insert_overwrite` strategies.
 
 ---
 
@@ -187,7 +170,7 @@ A dbt run with many models will be significantly slower on FabricSpark than on F
 | SQL dialect | T-SQL | Spark SQL |
 | Connection | mssql-python (TDS protocol) | Livy sessions (HTTP REST) |
 | Identifier quoting | `[brackets]` | `` `backticks` `` |
-| Default materialization | `table` | `materialized_view` (lake view) |
+| Default materialization | `table` | `view` |
 | Views | Supported | Supported |
 | String type | `varchar(MAX)` | `string` |
 | Timestamp type | `datetime2(6)` | `timestamp` |

--- a/src/dbt/adapters/fabricspark/fabricspark_adapter.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_adapter.py
@@ -82,13 +82,14 @@ class FabricSparkAdapter(BaseFabricAdapter, SparkAdapter):
             # Table Properties: [key=value, ...]
             # Location: abfss://...
 
-            # 2 possible types: MATERIALIZED_LAKE_VIEW or MANAGED (regular table)
+            # 3 possible types: MATERIALIZED_LAKE_VIEW, VIEW, or MANAGED (regular table)
 
-            rel_type: FabricSparkRelationType = (
-                FabricSparkRelationType.MaterializedView
-                if "Type: MATERIALIZED_LAKE_VIEW" in information
-                else FabricSparkRelationType.Table
-            )
+            if "Type: MATERIALIZED_LAKE_VIEW" in information:
+                rel_type = FabricSparkRelationType.MaterializedView
+            elif "Type: VIEW" in information:
+                rel_type = FabricSparkRelationType.View
+            else:
+                rel_type = FabricSparkRelationType.Table
 
             relation: FabricSparkRelation = self.Relation.create(
                 catalog=_workspace,

--- a/src/dbt/adapters/fabricspark/fabricspark_relation.py
+++ b/src/dbt/adapters/fabricspark/fabricspark_relation.py
@@ -30,6 +30,7 @@ class FabricSparkIncludePolicy(SparkIncludePolicy):
 
 class FabricSparkRelationType(StrEnum):
     Table = "table"
+    View = "view"
     CTE = "cte"
     MaterializedView = "materialized_view"
     Ephemeral = "ephemeral"
@@ -50,6 +51,7 @@ class FabricSparkRelation(BaseRelation):
         default_factory=lambda: frozenset(
             {
                 FabricSparkRelationType.MaterializedView,
+                FabricSparkRelationType.View,
             }
         )
     )
@@ -72,6 +74,8 @@ class FabricSparkRelation(BaseRelation):
                 return FabricSparkRelationType.MaterializedView
             case "managed":
                 return FabricSparkRelationType.Table
+            case "view":
+                return FabricSparkRelationType.View
             case _:
                 return None
 

--- a/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
@@ -1,12 +1,18 @@
 {% macro fabricspark__persist_docs(relation, model, for_relation, for_columns) -%}
   {% if for_relation and config.persist_relation_docs() and model.description %}
     {% set escaped_comment = model.description | replace("'", "\\'") %}
-    {% set comment_query %}
-      comment on table {{ relation }} is '{{ escaped_comment }}';
-    {% endset %}
+    {% if relation.is_view %}
+      {% set comment_query %}
+        alter view {{ relation }} set tblproperties ('comment' = '{{ escaped_comment }}');
+      {% endset %}
+    {% else %}
+      {% set comment_query %}
+        comment on table {{ relation }} is '{{ escaped_comment }}';
+      {% endset %}
+    {% endif %}
     {% do run_query(comment_query) %}
   {% endif %}
-  {% if for_columns and config.persist_column_docs() and model.columns %}
+  {% if for_columns and config.persist_column_docs() and model.columns and not relation.is_view %}
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
     {% set filtered_columns = validate_doc_columns(relation, model.columns, existing_columns) %}
     {% do alter_column_comment(relation, filtered_columns) %}

--- a/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/persist_docs.sql
@@ -1,4 +1,9 @@
+{# dbt-spark only persists column comments (no relation-level comments).
+   We add relation-level comments and use validate_doc_columns from dbt-adapters
+   to filter columns before calling alter_column_comment. #}
 {% macro fabricspark__persist_docs(relation, model, for_relation, for_columns) -%}
+  {# dbt-spark has no relation-level comment support. We add it using COMMENT ON TABLE
+     for tables and ALTER VIEW SET TBLPROPERTIES for views (Spark rejects COMMENT ON VIEW). #}
   {% if for_relation and config.persist_relation_docs() and model.description %}
     {% set escaped_comment = model.description | replace("'", "\\'") %}
     {% if relation.is_view %}
@@ -12,6 +17,8 @@
     {% endif %}
     {% do run_query(comment_query) %}
   {% endif %}
+  {# Spark does not support ALTER TABLE CHANGE COLUMN on views, so column comments are
+     skipped for views. dbt-spark also skips views (it checks file_format in delta/hudi/iceberg). #}
   {% if for_columns and config.persist_column_docs() and model.columns and not relation.is_view %}
     {% set existing_columns = adapter.get_columns_in_relation(relation) | map(attribute="name") | list %}
     {% set filtered_columns = validate_doc_columns(relation, model.columns, existing_columns) %}
@@ -19,6 +26,9 @@
   {% endif %}
 {% endmacro %}
 
+{# dbt-spark guards this with a file_format check (delta/hudi/iceberg). Fabric Lakehouse
+   always uses Delta, so we skip that check. We also use validate_doc_columns in the caller
+   instead of iterating over raw model.columns. #}
 {% macro fabricspark__alter_column_comment(relation, column_dict) %}
   {% for column_name in column_dict %}
     {% set comment = column_dict[column_name]['description'] %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
@@ -1,8 +1,12 @@
+{# dbt-spark returns True (Delta supports SHALLOW CLONE); Fabric Lakehouse does not. #}
 {% macro fabricspark__can_clone_table() %}
     {{ return(False) }}
 {% endmacro %}
 
 
+{# dbt-spark's clone requires file_format='delta' and delegates to SHALLOW CLONE or the
+   view materialization. We skip the file_format check (no Delta clone in Fabric) and
+   always create a view via inline SQL instead of delegating to the view materialization. #}
 {% materialization clone, adapter='fabricspark' %}
 
   {%- set relations = {'relations': []} -%}
@@ -21,6 +25,8 @@
 
   {%- set target_relation = this.incorporate(type='view') -%}
 
+  {# dbt-spark only drops non-table relations; we drop any existing relation since
+     Fabric has more types (table, materialized_view) that block CREATE OR REPLACE VIEW. #}
   {% if existing_relation is not none %}
       {{ drop_relation_if_exists(existing_relation) }}
   {% endif %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
@@ -19,16 +19,16 @@
       {{ return(relations) }}
   {%- endif -%}
 
-  {%- set target_relation = this.incorporate(type='materialized_view') -%}
+  {%- set target_relation = this.incorporate(type='view') -%}
 
   {% if existing_relation is not none %}
       {{ drop_relation_if_exists(existing_relation) }}
   {% endif %}
 
-  {%- set clone_sql = "select * from " ~ defer_relation -%}
-
   {% call statement('main') %}
-      {{ get_create_materialized_view_as_sql(target_relation, clone_sql) }}
+      create or replace view {{ target_relation }} as (
+          select * from {{ defer_relation }}
+      )
   {% endcall %}
 
   {%- set grant_config = config.get('grants') -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
@@ -1,12 +1,16 @@
-{# dbt-spark returns True (Delta supports SHALLOW CLONE); Fabric Lakehouse does not. #}
+{# Delta SHALLOW CLONE works within the same schema in Fabric Lakehouse. #}
 {% macro fabricspark__can_clone_table() %}
-    {{ return(False) }}
+    {{ return(True) }}
+{% endmacro %}
+
+{% macro fabricspark__create_or_replace_clone(this_relation, defer_relation) %}
+    create or replace table {{ this_relation }} shallow clone {{ defer_relation }}
 {% endmacro %}
 
 
-{# dbt-spark's clone requires file_format='delta' and delegates to SHALLOW CLONE or the
-   view materialization. We skip the file_format check (no Delta clone in Fabric) and
-   always create a view via inline SQL instead of delegating to the view materialization. #}
+{# dbt-spark's clone requires file_format='delta' and errors if not set. We skip that check
+   (Fabric Lakehouse always uses Delta). SHALLOW CLONE works within the same schema; for
+   cross-schema we fall back to the view materialization since SHALLOW CLONE fails there. #}
 {% materialization clone, adapter='fabricspark' %}
 
   {%- set relations = {'relations': []} -%}
@@ -23,23 +27,39 @@
       {{ return(relations) }}
   {%- endif -%}
 
-  {%- set target_relation = this.incorporate(type='view') -%}
-
-  {# dbt-spark only drops non-table relations; we drop any existing relation since
-     Fabric has more types (table, materialized_view) that block CREATE OR REPLACE VIEW. #}
-  {% if existing_relation is not none %}
-      {{ drop_relation_if_exists(existing_relation) }}
-  {% endif %}
-
-  {% call statement('main') %}
-      create or replace view {{ target_relation }} as
-          select * from {{ defer_relation }}
-  {% endcall %}
-
+  {%- set other_existing_relation = load_cached_relation(defer_relation) -%}
   {%- set grant_config = config.get('grants') -%}
-  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
-  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-  {{ return({'relations': [target_relation]}) }}
+  {# Same schema + source is a table → SHALLOW CLONE (zero-copy, instant) #}
+  {%- if other_existing_relation and other_existing_relation.type == 'table'
+         and this.schema == defer_relation.schema -%}
+
+      {%- set target_relation = this.incorporate(type='table') -%}
+      {% if existing_relation is not none and not existing_relation.is_table %}
+        {{ drop_relation_if_exists(existing_relation) }}
+      {% endif %}
+
+      {% call statement('main') %}
+          {{ create_or_replace_clone(target_relation, defer_relation) }}
+      {% endcall %}
+
+      {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+      {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+      {% do persist_docs(target_relation, model) %}
+
+      {{ return({'relations': [target_relation]}) }}
+
+  {%- else -%}
+
+      {# Cross-schema or non-table source → delegate to view materialization #}
+      {% set search_name = "materialization_view_" ~ adapter.type() %}
+      {% if not search_name in context %}
+          {% set search_name = "materialization_view_default" %}
+      {% endif %}
+      {% set materialization_macro = context[search_name] %}
+      {% set relations = materialization_macro() %}
+      {{ return(relations) }}
+
+  {%- endif -%}
 
 {% endmaterialization %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/clone.sql
@@ -32,9 +32,8 @@
   {% endif %}
 
   {% call statement('main') %}
-      create or replace view {{ target_relation }} as (
+      create or replace view {{ target_relation }} as
           select * from {{ defer_relation }}
-      )
   {% endcall %}
 
   {%- set grant_config = config.get('grants') -%}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -7,15 +7,21 @@
 
     {%- set target_relation = this.incorporate(type='view') -%}
 
-    {{ run_hooks(pre_hooks) }}
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-    {%- if old_relation is not none and old_relation.is_table -%}
+    {%- if old_relation is not none and not old_relation.is_view -%}
         {%- if should_full_refresh() -%}
             {% do adapter.drop_relation(old_relation) %}
         {%- else -%}
-            {{ exceptions.raise_compiler_error("Cannot create view " ~ target_relation ~ " because a table with that name already exists. Use --full-refresh to drop the table first.") }}
+            {{ exceptions.raise_compiler_error(
+                "Cannot create view " ~ target_relation
+                ~ " because a relation of type '" ~ old_relation.type
+                ~ "' already exists. Use --full-refresh to drop it first."
+            ) }}
         {%- endif -%}
     {%- endif -%}
+
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
     {% call statement('main') -%}
         create or replace view {{ target_relation }} as (
@@ -26,7 +32,8 @@
     {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-    {{ run_hooks(post_hooks) }}
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
 
     {{ return({'relations': [target_relation]}) }}
 {%- endmaterialization %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -32,7 +32,8 @@
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
     {# Neither dbt-spark's view materialization nor upstream create_or_replace_view() calls
-       persist_docs. We add it so relation/column comments are applied (like table/incremental). #}
+       persist_docs. We add it for relation-level comments (column comments are skipped for
+       views in fabricspark__persist_docs since Spark rejects ALTER TABLE CHANGE COLUMN on views). #}
     {% do persist_docs(target_relation, model) %}
 
     {{ run_hooks(post_hooks, inside_transaction=True) }}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -1,0 +1,32 @@
+{% materialization view, adapter='fabricspark' %}
+    {%- set identifier = model['alias'] -%}
+    {%- set grant_config = config.get('grants') -%}
+
+    {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+    {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
+
+    {%- set target_relation = this.incorporate(type='view') -%}
+
+    {{ run_hooks(pre_hooks) }}
+
+    {%- if old_relation is not none and old_relation.is_table -%}
+        {%- if should_full_refresh() -%}
+            {% do adapter.drop_relation(old_relation) %}
+        {%- else -%}
+            {{ exceptions.raise_compiler_error("Cannot create view " ~ target_relation ~ " because a table with that name already exists. Use --full-refresh to drop the table first.") }}
+        {%- endif -%}
+    {%- endif -%}
+
+    {% call statement('main') -%}
+        create or replace view {{ target_relation }} as (
+            {{ sql }}
+        )
+    {%- endcall %}
+
+    {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+    {{ run_hooks(post_hooks) }}
+
+    {{ return({'relations': [target_relation]}) }}
+{%- endmaterialization %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -1,8 +1,9 @@
 {% materialization view, adapter='fabricspark' %}
-    {%- set identifier = model['alias'] -%}
     {%- set grant_config = config.get('grants') -%}
 
-    {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+    {# Upstream create_or_replace_view() uses adapter.get_relation(); we use load_cached_relation(this)
+       for consistency with our other materializations (clone, materialized_view, incremental). #}
+    {%- set old_relation = load_cached_relation(this) -%}
     {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
     {%- set target_relation = this.incorporate(type='view') -%}
@@ -23,9 +24,8 @@
     {# Inline SQL instead of dispatching to get_create_view_as_sql() — Spark SQL uses
        CREATE OR REPLACE VIEW directly (no intermediate/rename/backup swap like dbt-adapters default). #}
     {% call statement('main') -%}
-        create or replace view {{ target_relation }} as (
+        create or replace view {{ target_relation }} as
             {{ sql }}
-        )
     {%- endcall %}
 
     {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -11,19 +11,11 @@
        inside_transaction. We split into outside/inside to match dbt-adapters' default pattern. #}
     {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-    {# Upstream create_or_replace_view() only checks old_relation.is_table via handle_existing_table().
-       We check any non-view type (table, materialized_view) since FabricSpark has more relation types.
-       We also raise an explicit error instead of silently dropping when --full-refresh is not set. #}
+    {# Upstream create_or_replace_view() drops any non-view relation unconditionally via
+       handle_existing_table(). We match that behavior for all non-view types (table,
+       materialized_view) since CREATE OR REPLACE VIEW cannot replace a table. #}
     {%- if old_relation is not none and not old_relation.is_view -%}
-        {%- if should_full_refresh() -%}
-            {% do adapter.drop_relation(old_relation) %}
-        {%- else -%}
-            {{ exceptions.raise_compiler_error(
-                "Cannot create view " ~ target_relation
-                ~ " because a relation of type '" ~ old_relation.type
-                ~ "' already exists. Use --full-refresh to drop it first."
-            ) }}
-        {%- endif -%}
+        {% do adapter.drop_relation(old_relation) %}
     {%- endif -%}
 
     {{ run_hooks(pre_hooks, inside_transaction=True) }}
@@ -38,6 +30,8 @@
 
     {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+    {% do persist_docs(target_relation, model) %}
 
     {{ run_hooks(post_hooks, inside_transaction=True) }}
     {{ run_hooks(post_hooks, inside_transaction=False) }}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -31,6 +31,8 @@
     {% set should_revoke = should_revoke(exists_as_view, full_refresh_mode=True) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
+    {# Neither dbt-spark's view materialization nor upstream create_or_replace_view() calls
+       persist_docs. We add it so relation/column comments are applied (like table/incremental). #}
     {% do persist_docs(target_relation, model) %}
 
     {{ run_hooks(post_hooks, inside_transaction=True) }}

--- a/src/dbt/include/fabricspark/macros/materializations/models/view.sql
+++ b/src/dbt/include/fabricspark/macros/materializations/models/view.sql
@@ -7,8 +7,13 @@
 
     {%- set target_relation = this.incorporate(type='view') -%}
 
+    {# dbt-spark delegates to create_or_replace_view() which calls run_hooks(pre_hooks) without
+       inside_transaction. We split into outside/inside to match dbt-adapters' default pattern. #}
     {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
+    {# Upstream create_or_replace_view() only checks old_relation.is_table via handle_existing_table().
+       We check any non-view type (table, materialized_view) since FabricSpark has more relation types.
+       We also raise an explicit error instead of silently dropping when --full-refresh is not set. #}
     {%- if old_relation is not none and not old_relation.is_view -%}
         {%- if should_full_refresh() -%}
             {% do adapter.drop_relation(old_relation) %}
@@ -23,6 +28,8 @@
 
     {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
+    {# Inline SQL instead of dispatching to get_create_view_as_sql() — Spark SQL uses
+       CREATE OR REPLACE VIEW directly (no intermediate/rename/backup swap like dbt-adapters default). #}
     {% call statement('main') -%}
         create or replace view {{ target_relation }} as (
             {{ sql }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -294,9 +294,6 @@ def dbt_project_yml(project_root, project_config_update, adapter_type: str):
         "flags": {"send_anonymous_usage_stats": False},
     }
 
-    if adapter_type == "fabricspark":
-        project_config["models"] = {"+materialized": "materialized_view"}
-
     if project_config_update:
         if isinstance(project_config_update, str):
             project_config_update = yaml.safe_load(project_config_update)

--- a/tests/fabricspark/adapter/test_basic.py
+++ b/tests/fabricspark/adapter/test_basic.py
@@ -1,18 +1,11 @@
 import pytest
 
-from dbt.tests.adapter.basic import expected_catalog, files
+from dbt.tests.adapter.basic import expected_catalog
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
 from dbt.tests.adapter.basic.test_docs_generate import (
     BaseDocsGenerate,
     BaseDocsGenReferences,
-    models__readme_md,
-    models__schema_yml,
-    ref_models__docs_md,
-    ref_models__ephemeral_copy_sql,
-    ref_models__ephemeral_summary_sql,
-    ref_models__schema_yml,
-    ref_sources__schema_yml,
 )
 from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
@@ -33,91 +26,11 @@ from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCo
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_table_materialization import BaseTableMaterialization
 from dbt.tests.adapter.basic.test_validate_connection import BaseValidateConnection
-from dbt.tests.util import (
-    AnyInteger,
-    check_relation_types,
-    check_relations_equal,
-    check_result_nodes_by_name,
-    relation_from_name,
-    run_dbt,
-)
+from dbt.tests.util import AnyInteger, run_dbt
 
 
 class TestSimpleMaterializationsSpark(BaseSimpleMaterializations):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "view_model.sql": """
-  {{ config(materialized="materialized_view") }}
-"""
-            + files.model_base,
-            "table_model.sql": files.base_table_sql,
-            "swappable.sql": files.base_materialized_var_sql,
-            "schema.yml": files.schema_base_yml,
-        }
-
-    def test_base(self, project):
-        # seed command
-        results = run_dbt(["seed"])
-        # seed result length
-        assert len(results) == 1
-
-        # run command
-        results = run_dbt()
-        # run result length
-        assert len(results) == 3
-
-        # names exist in result nodes
-        check_result_nodes_by_name(results, ["view_model", "table_model", "swappable"])
-
-        # check relation types
-        expected = {
-            "base": "table",
-            "view_model": "materialized_view",
-            "table_model": "table",
-            "swappable": "table",
-        }
-        check_relation_types(project.adapter, expected)
-
-        # base table rowcount
-        relation = relation_from_name(project.adapter, "base")
-        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
-        assert result[0] == 10
-
-        # relations_equal
-        check_relations_equal(project.adapter, ["base", "view_model", "table_model", "swappable"])
-
-        # check relations in catalog
-        catalog = run_dbt(["docs", "generate"])
-        assert len(catalog.nodes) == 4
-        assert len(catalog.sources) == 1
-
-        results = run_dbt(
-            ["run", "-s", "swappable", "--vars", "materialized_var: materialized_view"]
-        )
-        assert len(results) == 1
-
-        # check relation types, swappable is view
-        expected = {
-            "base": "table",
-            "view_model": "materialized_view",
-            "table_model": "table",
-            "swappable": "materialized_view",
-        }
-        check_relation_types(project.adapter, expected)
-
-        # run_dbt changing materialized_var to incremental
-        results = run_dbt(["run", "-s", "swappable", "--vars", "materialized_var: incremental"])
-        assert len(results) == 1
-
-        # check relation types, swappable is table
-        expected = {
-            "base": "table",
-            "view_model": "materialized_view",
-            "table_model": "table",
-            "swappable": "table",
-        }
-        check_relation_types(project.adapter, expected)
+    pass
 
 
 class TestSingularTestsSpark(BaseSingularTests):
@@ -133,18 +46,7 @@ class TestEmptySpark(BaseEmpty):
 
 
 class TestEphemeralSpark(BaseEphemeral):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "ephemeral.sql": files.base_ephemeral_sql,
-            "view_model.sql": """
-  {{ config(materialized="table") }}
-
-  select * from {{ ref('ephemeral') }}
-""",
-            "table_model.sql": files.ephemeral_table_sql,
-            "schema.yml": files.schema_base_yml,
-        }
+    pass
 
 
 class TestIncrementalSpark(BaseIncremental):
@@ -158,18 +60,7 @@ class TestIncrementalNotSchemaChangeFabric(BaseIncrementalNotSchemaChange):
 
 
 class TestGenericTestsSpark(BaseGenericTests):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "view_model.sql": """
-  {{ config(materialized="materialized_view") }}
-"""
-            + files.model_base,
-            "table_model.sql": files.base_table_sql,
-            "schema.yml": files.schema_base_yml,
-            "schema_view.yml": files.generic_test_view_yml,
-            "schema_table.yml": files.generic_test_table_yml,
-        }
+    pass
 
 
 class TestSnapshotCheckColsSpark(BaseSnapshotCheckCols):
@@ -185,32 +76,7 @@ class TestSnapshotTimestampSpark(BaseSnapshotTimestamp):
 
 
 class TestBaseCachingSpark(BaseAdapterMethod):
-    @pytest.fixture(scope="class")
-    def models(self):
-        adapter_methods_model_sql = """
-{% set upstream = ref('upstream') %}
-
-{% if execute %}
-    {%- do adapter.drop_schema(upstream) -%}
-    {% set existing = adapter.get_relation(upstream.database, upstream.schema, upstream.identifier) %}
-    {% if existing is not none %}
-        {% do exceptions.raise_compiler_error('expected ' ~ ' to not exist, but it did') %}
-    {% endif %}
-
-    {%- do adapter.create_schema(upstream) -%}
-
-    {% set sql = create_view_as(upstream, 'select 2 as id') %}
-    {% do run_query(sql) %}
-{% endif %}
-
-
-select * from {{ upstream }}
-"""
-        return {
-            "upstream.sql": "select 1 as id",
-            "expected.sql": "-- {{ ref('model') }}\nselect 2 as id",
-            "model.sql": adapter_methods_model_sql,
-        }
+    pass
 
 
 class TestValidateConnectionSpark(BaseValidateConnection):
@@ -219,32 +85,6 @@ class TestValidateConnectionSpark(BaseValidateConnection):
 
 class TestDocsGenerateSpark(BaseDocsGenerate):
     @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "schema.yml": models__schema_yml,
-            "second_model.sql": """
-{{
-    config(
-        materialized='materialized_view',
-        schema='test',
-    )
-}}
-
-select * from {{ ref('seed') }}
-""",
-            "readme.md": models__readme_md,
-            "model.sql": """
-{{
-    config(
-        materialized='materialized_view',
-    )
-}}
-
-select * from {{ ref('seed') }}
-""",
-        }
-
-    @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):
         return expected_catalog.base_expected_catalog(
             project,
@@ -252,32 +92,13 @@ select * from {{ ref('seed') }}
             id_type="bigint",
             text_type="string",
             time_type="timestamp",
-            view_type="materialized_view",
+            view_type="view",
             table_type="table",
             model_stats=expected_catalog.no_stats(),
         )
 
 
 class TestDocsGenReferencesSpark(BaseDocsGenReferences):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "schema.yml": ref_models__schema_yml,
-            "sources.yml": ref_sources__schema_yml,
-            "view_summary.sql": """
-{{
-  config(
-    materialized = "materialized_view"
-  )
-}}
-
-select first_name, ct from {{ref('ephemeral_summary')}}
-""",
-            "ephemeral_summary.sql": ref_models__ephemeral_summary_sql,
-            "ephemeral_copy.sql": ref_models__ephemeral_copy_sql,
-            "docs.md": ref_models__docs_md,
-        }
-
     @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):
         catalog = expected_catalog.expected_references_catalog(
@@ -287,7 +108,7 @@ select first_name, ct from {{ref('ephemeral_summary')}}
             text_type="string",
             time_type="timestamp",
             bigint_type="bigint",
-            view_type="materialized_view",
+            view_type="view",
             table_type="table",
             model_stats=expected_catalog.no_stats(),
         )
@@ -309,11 +130,9 @@ class TestGetCatalogForSingleRelationSpark(BaseGetCatalogForSingleRelation):
 
 class TestIncrementalBadStrategySpark(BaseIncrementalBadStrategy):
     def test_incremental_invalid_strategy(self, project):
-        # seed command
         results = run_dbt(["seed"])
         assert len(results) == 2
 
-        # try to run the incremental model, it should fail on the first attempt
         results = run_dbt(["run"], expect_pass=False)
         assert len(results.results) == 1
         assert "Invalid incremental strategy provided: bad_strategy" in results.results[0].message

--- a/tests/fabricspark/adapter/test_basic.py
+++ b/tests/fabricspark/adapter/test_basic.py
@@ -199,8 +199,7 @@ class TestBaseCachingSpark(BaseAdapterMethod):
 
     {%- do adapter.create_schema(upstream) -%}
 
-    {# upstream uses create_view_as — FabricSpark has no view support #}
-    {% set sql = create_table_as(False, upstream, 'select 2 as id') %}
+    {% set sql = create_view_as(upstream, 'select 2 as id') %}
     {% do run_query(sql) %}
 {% endif %}
 

--- a/tests/fabricspark/adapter/test_catalog.py
+++ b/tests/fabricspark/adapter/test_catalog.py
@@ -1,7 +1,6 @@
 import pytest
 
 from dbt.artifacts.schemas.catalog import CatalogArtifact
-from dbt.tests.adapter.catalog import files
 from dbt.tests.adapter.catalog.relation_types import CatalogRelationTypes
 from dbt.tests.adapter.catalog_integrations.test_catalog_integration import (
     BaseCatalogIntegrationValidation,
@@ -9,18 +8,12 @@ from dbt.tests.adapter.catalog_integrations.test_catalog_integration import (
 
 
 class TestCatalogRelationTypesFabricSpark(CatalogRelationTypes):
-    @pytest.fixture(scope="class")
-    def models(self):
-        yield {
-            "my_table.sql": files.MY_TABLE,
-            "my_materialized_view.sql": files.MY_MATERIALIZED_VIEW,
-        }
-
     @pytest.mark.parametrize(
         "node_name,relation_type",
         [
             ("seed.test.my_seed", "table"),
             ("model.test.my_table", "table"),
+            ("model.test.my_view", "view"),
             ("model.test.my_materialized_view", "materialized_view"),
         ],
     )

--- a/tests/fabricspark/adapter/test_column_types.py
+++ b/tests/fabricspark/adapter/test_column_types.py
@@ -4,7 +4,7 @@ from dbt.tests.adapter.column_types.fixtures import schema_yml
 from dbt.tests.adapter.column_types.test_column_types import BasePostgresColumnTypes
 
 model_sql = """
-{{ config(materialized="materialized_view") }}
+{{ config(materialized="view") }}
 select
     CAST(1 AS smallint) as smallint_col,
     CAST(2 AS int) as int_col,

--- a/tests/fabricspark/adapter/test_concurrency.py
+++ b/tests/fabricspark/adapter/test_concurrency.py
@@ -1,50 +1,5 @@
-import pytest
-
-from dbt.tests.adapter.concurrency.test_concurrency import (
-    BaseConcurrency,
-    models__dep_sql,
-    models__invalid_sql,
-    models__skip_sql,
-    models__table_a_sql,
-    models__table_b_sql,
-)
-
-models__view_model_materialized_view_sql = """
-{{
-  config(
-    materialized = "materialized_view"
-  )
-}}
-
-select * from {{ this.schema }}.seed
-
-"""
-
-models__view_with_conflicting_cascade_materialized_view_sql = """
-{{
-  config(
-    materialized = "materialized_view"
-  )
-}}
-
-select * from {{ref('table_a')}}
-
-union all
-
-select * from {{ref('table_b')}}
-
-"""
+from dbt.tests.adapter.concurrency.test_concurrency import BaseConcurrency
 
 
 class TestConcurrencyFabricSpark(BaseConcurrency):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "invalid.sql": models__invalid_sql,
-            "table_a.sql": models__table_a_sql,
-            "table_b.sql": models__table_b_sql,
-            "view_model.sql": models__view_model_materialized_view_sql,
-            "dep.sql": models__dep_sql,
-            "view_with_conflicting_cascade.sql": models__view_with_conflicting_cascade_materialized_view_sql,
-            "skip.sql": models__skip_sql,
-        }
+    pass

--- a/tests/fabricspark/adapter/test_dbt_clone.py
+++ b/tests/fabricspark/adapter/test_dbt_clone.py
@@ -1,110 +1,19 @@
 import pytest
 
-from dbt.tests.adapter.dbt_clone import fixtures
 from dbt.tests.adapter.dbt_clone.test_dbt_clone import (
     BaseCloneNotPossible,
     BaseClonePossible,
     BaseCloneSameSourceAndTarget,
     BaseCloneSameTargetAndState,
 )
-from dbt.tests.util import run_dbt
-
-fabricspark_view_model_sql = """
-{{ config(materialized='materialized_view') }}
-select * from {{ ref('seed') }}
-
--- establish a macro dependency that trips infinite recursion if not handled
--- depends on: {{ my_infinitely_recursive_macro() }}
-"""
-
-fabricspark_snapshot_sql = """
-{% snapshot my_cool_snapshot %}
-
-    {{
-        config(
-            target_database=database,
-            target_schema=schema,
-            unique_key='id',
-            strategy='check',
-            check_cols=['id'],
-            file_format='delta',
-        )
-    }}
-    select * from {{ ref('view_model') }}
-
-{% endsnapshot %}
-"""
 
 
 class TestFabricSparkCloneNotPossible(BaseCloneNotPossible):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "table_model.sql": fixtures.table_model_sql,
-            "view_model.sql": fabricspark_view_model_sql,
-            "ephemeral_model.sql": fixtures.ephemeral_model_sql,
-            "schema.yml": fixtures.schema_yml,
-            "exposures.yml": fixtures.exposures_yml,
-        }
-
-    @pytest.fixture(scope="class")
-    def snapshots(self):
-        return {
-            "snapshot.sql": fabricspark_snapshot_sql,
-        }
-
-    @pytest.fixture(scope="class")
-    def macros(self):
-        return {
-            "macros.sql": fixtures.macros_sql,
-            "my_can_clone_tables.sql": fixtures.custom_can_clone_tables_false_macros_sql,
-            "infinite_macros.sql": fixtures.infinite_macros_sql,
-            "get_schema_name.sql": fixtures.get_schema_name_sql,
-        }
-
-    def test_can_clone_false(self, project, unique_schema, other_schema):
-        project.create_test_schema(other_schema)
-        self.run_and_save_state(project.project_root, with_snapshot=True)
-
-        clone_args = [
-            "clone",
-            "--state",
-            "state",
-            "--target",
-            "otherschema",
-        ]
-
-        results = run_dbt(clone_args)
-        assert len(results) == 4
-
-        schema_relations = project.adapter.list_relations(
-            database=project.database, schema=other_schema
-        )
-        assert len(schema_relations) > 0
-        assert all(r.type == "materialized_view" for r in schema_relations)
-
-        results = run_dbt(clone_args)
-        assert len(results) == 4
-        assert all("no-op" in r.message.lower() for r in results)
-
-        results = run_dbt([*clone_args, "--full-refresh"])
-        assert len(results) == 4
-
-        results = run_dbt([*clone_args, "--resource-type", "model"])
-        assert len(results) == 2
-        assert all("no-op" in r.message.lower() for r in results)
+    pass
 
 
 class TestFabricSparkCloneSameTargetAndState(BaseCloneSameTargetAndState):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "table_model.sql": fixtures.table_model_sql,
-            "view_model.sql": fabricspark_view_model_sql,
-            "ephemeral_model.sql": fixtures.ephemeral_model_sql,
-            "schema.yml": fixtures.schema_yml,
-            "exposures.yml": fixtures.exposures_yml,
-        }
+    pass
 
 
 @pytest.mark.skip(

--- a/tests/fabricspark/adapter/test_persist_docs.py
+++ b/tests/fabricspark/adapter/test_persist_docs.py
@@ -1,6 +1,3 @@
-import pytest
-
-from dbt.tests.adapter.persist_docs import fixtures
 from dbt.tests.adapter.persist_docs.test_persist_docs import (
     BasePersistDocs,
     BasePersistDocsColumnMissing,
@@ -9,16 +6,7 @@ from dbt.tests.adapter.persist_docs.test_persist_docs import (
 
 
 class TestPersistDocsFabricSpark(BasePersistDocs):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "no_docs_model.sql": fixtures._MODELS__NO_DOCS_MODEL,
-            "table_model.sql": fixtures._MODELS__TABLE,
-            "view_model.sql": """
-{{ config(materialized='materialized_view') }}
-select 2 as id, 'Bob' as name
-""",
-        }
+    pass
 
 
 class TestPersistDocsColumnMissingFabricSpark(BasePersistDocsColumnMissing):

--- a/tests/fabricspark/adapter/test_persist_docs.py
+++ b/tests/fabricspark/adapter/test_persist_docs.py
@@ -1,12 +1,30 @@
+import json
+
 from dbt.tests.adapter.persist_docs.test_persist_docs import (
     BasePersistDocs,
     BasePersistDocsColumnMissing,
     BasePersistDocsCommentOnQuotedColumn,
 )
+from dbt.tests.util import run_dbt
 
 
 class TestPersistDocsFabricSpark(BasePersistDocs):
-    pass
+    def test_has_comments_pglike(self, project):
+        run_dbt(["docs", "generate"])
+        with open("target/catalog.json") as fp:
+            catalog_data = json.load(fp)
+        assert "nodes" in catalog_data
+        assert len(catalog_data["nodes"]) == 4
+        table_node = catalog_data["nodes"]["model.test.table_model"]
+        self._assert_has_table_comments(table_node)
+
+        view_node = catalog_data["nodes"]["model.test.view_model"]
+        self._assert_has_view_comments(
+            view_node, has_node_comments=True, has_column_comments=False
+        )
+
+        no_docs_node = catalog_data["nodes"]["model.test.no_docs_model"]
+        self._assert_has_view_comments(no_docs_node, False, False)
 
 
 class TestPersistDocsColumnMissingFabricSpark(BasePersistDocsColumnMissing):

--- a/tests/fabricspark/adapter/test_relations.py
+++ b/tests/fabricspark/adapter/test_relations.py
@@ -5,12 +5,7 @@ from dbt.tests.adapter.relations.test_dropping_schema_named import BaseDropSchem
 
 
 class TestChangeRelationTypesFabricSpark(BaseChangeRelationTypeValidator):
-    def test_changing_materialization_changes_relation_type(self, project):
-        self._run_and_check_materialization("materialized_view")
-        self._run_and_check_materialization("table")
-        self._run_and_check_materialization("materialized_view")
-        self._run_and_check_materialization("incremental")
-        self._run_and_check_materialization("table", extra_args=["--full-refresh"])
+    pass
 
 
 class TestDropSchemaNamedFabricSpark(BaseDropSchemaNamed):

--- a/tests/fabricspark/adapter/test_simple_copy.py
+++ b/tests/fabricspark/adapter/test_simple_copy.py
@@ -5,16 +5,6 @@ from dbt.tests.adapter.simple_copy.test_copy_uppercase import BaseSimpleCopyUppe
 from dbt.tests.adapter.simple_copy.test_simple_copy import EmptyModelsArentRunBase, SimpleCopyBase
 from dbt.tests.util import check_relations_equal, rm_file, run_dbt, write_file
 
-_FABRICSPARK_VIEW_MODEL = """
-{{
-  config(
-    materialized = "materialized_view"
-  )
-}}
-
-select * from {{ ref('seed') }}
-"""
-
 _FABRICSPARK_DISABLED = """
 {{
   config(
@@ -76,7 +66,7 @@ class FabricSparkSimpleCopySetup:
             "incremental.sql": _FABRICSPARK_INCREMENTAL,
             "interleaved_sort.sql": fixtures._MODELS__INTERLEAVED_SORT,
             "materialized.sql": fixtures._MODELS__MATERIALIZED,
-            "view_model.sql": _FABRICSPARK_VIEW_MODEL,
+            "view_model.sql": fixtures._MODELS__VIEW_MODEL,
         }
 
     @pytest.fixture(scope="class")
@@ -131,9 +121,7 @@ class TestSimpleCopyBaseFabricSpark(FabricSparkSimpleCopySetup, SimpleCopyBase):
             project.adapter, ["seed", "view_model", "incremental", "materialized", "get_and_ref"]
         )
 
-    @pytest.mark.skip(
-        "FabricSpark does not support CREATE VIEW or CREATE MATERIALIZED VIEW via raw SQL"
-    )
+    @pytest.mark.skip("Raw SQL DDL syntax differs from Spark SQL (backtick quoting, MV syntax)")
     def test_simple_copy_with_materialized_views(self, project):
         pass
 
@@ -154,7 +142,7 @@ class TestSimpleCopyUppercaseFabricSpark(BaseSimpleCopyUppercase):
             "INCREMENTAL.sql": _FABRICSPARK_INCREMENTAL,
             "INTERLEAVED_SORT.sql": fixtures._MODELS__INTERLEAVED_SORT,
             "MATERIALIZED.sql": fixtures._MODELS__MATERIALIZED,
-            "VIEW_MODEL.sql": _FABRICSPARK_VIEW_MODEL,
+            "VIEW_MODEL.sql": fixtures._MODELS__VIEW_MODEL,
         }
 
     def test_simple_copy_uppercase(self, project):

--- a/tests/fabricspark/adapter/test_view.py
+++ b/tests/fabricspark/adapter/test_view.py
@@ -57,7 +57,9 @@ class TestViewMaterialization:
             "view_on_table": "view",
         }
         check_relation_types(project.adapter, expected)
-        check_relations_equal(project.adapter, ["seed", "view_model", "table_model"])
+        check_relations_equal(
+            project.adapter, ["seed", "view_model", "table_model", "view_on_table"]
+        )
 
     def test_view_idempotent(self, project):
         results = run_dbt(["run"])

--- a/tests/fabricspark/adapter/test_view.py
+++ b/tests/fabricspark/adapter/test_view.py
@@ -1,0 +1,94 @@
+import pytest
+
+from dbt.tests.util import (
+    check_relation_types,
+    check_relations_equal,
+    run_dbt,
+    write_file,
+)
+
+seed_csv = """id,name
+1,Alice
+2,Bob
+3,Charlie
+"""
+
+view_model_sql = """
+{{ config(materialized='view') }}
+
+select * from {{ ref('seed') }}
+"""
+
+view_on_table_sql = """
+{{ config(materialized='view') }}
+
+select * from {{ ref('table_model') }}
+"""
+
+table_model_sql = """
+{{ config(materialized='table') }}
+
+select * from {{ ref('seed') }}
+"""
+
+
+class TestViewMaterialization:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": seed_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "view_model.sql": view_model_sql,
+            "table_model.sql": table_model_sql,
+            "view_on_table.sql": view_on_table_sql,
+        }
+
+    def test_view_materialization(self, project):
+        run_dbt(["seed"])
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        expected = {
+            "seed": "table",
+            "view_model": "view",
+            "table_model": "table",
+            "view_on_table": "view",
+        }
+        check_relation_types(project.adapter, expected)
+        check_relations_equal(project.adapter, ["seed", "view_model", "table_model"])
+
+    def test_view_idempotent(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 3
+
+        expected = {
+            "seed": "table",
+            "view_model": "view",
+            "table_model": "table",
+            "view_on_table": "view",
+        }
+        check_relation_types(project.adapter, expected)
+
+
+class TestViewFullRefreshFromTable:
+    """--full-refresh can replace a table with a view."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"seed.csv": seed_csv}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model.sql": table_model_sql}
+
+    def test_table_to_view_full_refresh(self, project):
+        run_dbt(["seed"])
+        run_dbt(["run"])
+        check_relation_types(project.adapter, {"model": "table"})
+
+        write_file(view_model_sql, project.project_root, "models", "model.sql")
+
+        run_dbt(["run", "--full-refresh"])
+        check_relation_types(project.adapter, {"model": "view"})

--- a/tests/unit/test_fabricspark_adapter_helpers.py
+++ b/tests/unit/test_fabricspark_adapter_helpers.py
@@ -66,6 +66,14 @@ class TestTryTranslateType:
         result = FabricSparkRelation.try_translate_type("external")
         assert result is None
 
+    def test_view_uppercase(self):
+        result = FabricSparkRelation.try_translate_type("VIEW")
+        assert result == FabricSparkRelationType.View
+
+    def test_view_lowercase(self):
+        result = FabricSparkRelation.try_translate_type("view")
+        assert result == FabricSparkRelationType.View
+
 
 class TestBuildSparkRelationList:
     @pytest.fixture
@@ -159,6 +167,20 @@ class TestBuildSparkRelationList:
         )
         result = adapter._build_spark_relation_list(rows, self._info_func)
         assert result[0].type == FabricSparkRelationType.Table
+
+    def test_detects_view_type(self, adapter):
+        rows = self._make_rows(
+            [
+                {
+                    "namespace": "`ws`.`db`.`schema1`",
+                    "name": "my_spark_view",
+                    "information": "Type: VIEW\nProvider: delta",
+                },
+            ]
+        )
+        result = adapter._build_spark_relation_list(rows, self._info_func)
+        assert len(result) == 1
+        assert result[0].type == FabricSparkRelationType.View
 
     def test_extracts_workspace_database_schema(self, adapter):
         rows = self._make_rows(


### PR DESCRIPTION
## Summary

- Add Spark SQL view support (`CREATE OR REPLACE VIEW`) for FabricSpark adapter
- Add `View` variant to `FabricSparkRelationType` enum with metadata discovery
- Add view materialization macro with `persist_docs` support (relation-level via `ALTER VIEW SET TBLPROPERTIES`, column comments skipped — Spark limitation)
- Update clone macro to create views (not materialized lake views) as fallback
- Change default materialization from `materialized_view` to `view` (dbt's standard default)
- Simplify 8 test files by removing `view→materialized_view` workarounds
- Add integration tests for view materialization (create, idempotent, table→view, view-on-table)
- Add unit tests for VIEW detection in `_build_spark_relation_list` and `try_translate_type`
- Update docs and CLAUDE.md to reflect view support and new default

## Test plan

- [x] Unit tests: `test_fabricspark_adapter_helpers.py` (34 passed)
- [x] Integration: `test_view.py` (3 passed)
- [x] Integration: `test_catalog.py` (4 passed)
- [x] Integration: `test_basic.py` — `test_base` (1 passed)
- [x] Integration: `test_dbt_clone.py` (2 passed, 3 skipped)
- [x] Integration: `test_persist_docs.py` (3 passed)
- [x] Integration: `test_column_types.py` (1 passed)
- [x] Integration: `test_concurrency.py` (1 passed)
- [x] Integration: `test_relations.py` (2 passed)
- [x] Integration: `test_simple_copy.py` (3 passed, 1 skipped)
- [ ] Full `--de` regression suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)