### PR TITLE
Remove DE workflow job timeout and threads override

### DIFF
--- a/.github/workflows/integration-tests-de.yml
+++ b/.github/workflows/integration-tests-de.yml
@@ -33,7 +33,6 @@ jobs:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     environment: azure
-    timeout-minutes: 60
     steps:
       - name: Install mssql-python system dependencies
         run: sudo apt-get update && sudo apt-get install -y libltdl7
@@ -55,7 +54,6 @@ jobs:
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_THREADS: 2
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
         run: |
           export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
@@ -79,7 +77,6 @@ jobs:
        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     environment: azure
-    timeout-minutes: 60
 
     steps:
       - name: Resolve PR metadata
@@ -170,7 +167,6 @@ jobs:
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_THREADS: 2
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
           PYTEST_FILTER: ${{ steps.filter.outputs.expression }}
         run: |
@@ -224,7 +220,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number == ''
     runs-on: ubuntu-latest
     environment: azure
-    timeout-minutes: 60
     steps:
       - name: Install mssql-python system dependencies
         run: sudo apt-get update && sudo apt-get install -y libltdl7
@@ -246,7 +241,6 @@ jobs:
           FABRIC_TEST_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_THREADS: 2
           FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
           PYTEST_FILTER: ${{ github.event.inputs.pytest_filter }}
         run: |


### PR DESCRIPTION
## Summary

- Drop `timeout-minutes: 60` from all three jobs in `integration-tests-de.yml` so the GitHub Actions 6-hour default applies. The last two runs ([dispatch](https://github.com/sdebruyn/dbt-fabric/actions/runs/25996106456), [scheduled](https://github.com/sdebruyn/dbt-fabric/actions/runs/25978085719)) were cancelled at exactly 1h0m with all completed tests passing — the suite simply outgrew the limit.
- Remove the `FABRIC_TEST_THREADS: 2` env override in all three jobs so the conftest fallback of 10 takes effect, matching local development.

## Test plan

- [ ] Manually trigger the workflow (`gh workflow run integration-tests-de.yml`) and confirm the run completes within the 6-hour default.
- [ ] Verify the next scheduled run (Sun 01:00 UTC) finishes without cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)