### PR TITLE
Fix case mismatch in dbt-date round_timestamp test fixture

### DIFF
--- a/tests/fabric/packages/test_dbt_date.py
+++ b/tests/fabric/packages/test_dbt_date.py
@@ -84,7 +84,7 @@ class TestDbtDate(BaseDbtPackageTests):
     time_stamp_utc. round_timestamp adds 12h then truncates: 14:35+12h = next
     day. Upstream hardcodes '2021-06-07' assuming a non-UTC offset; we fix it. -#}
 {% macro get_test_dates() -%}
-{{ dbt_date_integration_tests.get_test_dates() | replace("'2021-06-07' as DATETIME2(6)) as rounded_timestamp,", "'2021-06-08' as DATETIME2(6)) as rounded_timestamp,") }}
+{{ dbt_date_integration_tests.get_test_dates() | replace("'2021-06-07' as datetime2(6)) as rounded_timestamp,", "'2021-06-08' as datetime2(6)) as rounded_timestamp,") }}
 {%- endmacro %}
 """,
         }


### PR DESCRIPTION
## Summary

- Fixes the `expression_is_true_test_dates_rounded_timestamp_dbt_date_round_timestamp_time_stamp_` test failure (2 rows not matching) in the DW integration tests for the dbt-date package.
- The `get_test_dates()` override used a Jinja `replace` filter matching `DATETIME2(6)` (uppercase), but `fabric__type_timestamp()` resolves to `datetime2(6)` (lowercase via the Jinja macro in `dbt_expectations/utils/datatypes.sql`). The replacement never fired, so the expected `rounded_timestamp` column stayed at `'2021-06-07'` while `round_timestamp()` correctly computed `'2021-06-08'`.
- The UTC variant passed because `rounded_timestamp_utc` already had the correct expected value (`'2021-06-08'`) from the upstream fixture.

## Test plan

- [ ] Run `/test-dw TestDbtDate` to confirm the round_timestamp assertion passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)