### PR TITLE
Investigate synapsesql schema-lock workarounds (paths A-D)

### DIFF
--- a/src/dbt/adapters/fabric/fabric_livy_helper.py
+++ b/src/dbt/adapters/fabric/fabric_livy_helper.py
@@ -27,6 +27,16 @@ class FabricLivyHelper(PythonJobHelper):
         if not self._sql_endpoint:
             self._sql_endpoint = fabric_api_client.get_warehouse_connection_string()
 
+    # The synapsesql connector holds JDBC sessions to the DW alive past the
+    # write call (per #238). Those sessions keep Sch-S on the target table's
+    # metadata and block any subsequent Sch-M-acquiring DDL (sp_rename, DROP,
+    # CREATE VIEW), causing minutes-long LCK_M_SCH_M waits.
+    #
+    # Forcing a JVM GC reliably tears the connections down within ~3-4s
+    # (empirically verified — see #271). The earlier fire-and-forget variant
+    # (#239) submitted the GC but didn't wait, so the next dbt op could
+    # start before the GC actually ran. Await the GC so the connections are
+    # closed before submit() returns.
     _GC_CODE = "spark._jvm.java.lang.System.gc()"
 
     def submit(self, compiled_code: str) -> Any:
@@ -41,5 +51,5 @@ class FabricLivyHelper(PythonJobHelper):
                 f"Logs URL: {livy_session.get_logs_url()}. "
                 f"Error: {result.error_message}"
             )
-        livy_session.run_statement(self._GC_CODE, "python", wait_for_result=False)
+        livy_session.run_statement(self._GC_CODE, "python")
         return result.to_submission_result(compiled_code)


### PR DESCRIPTION
Closes #271 — reopens / supersedes #239 which only delivered a partial fix.

## Summary

Flip the existing post-write JVM GC from fire-and-forget to awaited. The connector keeps its JDBC sessions alive past `df.write.synapsesql(...)`; those sessions hold `Sch-S` on the target table and block any later `Sch-M`-acquiring DDL with multi-minute `LCK_M_SCH_M` waits. Waiting for the GC ensures the connections are torn down before `submit()` returns, so the next dbt op never races against the leaked sessions.

## Investigation summary

Paths walked per #271:

| Path | Outcome |
|---|---|
| A. Awaited GC | **Chosen.** Probing showed connections drop from N→0 within 3-4s. |
| B. JVM reflection to close connector pool | Dead end. Connector keeps no static pool; connections live in Scala `Try` closures, unreachable from outside. Full method/field dump of `com.microsoft.spark.fabric.tds.*` confirms. |
| C. Spark JDBC config | Moot once A works. |
| D. Adapter-side DDL retry | Not needed once A works; symptom-only otherwise. |
| E. Upstream bug report to Microsoft | Already filed by maintainer. |

Empirical measurement from probing (single HC REPL):

| Technique | Sessions after write | After 60s |
|---|---|---|
| No cleanup | 2 | 2 (no natural decay) |
| Fire-and-forget GC (current `main`) | varies | varies — race-y |
| **Awaited `System.gc()`** | 0 within ~4s | 0 |
| `gc + sleep(2) + gc` | 0 within ~4s | 0 |
| `gc + runFinalization` | 0 within ~3s | 0 |

The original 2× regression concern from #239 was measured under `FABRIC_TEST_THREADS=10`. CI now runs with `THREADS=4` (#268), so the 4s per write is a fixed cost that the multi-minute lock waits dwarf.

## Test plan

- [x] Existing unit tests pass (`uv run pytest tests/unit/` → 438 passed)
- [x] `ruff format --check` + `ruff check` clean
- [ ] DW python model run (`/test-dw test_python_model`) shows no `LCK_M_SCH_M` waits and overall wall time improvement