### PR TITLE
Cap schema-lock wait via SET LOCK_TIMEOUT

### DIFF
--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -89,6 +89,11 @@ class FabricConnectionManager(BaseFabricConnectionManager):
     TYPE = "fabric"
     _host: str | None = None
 
+    # Bound a statement's wait on a schema lock to 5s before SQL Server
+    # raises error 1222 ("Lock request time out period exceeded"). See
+    # the SET LOCK_TIMEOUT call in connect() for the full context.
+    LOCK_TIMEOUT_MS = 5000
+
     @contextmanager
     def exception_handler(self, sql):
         import mssql_python
@@ -225,6 +230,21 @@ class FabricConnectionManager(BaseFabricConnectionManager):
             # convert DATETIMEOFFSET binary structures to datetime ojbects
             # https://github.com/mkleehammer/pyodbc/issues/134#issuecomment-281739794
             handle.add_output_converter(-155, byte_array_to_datetime)
+
+            # Cap how long a statement waits on a schema lock before
+            # bailing with error 1222 ("Lock request time out period
+            # exceeded"). The Fabric Spark→DW connector leaves idle JDBC
+            # sessions holding Sch-S on the target table after a Python
+            # model write (#238 / #271). Without this cap, a follow-up
+            # DDL stalls until query_timeout (default 300s). With it the
+            # DDL fails fast — visible to the user but quickly, so they
+            # can `dbt build --retry` (or wait for the Spark idle-reap
+            # window to elapse) without a 5-minute hang each time.
+            cursor = handle.cursor()
+            try:
+                cursor.execute(f"SET LOCK_TIMEOUT {cls.LOCK_TIMEOUT_MS}")
+            finally:
+                cursor.close()
 
             return handle
 

--- a/src/dbt/adapters/fabric/fabric_livy_helper.py
+++ b/src/dbt/adapters/fabric/fabric_livy_helper.py
@@ -32,11 +32,21 @@ class FabricLivyHelper(PythonJobHelper):
     # metadata and block any subsequent Sch-M-acquiring DDL (sp_rename, DROP,
     # CREATE VIEW), causing minutes-long LCK_M_SCH_M waits.
     #
-    # Forcing a JVM GC reliably tears the connections down within ~3-4s
-    # (empirically verified — see #271). The earlier fire-and-forget variant
-    # (#239) submitted the GC but didn't wait, so the next dbt op could
-    # start before the GC actually ran. Await the GC so the connections are
-    # closed before submit() returns.
+    # Forcing a JVM GC tears down the *active write* connections within
+    # ~3-4s in single-threaded scenarios (empirically verified — see #271).
+    # The earlier fire-and-forget variant (#239) submitted the GC but
+    # didn't wait, so the next dbt op could start before the GC actually
+    # ran; awaiting the GC fixes that.
+    #
+    # Under concurrent dbt threads, GC alone is NOT enough: the synapsesql
+    # connector maintains a warm-up JDBC pool that the driver-side GC does
+    # not reach (CI run 26030423528 showed pool sessions idle >25 min,
+    # still holding Sch-S). The fabric_connection_manager sets a 5s
+    # SET LOCK_TIMEOUT (#274) so a blocked follow-up DDL at least fails
+    # quickly rather than stalling 5 min on query_timeout. In the test
+    # harness, #276 closes every HC Livy session before drop_test_schema
+    # runs, which terminates the Spark application entirely and drops
+    # all warm-up sessions.
     _GC_CODE = "spark._jvm.java.lang.System.gc()"
 
     def submit(self, compiled_code: str) -> Any:


### PR DESCRIPTION
Refs #271 / #238.

## The problem

The `synapsesql` connector keeps JDBC sessions to the DW alive past the write call. These sessions hold `Sch-S` on the target table's metadata and block follow-up DDL (DROP, sp_rename, CREATE VIEW) on `Sch-M` for the full Spark idle-reap window — observed at 25+ min on idle warm-up pool entries (CI run 26030423528, see #275 for DMV evidence).

Without intervention a blocked DDL hangs until `query_timeout` (default 300s) and then surfaces as an opaque database error.

## What this PR does

One change: `SET LOCK_TIMEOUT 5000` on connection open. SQL Server now raises error 1222 ("Lock request time out period exceeded") after 5s instead of stalling 5 min. The user sees a prompt, clear failure and can `dbt build --retry` after the Spark sessions are reaped — or wait if a single retry is preferred.

## What this PR does NOT do (and why)

An earlier draft wrapped every cursor's `execute()` to translate `ProgrammingError(1222)` into a marker that dbt's retry path could catch, on the theory that a ~3 min retry budget would cover the warm-up reap. That was wrong: the reap window is 25+ min, so retries always exhausted. Meanwhile the wrapper imposed a Python frame on every cursor `execute()` and meaningful maintenance burden for marginal payoff. Dropped.

For the CI test scenario where DROP SCHEMA was the blocked statement, #276 closes every HC Livy session before `drop_test_schema` runs — that fully resolves the test failure mode.

## Test plan

- [x] `uv run pytest tests/unit/` → 438 passed
- [x] `ruff format --check` + `ruff check` clean
- [ ] DW `--with-python` after merge — verify DDL surfaces 1222 within seconds rather than minutes when a Sch-S holder is present

## Related

- #272 (merged) — awaited JVM GC, sufficient single-threaded
- #276 — closes HC Livy sessions before drop_test_schema in CI