### PR TITLE
Add FabricSpark dbt-audit-helper integration tests and macro overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,6 @@ When adding override macros for a community package:
 1. Place the override macros in `src/dbt/include/fabric/macros/dbt_package_support/<package_name>/` (or `fabricspark/` equivalent)
 2. Only override leaf macros that the package dispatches to — don't override orchestration macros that already use dispatched calls
 3. Document the required `dispatch` config in the docs page for that feature
-4. Add inline Jinja comments (`{#- ... -#}`) documenting: which upstream macro is overridden, what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original
 
 ### `@available` decorator
 
@@ -312,6 +311,7 @@ CI authenticates to Azure via OIDC (federated credentials, no secrets stored). T
 - **Quote style**: double quotes
 - **Lint rules**: isort (`I`) + no commented-out code (`ERA`)
 - **No comments in code** unless the _why_ is non-obvious
+- **Macro overrides require inline Jinja comments**: every macro that overrides an upstream or community package macro must have a `{#- ... -#}` header comment stating which macro it overrides (package + name), what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original. Use `{#- ... #}` (no trailing dash) when the comment precedes SQL keywords to avoid whitespace-stripping issues
 - **Always run ruff before committing**: `uv run ruff format .` and `uv run ruff check --fix .` must pass before every commit
 - **PEP 604 union syntax**: use `X | Y` instead of `typing.Union[X, Y]` — the project targets Python 3.13 and has no `from typing import Union` imports
 - **Class constants at the top**: group all class-level constants together at the top of the class body, before any methods

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,10 @@ dispatch:
 The key insight is that `'dbt'` is the `GLOBAL_PROJECT_NAME` constant in dbt-core. When `get_from_package("dbt", macro_name)` is called during dispatch, it searches the `global_project_namespace` — which contains all adapter-internal macros (everything under `src/dbt/include/fabric/macros/`). This means putting `'dbt'` first in the `search_order` makes dbt find our `fabric__create_external_table` before the package's version.
 
 When adding override macros for a community package:
-1. Place the override macros in `src/dbt/include/fabric/macros/dbt_package_support/<package_name>/`
+1. Place the override macros in `src/dbt/include/fabric/macros/dbt_package_support/<package_name>/` (or `fabricspark/` equivalent)
 2. Only override leaf macros that the package dispatches to — don't override orchestration macros that already use dispatched calls
 3. Document the required `dispatch` config in the docs page for that feature
+4. Add inline Jinja comments (`{#- ... -#}`) documenting: which upstream macro is overridden, what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original
 
 ### `@available` decorator
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ CI authenticates to Azure via OIDC (federated credentials, no secrets stored). T
 - **Quote style**: double quotes
 - **Lint rules**: isort (`I`) + no commented-out code (`ERA`)
 - **No comments in code** unless the _why_ is non-obvious
-- **Macro overrides require inline Jinja comments**: every macro that overrides an upstream or community package macro must have a `{#- ... -#}` header comment stating which macro it overrides (package + name), what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original. Use `{#- ... #}` (no trailing dash) when the comment precedes SQL keywords to avoid whitespace-stripping issues
+- **Macro overrides require inline Jinja comments**: every macro that overrides another macro (adapter base classes, dbt-adapters, dbt-spark, or community packages) must have a `{#- ... -#}` header comment stating which macro it overrides (package + name), what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original. Use `{#- ... #}` (no trailing dash) when the comment precedes SQL keywords to avoid whitespace-stripping issues
 - **Always run ruff before committing**: `uv run ruff format .` and `uv run ruff check --fix .` must pass before every commit
 - **PEP 604 union syntax**: use `X | Y` instead of `typing.Union[X, Y]` — the project targets Python 3.13 and has no `from typing import Union` imports
 - **Class constants at the top**: group all class-level constants together at the top of the class body, before any methods

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ CI authenticates to Azure via OIDC (federated credentials, no secrets stored). T
 - **Quote style**: double quotes
 - **Lint rules**: isort (`I`) + no commented-out code (`ERA`)
 - **No comments in code** unless the _why_ is non-obvious
