### PR TITLE
Use dispatch for dbt-date get_fiscal_periods (closes #243)

### DIFF
--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_date/fiscal_date/get_fiscal_periods.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_date/fiscal_date/get_fiscal_periods.sql
@@ -1,11 +1,22 @@
-{% macro get_fiscal_periods(dates, year_end_month, week_start_day, shift_year=1) %}
+{#-
+Overrides: dbt_date.default__get_fiscal_periods (godatadriven/dbt-date >= 0.18.0)
+What differs:
+  1. Upstream calls dbt_date.get_fiscal_year_dates(...) which produces a nested
+     CTE. Fabric doesn't allow nested CTEs in CREATE VIEW, so we inline it.
+  2. Upstream uses positional GROUP BY (1, 2) and ORDER BY (1, 2). T-SQL does
+     not support either, so we use explicit column references and drop the
+     trailing ORDER BY (Fabric views/subqueries can't ORDER BY anyway).
+  3. Upstream uses mod(x, 13). T-SQL uses the % operator.
+Why: works around T-SQL dialect limitations vs the default implementation.
+Once these limitations are lifted, this whole override can be removed.
+-#}
+{% macro fabric__get_fiscal_periods(dates, year_end_month, week_start_day, shift_year=1) %}
 {#
 This macro requires you to pass in a ref to a date dimension, created via
 dbt_date.get_date_dimension()s
 #}
 
-{#- Upstream calls {{ dbt_date.get_fiscal_year_dates(...) }} which produces a nested CTE.
-    Fabric doesn't allow nested CTEs in CREATE VIEW, so we inline it. #}
+{#- Inlined dbt_date.get_fiscal_year_dates below to avoid nested CTEs in CREATE VIEW. #}
 -- this gets all the dates within a fiscal year
 -- determined by the given year-end-month
 -- ending on the saturday closest to that month's end date

--- a/tests/fabric/packages/test_dbt_date.py
+++ b/tests/fabric/packages/test_dbt_date.py
@@ -1,30 +1,8 @@
-from pathlib import Path
-
 import pytest
 
 from tests.packages.base_package_test import BaseDbtPackageTests
 
-_FISCAL_PERIODS_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "src/dbt/include/fabric/macros/dbt_package_support/dbt_date/fiscal_date"
-    / "get_fiscal_periods.sql"
-)
-
 _TEST_DATES_SQL = "{{ get_test_dates() }}"
-
-_DIM_DATE_FISCAL_SQL = "{{ get_fiscal_periods(ref('dates'), year_end_month=1, week_start_day=1) }}"
-
-_DIM_DATE_SQL = """
-select
-    d.*,
-    f.fiscal_week_of_year,
-    f.fiscal_week_of_period,
-    f.fiscal_period_number,
-    f.fiscal_quarter_number,
-    f.fiscal_period_of_quarter
-from {{ ref("dates") }} d
-left join {{ ref("dim_date_fiscal") }} f on d.date_day = f.date_day
-""".strip()
 
 
 class TestDbtDate(BaseDbtPackageTests):
@@ -44,8 +22,6 @@ class TestDbtDate(BaseDbtPackageTests):
     def models(self):
         return {
             "test_dates.sql": _TEST_DATES_SQL,
-            "dim_date.sql": _DIM_DATE_SQL,
-            "dim_date_fiscal.sql": _DIM_DATE_FISCAL_SQL,
         }
 
     @pytest.fixture(scope="class")
@@ -53,15 +29,12 @@ class TestDbtDate(BaseDbtPackageTests):
         return {
             "dbt_date_integration_tests": {
                 "test_dates": {"+enabled": False},
-                "dim_date": {"+enabled": False},
-                "dim_date_fiscal": {"+enabled": False},
             }
         }
 
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "get_fiscal_periods.sql": _FISCAL_PERIODS_PATH.read_text(),
             "fabric_test_helpers.sql": """
 {% macro get_test_week_of_year() -%}
     {{ return([49, 49]) }}

--- a/tests/packages/base_package_test.py
+++ b/tests/packages/base_package_test.py
@@ -26,7 +26,7 @@ class BaseDbtPackageTests:
 
     @pytest.fixture(scope="class")
     def dbt_date_revision(self) -> str:
-        return "0.17.2"
+        return "0.18.0"
 
     @pytest.fixture(scope="class")
     def packages(


### PR DESCRIPTION
## Summary

- Bump dbt-date integration test pin from 0.17.2 to 0.18.0
- Convert our full-copy `get_fiscal_periods` macro into a `fabric__get_fiscal_periods` dispatch override (same SQL, now registered via dispatch instead of injected at test time)
- Drop the `dim_date` and `dim_date_fiscal` model overrides — upstream's models now build natively against our override via dispatch
- Keep the `test_dates` model override and the `fabric_test_helpers.sql` macros, because upstream's default `test_dates` still hardcodes PG-style timestamps (`'2021-06-07 14:35:20.000000 UTC'`) and a `rounded_timestamp` value that only matches a non-UTC offset — neither works under our UTC test profile on Fabric

dbt-date 0.18.0 ([godatadriven/dbt-date#50](https://github.com/godatadriven/dbt-date/pull/50)) made `get_fiscal_periods` dispatchable, which unlocks part of the cleanup tracked in #243.

## Test plan

- [x] `uv run pytest -k "TestDbtDate" --dw` (42/42 PASS in 30s)
- [x] `uv run ruff format --check .` + `uv run ruff check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)