### PR TITLE
Add dbt-project-evaluator integration tests

### DIFF
--- a/tests/fabric/packages/test_dbt_project_evaluator.py
+++ b/tests/fabric/packages/test_dbt_project_evaluator.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tests.packages.base_package_test import BaseDbtPackageTests
+
+
+class TestDbtProjectEvaluator(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "dbt_project_evaluator"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "https://github.com/sdebruyn/dbt-project-evaluator"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "feature/fabric-support"
+
+    @pytest.fixture(scope="class")
+    def packages(self, package_repo, package_revision, dbt_utils_version):
+        return {
+            "packages": [
+                {"git": package_repo, "revision": package_revision},
+                {"package": "dbt-labs/dbt_utils", "version": dbt_utils_version},
+            ]
+        }
+
+    @pytest.fixture(scope="class")
+    def seeds_config(self):
+        col_type = "varchar(8000)"
+        return {
+            "dbt_project_evaluator": {
+                "dbt_project_evaluator_exceptions": {
+                    "+column_types": {
+                        "fct_name": col_type,
+                        "column_name": col_type,
+                        "id_to_exclude": col_type,
+                        "comment": col_type,
+                    }
+                }
+            }
+        }
+
+    @pytest.fixture(scope="class")
+    def project_vars(self):
+        return {
+            "max_depth_dag": 9,
+        }


### PR DESCRIPTION
## Summary

- Adds integration test for dbt-project-evaluator package against Fabric Data Warehouse
- Uses the Fabric-compatible fork at [sdebruyn/dbt-project-evaluator](https://github.com/sdebruyn/dbt-project-evaluator/tree/feature/fabric-support) (upstream PR: https://github.com/dbt-labs/dbt-project-evaluator/pull/576)
- All 78 models and tests pass: 48 table models, 1 seed, 29 data tests, 0 errors, 0 skips

## Test plan

- [x] `uv run pytest -k "TestDbtProjectEvaluator" --dw` passes (78/78)

🤖 Generated with [Claude Code](https://claude.com/claude-code)