-- **Macro overrides require inline Jinja comments**: every macro that overrides another macro (adapter base classes, dbt-adapters, dbt-spark, or community packages) must have a `{#- ... -#}` header comment stating which macro it overrides (package + name), what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original. Use `{#- ... #}` (no trailing dash) when the comment precedes SQL keywords to avoid whitespace-stripping issues
+- **Macro overrides require inline Jinja comments**: every macro that overrides another macro (adapter base classes, dbt-adapters, dbt-spark, or community packages) must have a `{#- ... -#}` header comment stating which macro it overrides (source + name), what specifically differs, and why. Annotate individual lines/blocks that diverge from upstream so a reader can compare without opening the original. Use `{#- ... #}` (no trailing dash) when the comment precedes SQL keywords to avoid whitespace-stripping issues
 - **Always run ruff before committing**: `uv run ruff format .` and `uv run ruff check --fix .` must pass before every commit
 - **PEP 604 union syntax**: use `X | Y` instead of `typing.Union[X, Y]` — the project targets Python 3.13 and has no `from typing import Union` imports
 - **Class constants at the top**: group all class-level constants together at the top of the class body, before any methods

--- a/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/compare_which_query_columns_differ.sql
+++ b/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/compare_which_query_columns_differ.sql
@@ -46,7 +46,7 @@
         ) dbt_ah_b
         on dbt_ah_a.dbt_audit_surrogate_key = dbt_ah_b.dbt_audit_surrogate_key
     ) dbt_ah_calculated
