### PR TITLE
Change FabricSpark default materialization to view

### DIFF
--- a/docs/comparison-dbt-fabric.md
+++ b/docs/comparison-dbt-fabric.md
@@ -33,7 +33,7 @@ This adapter provides a full second adapter (`fabricspark`) for Fabric Lakehouse
 | Materialized View | No | Yes (Fabric lake views) | No |
 | Python models | Yes (via Livy) | Yes (via Livy) | No |
 
-The `fabricspark` adapter introduces `materialized_view` as the default materialization (since Fabric Lakehouse doesn't support traditional SQL views, only Delta lake views created with `CREATE OR REPLACE MATERIALIZED LAKE VIEW`). The adapter also uniquely supports `insert_overwrite` for FabricSpark incremental models.
+The `fabricspark` adapter supports `materialized_view` as a materialization (creating Fabric lake views with `CREATE OR REPLACE MATERIALIZED LAKE VIEW`). The default materialization is `view`, matching standard dbt behavior. The adapter also uniquely supports `insert_overwrite` for FabricSpark incremental models.
 
 Both Python model support for Fabric DW (via Livy sessions writing through `synapsesql`) and FabricSpark (native PySpark via Livy) are exclusive to this adapter.
 

--- a/src/dbt/include/fabricspark/dbt_project.yml
+++ b/src/dbt/include/fabricspark/dbt_project.yml
@@ -6,4 +6,4 @@ config-version: 2
 macro-paths: ["macros"]
 
 models:
-  +materialized: materialized_view
+  +materialized: view

--- a/src/dbt/include/fabricspark/dbt_project.yml
+++ b/src/dbt/include/fabricspark/dbt_project.yml
@@ -4,6 +4,3 @@ version: 1.0
 config-version: 2
 
 macro-paths: ["macros"]
-
-models:
-  +materialized: view


### PR DESCRIPTION
## Summary

- Changes the FabricSpark default materialization from `materialized_view` to `view` in `dbt_project.yml`
- Updates the comparison docs to reflect that `view` is now the default

PR #234 added Spark SQL view support, so the default can now be the standard `view` instead of `materialized_view`. This aligns FabricSpark with standard dbt behavior where `view` is the default materialization.

## Test plan

- [ ] Run FabricSpark integration tests (`/test-de`) to verify views work as the default materialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)