### PR TITLE
Update package docs with accurate override notes

### DIFF
--- a/docs/packages/dbt-date.md
+++ b/docs/packages/dbt-date.md
@@ -23,7 +23,7 @@ Macros marked with **(override)** have a T-SQL-compatible override in this adapt
 | Macro | Status | Notes |
 |---|---|---|
 | `get_base_dates` | ✅ | |
-| `get_date_dimension` | ✅ **(override)** | Inlined without nested CTEs (not supported in Fabric) |
+| `get_date_dimension` | ✅ **(override)** | Inlined without nested CTEs (Fabric disallows nested CTEs in `CREATE VIEW`) |
 
 ### Current date/time
 
@@ -95,7 +95,8 @@ Macros marked with **(override)** have a T-SQL-compatible override in this adapt
 
 | Macro | Status | Notes |
 |---|---|---|
-| `get_fiscal_periods` | ✅ **(override)** | Rewritten for T-SQL CTE and date arithmetic syntax |
+| `get_fiscal_periods` | ✅ **(override)** | Inlined without nested CTEs; T-SQL date arithmetic and `%` operator |
+| `get_fiscal_year_dates` | ✅ **(override)** | T-SQL positional `GROUP BY` and `ORDER BY` replaced with explicit columns |
 
 ### Jinja utilities
 

--- a/docs/packages/dbt-utils.md
+++ b/docs/packages/dbt-utils.md
@@ -25,10 +25,10 @@ Macros marked with **(override)** have a T-SQL-compatible override in this adapt
 | `accepted_range` | ✅ | |
 | `at_least_one` | ✅ **(override)** | Subquery requires column alias; uses `TOP 1` instead of `LIMIT 1` |
 | `cardinality_equality` | ✅ | |
-| `equal_rowcount` | ✅ **(override)** | T-SQL subquery and comparison syntax |
+| `equal_rowcount` | ✅ **(override)** | Uses `FULL JOIN` with explicit `ON` clause; `COALESCE` for NULL-safe comparison |
 | `equality` | ✅ | |
 | `expression_is_true` | ✅ **(override)** | T-SQL boolean handling differences |
-| `fewer_rows_than` | ✅ **(override)** | T-SQL subquery and comparison syntax |
+| `fewer_rows_than` | ✅ **(override)** | Uses `FULL JOIN` with explicit `ON` clause; `CASE` instead of `GREATEST()` |
 | `mutually_exclusive_ranges` | ✅ **(override)** | T-SQL window function and boolean syntax |
 | `not_accepted_values` | ✅ | |
 | `not_constant` | ✅ | |


### PR DESCRIPTION
## Summary
- Add missing `get_fiscal_year_dates` override to dbt-date macro table
- Clarify that the nested CTE limitation is specific to `CREATE VIEW` (not all queries)
- Update `equal_rowcount` and `fewer_rows_than` notes to reflect the FULL JOIN + COALESCE approach

## Test plan
- [ ] `uv run zensical build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)