### PR TITLE
Centralize package versions in base test fixtures

### DIFF
--- a/src/dbt/include/fabric/macros/utils/split_part.sql
+++ b/src/dbt/include/fabric/macros/utils/split_part.sql
@@ -1,3 +1,5 @@
+{#- T-SQL STRING_SPLIT only accepts single-char separators. We REPLACE the actual
+    delimiter with char(1) (SOH) first, then split on that. #}
 {% macro fabric__split_part(string_text, delimiter_text, part_number) %}
     (
         select value

--- a/tests/fabric/packages/base_package_test.py
+++ b/tests/fabric/packages/base_package_test.py
@@ -17,7 +17,25 @@ class BaseDbtPackageTests:
         raise NotImplementedError("Subclasses must implement package_version")
 
     @pytest.fixture(scope="class")
-    def packages(self, package_name: str, package_repo: str, package_revision: str):
+    def dbt_utils_version(self) -> str:
+        return "1.3.3"
+
+    @pytest.fixture(scope="class")
+    def dbt_date_repo(self) -> str:
+        return "https://github.com/godatadriven/dbt-date"
+
+    @pytest.fixture(scope="class")
+    def dbt_date_revision(self) -> str:
+        return "0.17.2"
+
+    @pytest.fixture(scope="class")
+    def packages(
+        self,
+        package_name: str,
+        package_repo: str,
+        package_revision: str,
+        dbt_utils_version: str,
+    ):
         packages = [
             {"git": package_repo, "revision": package_revision},
             {
@@ -28,7 +46,7 @@ class BaseDbtPackageTests:
         ]
 
         if package_name != "dbt_utils":
-            packages.append({"package": "dbt-labs/dbt_utils", "version": "1.3.3"})
+            packages.append({"package": "dbt-labs/dbt_utils", "version": dbt_utils_version})
 
         return {"packages": packages}
 

--- a/tests/fabric/packages/test_dbt_date.py
+++ b/tests/fabric/packages/test_dbt_date.py
@@ -33,12 +33,12 @@ class TestDbtDate(BaseDbtPackageTests):
         return "dbt_date"
 
     @pytest.fixture(scope="class")
-    def package_repo(self) -> str:
-        return "https://github.com/godatadriven/dbt-date"
+    def package_repo(self, dbt_date_repo) -> str:
+        return dbt_date_repo
 
     @pytest.fixture(scope="class")
-    def package_revision(self) -> str:
-        return "0.17.2"
+    def package_revision(self, dbt_date_revision) -> str:
+        return dbt_date_revision
 
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/fabric/packages/test_dbt_utils.py
+++ b/tests/fabric/packages/test_dbt_utils.py
@@ -34,8 +34,8 @@ class TestDbtUtils(BaseDbtPackageTests):
         return "https://github.com/dbt-labs/dbt-utils"
 
     @pytest.fixture(scope="class")
-    def package_revision(self) -> str:
-        return "1.3.3"
+    def package_revision(self, dbt_utils_version) -> str:
+        return dbt_utils_version
 
     @pytest.fixture(scope="class")
     def seeds_config(self):


### PR DESCRIPTION
## Summary
- Add `dbt_utils_version`, `dbt_date_repo`, `dbt_date_revision` fixtures to `BaseDbtPackageTests` for reuse across package test classes (needed by upcoming dbt-expectations tests)
- Update `TestDbtUtils` and `TestDbtDate` to use centralized fixtures instead of hardcoding
- Add inline comment explaining the `char(1)` workaround in `split_part.sql`

## Test plan
- [x] `TestDbtUtils` passes
- [x] `TestDbtDate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)