-    {#- lateral view inline replaces upstream's UNION ALL over CTE `calculated` -#}
+    {#- lateral view inline replaces upstream's UNION ALL over CTE `calculated` #}
     lateral view inline(array(
         {% for column in columns %}
             named_struct('column_name', '{{ column }}', 'has_difference', {{ column | lower }}_has_difference)

--- a/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/compare_which_query_columns_differ.sql
+++ b/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/compare_which_query_columns_differ.sql
@@ -1,6 +1,14 @@
-{#- Spark fully qualifies CTE names when storing view text, turning
-    them into 3-part table references that don't exist. Avoid CTEs
-    entirely by using inline subqueries and stack() to unpivot. -#}
+{#- Override: audit_helper.default__compare_which_query_columns_differ
+    (dbt-audit-helper 0.13.0, macros/compare_which_query_columns_differ.sql)
+
+    Upstream uses CTEs named `a`, `b`, `calculated` and UNION ALL to unpivot.
+    Spark fully qualifies CTE names when storing view text (e.g. `a` becomes
+    `catalog.schema.a`), making the view unqueryable.
+
+    Changes vs upstream:
+    - CTEs replaced with inline subqueries to avoid Spark's CTE qualification
+    - UNION ALL unpivot replaced with lateral view inline(array(named_struct(...)))
+      for a single-pass unpivot that doesn't reference a CTE multiple times -#}
 {% macro fabricspark__compare_which_query_columns_differ(a_query, b_query, primary_key_columns, columns, event_time) %}
     {% set columns = audit_helper._ensure_all_pks_are_in_column_set(primary_key_columns, columns) %}
     {% if event_time %}
@@ -21,6 +29,7 @@
                     ~ ")") }} as {{ column | lower }}_has_difference
                 {%- if not loop.last %}, {% endif %}
             {% endfor %}
+        {#- inline subqueries instead of CTEs `a` and `b` -#}
         from (
             select
                 {{ joined_cols }},
@@ -37,6 +46,7 @@
         ) dbt_ah_b
         on dbt_ah_a.dbt_audit_surrogate_key = dbt_ah_b.dbt_audit_surrogate_key
     ) dbt_ah_calculated
+    {#- lateral view inline replaces upstream's UNION ALL over CTE `calculated` -#}
     lateral view inline(array(
         {% for column in columns %}
             named_struct('column_name', '{{ column }}', 'has_difference', {{ column | lower }}_has_difference)

--- a/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/compare_which_query_columns_differ.sql
+++ b/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/compare_which_query_columns_differ.sql
@@ -1,0 +1,47 @@
+{#- Spark fully qualifies CTE names when storing view text, turning
+    them into 3-part table references that don't exist. Avoid CTEs
+    entirely by using inline subqueries and stack() to unpivot. -#}
+{% macro fabricspark__compare_which_query_columns_differ(a_query, b_query, primary_key_columns, columns, event_time) %}
+    {% set columns = audit_helper._ensure_all_pks_are_in_column_set(primary_key_columns, columns) %}
+    {% if event_time %}
+        {% set event_time_props = audit_helper._get_comparison_bounds(event_time) %}
+    {% endif %}
+
+    {% set joined_cols = columns | join(", ") %}
+
+    select column_name, has_difference
+    from (
+        select
+            {% for column in columns %}
+                {% set quoted_column = adapter.quote(column) %}
+                {{ dbt.bool_or("("
+                    ~ "dbt_ah_a." ~ quoted_column ~ " != dbt_ah_b." ~ quoted_column
+                    ~ " or (dbt_ah_a." ~ quoted_column ~ " is null and dbt_ah_b." ~ quoted_column ~ " is not null)"
+                    ~ " or (dbt_ah_a." ~ quoted_column ~ " is not null and dbt_ah_b." ~ quoted_column ~ " is null)"
+                    ~ ")") }} as {{ column | lower }}_has_difference
+                {%- if not loop.last %}, {% endif %}
+            {% endfor %}
+        from (
+            select
+                {{ joined_cols }},
+                {{ audit_helper._generate_null_safe_surrogate_key(primary_key_columns) }} as dbt_audit_surrogate_key
+            from ({{ a_query }}) as a_subq
+            {{ audit_helper.event_time_filter(event_time_props) }}
+        ) dbt_ah_a
+        inner join (
+            select
+                {{ joined_cols }},
+                {{ audit_helper._generate_null_safe_surrogate_key(primary_key_columns) }} as dbt_audit_surrogate_key
+            from ({{ b_query }}) as b_subq
+            {{ audit_helper.event_time_filter(event_time_props) }}
+        ) dbt_ah_b
+        on dbt_ah_a.dbt_audit_surrogate_key = dbt_ah_b.dbt_audit_surrogate_key
+    ) dbt_ah_calculated
+    lateral view inline(array(
+        {% for column in columns %}
+            named_struct('column_name', '{{ column }}', 'has_difference', {{ column | lower }}_has_difference)
+            {%- if not loop.last %}, {% endif %}
+        {% endfor %}
+    )) v as column_name, has_difference
+
+{% endmacro %}

--- a/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/quick_are_queries_identical.sql
+++ b/src/dbt/include/fabricspark/macros/dbt_package_support/dbt_audit_helper/quick_are_queries_identical.sql
@@ -1,0 +1,26 @@
+{#- Override: audit_helper.default__quick_are_queries_identical
+    (dbt-audit-helper 0.13.0, macros/quick_are_queries_identical.sql)
+
+    The default raises a compiler error for unknown adapters. This
+    implements a Spark version modeled after the Snowflake variant:
+    - hash_agg() replaced with bit_xor(xxhash64()) (Spark equivalents)
+    - No CTEs to avoid Spark's view text qualification issue -#}
+{% macro fabricspark__quick_are_queries_identical(query_a, query_b, columns, event_time) %}
+    {% set joined_cols = columns | join(", ") %}
+    {% if event_time %}
+        {% set event_time_props = audit_helper._get_comparison_bounds(event_time) %}
+    {% endif %}
+
+    select count(distinct hash_result) = 1 as are_tables_identical
+    from (
+        select bit_xor(xxhash64({{ joined_cols }})) as hash_result
+        from ({{ query_a }}) query_a_subq
+        {{ audit_helper.event_time_filter(event_time_props) }}
+
+        union all
+
+        select bit_xor(xxhash64({{ joined_cols }})) as hash_result
+        from ({{ query_b }}) query_b_subq
+        {{ audit_helper.event_time_filter(event_time_props) }}
+    ) as hashes
+{% endmacro %}

--- a/tests/fabricspark/packages/test_dbt_audit_helper.py
+++ b/tests/fabricspark/packages/test_dbt_audit_helper.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tests.packages.base_package_test import BaseDbtPackageTests
+
+
+class TestDbtAuditHelper(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "audit_helper"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "https://github.com/dbt-labs/dbt-audit-helper"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "0.13.0"
+
+    @pytest.fixture(scope="class")
+    def models_config(self):
+        return {
+            "audit_helper_integration_tests": {
+                "unit_test_placeholder_models": {
+                    "unit_test_struct_model_a": {"+enabled": False},
+                    "unit_test_struct_model_b": {"+enabled": False},
+                },
+                "unit_test_wrappers": {"+enabled": False},
+                "data_tests": {
+                    "compare_and_classify_query_results": {"+enabled": False},
+                },
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def project_vars(self):
+        return {
+            "compare_queries_summarize": True,
+            "primary_key_columns_var": ["col1"],
+            "columns_var": ["col1"],
+            "event_time_var": None,
+            "quick_are_queries_identical_cols": ["col1"],
+        }

--- a/tests/fabricspark/packages/test_dbt_audit_helper.py
+++ b/tests/fabricspark/packages/test_dbt_audit_helper.py
@@ -20,17 +20,17 @@ class TestDbtAuditHelper(BaseDbtPackageTests):
     def models_config(self):
         return {
             "audit_helper_integration_tests": {
-                # struct models use _basic_json_function which only has
-                # implementations for specific adapters, not fabricspark
+                # _basic_json_function has no fabricspark implementation
                 "unit_test_placeholder_models": {
                     "unit_test_struct_model_a": {"+enabled": False},
                     "unit_test_struct_model_b": {"+enabled": False},
                 },
-                # unit_compare_classify_struct depends on the disabled struct
-                # models; unit_quick_are_queries_identical calls
-                # quick_are_queries_identical() which is not implemented for
-                # fabricspark; remaining wrappers depend on these
-                "unit_test_wrappers": {"+enabled": False},
+                "unit_test_wrappers": {
+                    # depends on the disabled struct placeholder models
+                    "unit_compare_classify_struct": {"+enabled": False},
+                    # Spark: distinct window functions are unsupported
+                    "unit_compare_classify": {"+enabled": False},
+                },
                 "data_tests": {
                     # Spark: distinct window functions are unsupported
                     "compare_and_classify_query_results": {"+enabled": False},

--- a/tests/fabricspark/packages/test_dbt_audit_helper.py
+++ b/tests/fabricspark/packages/test_dbt_audit_helper.py
@@ -20,12 +20,19 @@ class TestDbtAuditHelper(BaseDbtPackageTests):
     def models_config(self):
         return {
             "audit_helper_integration_tests": {
+                # struct models use _basic_json_function which only has
+                # implementations for specific adapters, not fabricspark
                 "unit_test_placeholder_models": {
                     "unit_test_struct_model_a": {"+enabled": False},
                     "unit_test_struct_model_b": {"+enabled": False},
                 },
+                # unit_compare_classify_struct depends on the disabled struct
+                # models; unit_quick_are_queries_identical calls
+                # quick_are_queries_identical() which is not implemented for
+                # fabricspark; remaining wrappers depend on these
                 "unit_test_wrappers": {"+enabled": False},
                 "data_tests": {
+                    # Spark: distinct window functions are unsupported
                     "compare_and_classify_query_results": {"+enabled": False},
                 },
             }


### PR DESCRIPTION
## Summary

- Adds `tests/fabricspark/packages/test_dbt_audit_helper.py` running dbt-audit-helper 0.13.0 against FabricSpark (Lakehouse via Livy)
- Implements `fabricspark__compare_which_query_columns_differ` — avoids CTEs (Spark qualifies CTE names in view text) using inline subqueries + `lateral view inline(array(named_struct(...)))` for unpivoting
- Implements `fabricspark__quick_are_queries_identical` — Spark version using `bit_xor(xxhash64())` for order-independent table hashing (upstream default raises error for unknown adapters)
- 87/87 dbt build steps pass (seeds, views, data tests, unit tests)
- Updates CLAUDE.md: macro override comment rule applies to all overrides (adapter, upstream, community packages)

## Disabled tests

- `unit_test_struct_model_a/b` — `_basic_json_function` has no fabricspark implementation
- `unit_compare_classify_struct` — depends on disabled struct models
- `unit_compare_classify` — Spark does not support distinct window functions
- `compare_and_classify_query_results` — same distinct window function limitation

## Test plan

- [x] Run `uv run pytest --de -k "TestDbtAuditHelper"` — 87/87 PASS
- [x] Verify macro overrides have inline Jinja comments documenting upstream differences
- [x] Verify disabled tests have comments explaining why

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)