### PR TITLE
Make LOCK_TIMEOUT configurable, default 30s

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,7 +434,7 @@ How long a statement waits on a schema lock before failing with `Lock request ti
 
 The Fabric Spark&rarr;DW connector used by [Python models](python-models.md) leaves idle JDBC sessions holding a Sch-S lock on the target table for up to the Spark idle-reap window (~25 minutes). Without this cap, a follow-up DDL would stall on the same lock until [`query_timeout`](#query_timeout) (default 24 hours). With the cap the DDL fails fast enough to be visible to the user, who can `dbt build --retry` (or wait for the lock holder to release) instead of hanging.
 
-Set to `0` to disable the cap (let SQL Server wait indefinitely).
+Set to `0` to skip the `SET LOCK_TIMEOUT` entirely. SQL Server's default of `-1` (wait indefinitely) then applies.
 
 !!! info "Data Warehouse only"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -425,6 +425,21 @@ The timeout for executing a query.
 - For `type: fabric`: this can be useful if you are receiving the `Query timeout expired` error. Default: **86400 seconds (24 hours)**.
 - For `type: fabricspark`: controls how long the adapter waits for a Livy statement to complete. Default: **86400 seconds (24 hours)**.
 
+### `lock_timeout`
+
+Possible values: any integer (milliseconds) :timer:<br>
+Default: `30000` (30 seconds)
+
+How long a statement waits on a schema lock before failing with `Lock request time out period exceeded`. The adapter issues `SET LOCK_TIMEOUT` on every new connection.
+
+The Fabric Spark&rarr;DW connector used by [Python models](python-models.md) leaves idle JDBC sessions holding a Sch-S lock on the target table for up to the Spark idle-reap window (~25 minutes). Without this cap, a follow-up DDL would stall on the same lock until [`query_timeout`](#query_timeout) (default 24 hours). With the cap the DDL fails fast enough to be visible to the user, who can `dbt build --retry` (or wait for the lock holder to release) instead of hanging.
+
+Set to `0` to disable the cap (let SQL Server wait indefinitely).
+
+!!! info "Data Warehouse only"
+
+    This option only applies to `type: fabric`.
+
 ### `spark_session_timeout`
 
 Possible values: any integer (seconds) :timer:<br>

--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -89,11 +89,6 @@ class FabricConnectionManager(BaseFabricConnectionManager):
     TYPE = "fabric"
     _host: str | None = None
 
-    # Bound a statement's wait on a schema lock to 5s before SQL Server
-    # raises error 1222 ("Lock request time out period exceeded"). See
-    # the SET LOCK_TIMEOUT call in connect() for the full context.
-    LOCK_TIMEOUT_MS = 5000
-
     @contextmanager
     def exception_handler(self, sql):
         import mssql_python
@@ -236,13 +231,16 @@ class FabricConnectionManager(BaseFabricConnectionManager):
             # exceeded"). The Fabric Spark→DW connector leaves idle JDBC
             # sessions holding Sch-S on the target table after a Python
             # model write (#238 / #271). Without this cap, a follow-up
-            # DDL stalls until query_timeout (default 300s). With it the
-            # DDL fails fast — visible to the user but quickly, so they
+            # DDL stalls until query_timeout (default 300s). With the cap
+            # the DDL fails fast enough to be visible to the user, who
             # can `dbt build --retry` (or wait for the Spark idle-reap
-            # window to elapse) without a 5-minute hang each time.
+            # window to elapse) instead of hanging. The default of 30s
+            # leaves room for the DW to detect closed TCP connections
+            # after a python-model Spark application terminates; profiles
+            # can override via the `lock_timeout` credential.
             cursor = handle.cursor()
             try:
-                cursor.execute(f"SET LOCK_TIMEOUT {cls.LOCK_TIMEOUT_MS}")
+                cursor.execute(f"SET LOCK_TIMEOUT {credentials.lock_timeout}")
             finally:
                 cursor.close()
 

--- a/src/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/src/dbt/adapters/fabric/fabric_connection_manager.py
@@ -237,12 +237,15 @@ class FabricConnectionManager(BaseFabricConnectionManager):
             # window to elapse) instead of hanging. The default of 30s
             # leaves room for the DW to detect closed TCP connections
             # after a python-model Spark application terminates; profiles
-            # can override via the `lock_timeout` credential.
-            cursor = handle.cursor()
-            try:
-                cursor.execute(f"SET LOCK_TIMEOUT {credentials.lock_timeout}")
-            finally:
-                cursor.close()
+            # can override via the `lock_timeout` credential. Setting
+            # lock_timeout to 0 skips the SET entirely, leaving SQL
+            # Server's default of -1 (wait indefinitely) in place.
+            if credentials.lock_timeout > 0:
+                cursor = handle.cursor()
+                try:
+                    cursor.execute(f"SET LOCK_TIMEOUT {credentials.lock_timeout}")
+                finally:
+                    cursor.close()
 
             return handle
 

--- a/src/dbt/adapters/fabric/fabric_credentials.py
+++ b/src/dbt/adapters/fabric/fabric_credentials.py
@@ -15,6 +15,7 @@ class FabricCredentials(BaseFabricCredentials):
     trust_cert: bool | None = False
     schema_authorization: str | None = None
     login_timeout: int = 0
+    lock_timeout: int = 30000
     lakehouse: str | None = None
 
     _ALIASES = BaseFabricCredentials._ALIASES | {
@@ -58,6 +59,7 @@ class FabricCredentials(BaseFabricCredentials):
             "trust_cert",
             "schema_authorization",
             "login_timeout",
+            "lock_timeout",
             "lakehouse",
         )
 

--- a/tests/unit/test_credentials_serialization.py
+++ b/tests/unit/test_credentials_serialization.py
@@ -94,3 +94,17 @@ class TestFabricCredentialsAliases:
         assert FabricCredentials._ALIASES["app_id"] == "client_id"
         assert FabricCredentials._ALIASES["app_secret"] == "client_secret"
         assert FabricCredentials._ALIASES["workspace"] == "workspace_name"
+
+
+class TestFabricCredentialsLockTimeout:
+    def test_default_is_30_seconds(self):
+        creds = FabricCredentials(database="db", schema="s")
+        assert creds.lock_timeout == 30000
+
+    def test_can_be_overridden(self):
+        creds = FabricCredentials(database="db", schema="s", lock_timeout=60000)
+        assert creds.lock_timeout == 60000
+
+    def test_appears_in_connection_keys(self):
+        creds = FabricCredentials(database="db", schema="s")
+        assert "lock_timeout" in creds._connection_keys()


### PR DESCRIPTION
Follow-up to #276.

## What

Add a `lock_timeout` credential (milliseconds, default `30000`) on `FabricCredentials` and use it in `FabricConnectionManager` instead of the hard-coded `LOCK_TIMEOUT_MS = 5000` class constant. Profiles can now override the value or disable it entirely (set `0`).

## Why

The 5 s `SET LOCK_TIMEOUT` introduced in #274 is too tight in the schema-drop window after a python-model run. With #276 we now terminate the underlying Spark application and wait for it to reach `'killed'` before letting teardown continue, but the DW still needs a few extra seconds to detect the closed TCP connections from the synapsesql JDBC pool. Empirically (#276 verification run): the Livy session reached `'killed'` at 21:39:35, `DROP SCHEMA` ran at 21:39:36, and the 5 s lock-timeout fired at 21:39:41 — i.e. the lock was actually held for ~10 s after the JVM died.

30 s comfortably covers that DW-side detection window without hiding longer concurrent-DDL conflicts (those would still fail fast enough to be visible to the user, who can `dbt build --retry`).

## Test plan

- [x] `uv run pytest tests/unit/` → 360 passed (incl. 3 new tests for the credential)
- [x] `ruff format --check` + `ruff check` clean
- [ ] DW integration tests with `--with-python` after merging — verify `DROP SCHEMA` no longer trips on the lock timeout

## Refs

- #238 (root cause), #271 (investigation), #274 (introduced the 5 s cap), #276 (test-side Spark-app termination)