### PR TITLE
Add FabricSpark integration tests for dbt_artifacts package

### DIFF
--- a/tests/fabricspark/packages/test_dbt_artifacts.py
+++ b/tests/fabricspark/packages/test_dbt_artifacts.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dbt.tests.util import run_dbt
 from tests.packages.base_package_test import BaseDbtPackageTests
 
 
@@ -35,3 +36,21 @@ class TestDbtArtifacts(BaseDbtPackageTests):
                 {"package": "dbt-labs/dbt_utils", "version": dbt_utils_version},
             ]
         }
+
+    @pytest.fixture(scope="class")
+    def models_config(self):
+        return {
+            "dbt_artifacts": {
+                "+file_format": "delta",
+            }
+        }
+
+    def test_package(self, project, dbt_core_bug_workaround):
+        run_dbt(["deps"])
+        run_dbt(
+            [
+                "build",
+                "--exclude",
+                "microbatch",
+            ],
+        )

--- a/tests/fabricspark/packages/test_dbt_artifacts.py
+++ b/tests/fabricspark/packages/test_dbt_artifacts.py
@@ -1,0 +1,37 @@
+import pytest
+
+from tests.packages.base_package_test import BaseDbtPackageTests
+
+
+class TestDbtArtifacts(BaseDbtPackageTests):
+    @pytest.fixture(scope="class")
+    def package_name(self) -> str:
+        return "dbt_artifacts"
+
+    @pytest.fixture(scope="class")
+    def package_repo(self) -> str:
+        return "https://github.com/brooklyn-data/dbt_artifacts"
+
+    @pytest.fixture(scope="class")
+    def package_revision(self) -> str:
+        return "2.10.1"
+
+    @pytest.fixture(scope="class")
+    def packages(
+        self,
+        package_name: str,
+        package_repo: str,
+        package_revision: str,
+        dbt_utils_version: str,
+    ):
+        return {
+            "packages": [
+                {"git": package_repo, "revision": package_revision},
+                {
+                    "git": package_repo,
+                    "revision": package_revision,
+                    "subdirectory": "integration_test_project",
+                },
+                {"package": "dbt-labs/dbt_utils", "version": dbt_utils_version},
+            ]
+        }

--- a/tests/fabricspark/packages/test_dbt_artifacts.py
+++ b/tests/fabricspark/packages/test_dbt_artifacts.py
@@ -42,7 +42,7 @@ class TestDbtArtifacts(BaseDbtPackageTests):
         return {
             "dbt_artifacts": {
                 "+file_format": "delta",
-            }
+            },
         }
 
     def test_package(self, project, dbt_core_bug_workaround):

--- a/tests/fabricspark/packages/test_dbt_artifacts.py
+++ b/tests/fabricspark/packages/test_dbt_artifacts.py
@@ -1,6 +1,5 @@
 import pytest
 
-from dbt.tests.util import run_dbt
 from tests.packages.base_package_test import BaseDbtPackageTests
 
 
@@ -43,14 +42,9 @@ class TestDbtArtifacts(BaseDbtPackageTests):
             "dbt_artifacts": {
                 "+file_format": "delta",
             },
+            "artifacts_integration_tests": {
+                "microbatch": {
+                    "+partition_by": ["transaction_ts"],
+                },
+            },
         }
-
-    def test_package(self, project, dbt_core_bug_workaround):
-        run_dbt(["deps"])
-        run_dbt(
-            [
-                "build",
-                "--exclude",
-                "microbatch",
-            ],
-        )


### PR DESCRIPTION
## Summary

- Adds `tests/fabricspark/packages/test_dbt_artifacts.py` with integration test class
- Runs dbt_artifacts 2.10.1 integration test suite against FabricSpark (Lakehouse via Livy)
- Uses `BaseDbtPackageTests` base class from the shared `tests/packages/` module
- Overrides `models_config` to set `file_format=delta` for dbt_artifacts models (upstream defaults to empty string for non-Databricks targets, failing dbt-spark's file format validation)
- Overrides `partition_by` for the microbatch model specifically — upstream uses BigQuery-style dict which dbt-spark's `partition_cols` macro iterates as column names; replaced with Spark-compatible list format

## Results

49/51 models pass (2 NO-OP), 0 errors, 0 skips. All models including microbatch run successfully. The on-run-end hook uploads all metadata (model executions, seeds, snapshots, tests, sources, invocations, exposures).

## Test plan

- [x] Run `uv run pytest --de -k "TestDbtArtifacts"` against real Fabric Lakehouse
- [x] All models compile and run including microbatch
- [x] on-run-end hook uploads metadata successfully

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)