### PR TITLE
Always run python_model tests in CI

### DIFF
--- a/.github/workflows/integration-tests-de.yml
+++ b/.github/workflows/integration-tests-de.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
           export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
-          uv run pytest -ra -v --de --with-python
+          uv run pytest -ra -v --de
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/integration-tests-dw.yml
+++ b/.github/workflows/integration-tests-dw.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: ""
-      with_python:
-        description: "Include Python model tests (requires Livy session)"
-        required: false
-        type: boolean
-        default: false
       pr_number:
         description: "PR number to test (leave empty for current branch)"
         required: false
@@ -85,7 +80,7 @@ jobs:
         run: |
           export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
           export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
-          uv run pytest -ra -v --dw --with-python
+          uv run pytest -ra -v --dw
 
       - name: Upload test logs
         if: always()
@@ -121,6 +116,7 @@ jobs:
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ci04
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
         run: |
           export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
           export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
@@ -241,9 +237,9 @@ jobs:
           export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
           export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
           if [ -n "$PYTEST_FILTER" ]; then
-            uv run pytest -ra -v --dw --with-python -k "$PYTEST_FILTER"
+            uv run pytest -ra -v --dw -k "$PYTEST_FILTER"
           else
-            uv run pytest -ra -v --dw --with-python
+            uv run pytest -ra -v --dw
           fi
 
       - name: Upload test logs
@@ -311,19 +307,15 @@ jobs:
           FABRIC_TEST_WORKSPACE_NAME: adapter-ci
           FABRIC_TEST_DWH_NAME: ci04
           FABRIC_TEST_LAKEHOUSE_NAME: cilh
-          FABRIC_TEST_LIVY_SESSION_NAME: ${{ inputs.with_python && github.run_id || '' }}
+          FABRIC_TEST_LIVY_SESSION_NAME: ${{ github.run_id }}
           PYTEST_FILTER: ${{ github.event.inputs.pytest_filter }}
         run: |
           export FABRIC_TEST_FEDERATED_TOKEN_URL="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
           export FABRIC_TEST_FEDERATED_TOKEN_HEADER="bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}"
-          ARGS="-ra -v --dw"
-          if [[ "${{ inputs.with_python }}" == "true" ]]; then
-            ARGS="$ARGS --with-python"
-          fi
           if [ -n "$PYTEST_FILTER" ]; then
-            uv run pytest $ARGS -k "$PYTEST_FILTER"
+            uv run pytest -ra -v --dw -k "$PYTEST_FILTER"
           else
-            uv run pytest $ARGS
+            uv run pytest -ra -v --dw
           fi
 
       - name: Upload test logs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,12 +107,6 @@ def profile_user(dbt_profile_target):
 def pytest_addoption(parser):
     parser.addoption("--with-grants", action="store_true", default=False, help="run GRANT tests")
     parser.addoption(
-        "--with-python",
-        action="store_true",
-        default=False,
-        help="run Python model tests (slow, requires Livy sessions)",
-    )
-    parser.addoption(
         "--de", action="store_true", default=False, help="run only Fabric Spark tests"
     )
     parser.addoption(
@@ -122,7 +116,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "grants: mark test containing GRANT statements")
-    config.addinivalue_line("markers", "python_model: mark test requiring Python model execution")
+    config.addinivalue_line("markers", "python_model: mark test exercising a Python model")
     config.addinivalue_line(
         "markers", "requires_purview: skip unless FABRIC_TEST_PURVIEW_ENDPOINT is set"
     )
@@ -188,7 +182,6 @@ def pytest_collection_modifyitems(config, items):
         adapter_type = None
 
     skip_grants = pytest.mark.skip(reason="need --with-grants option to run")
-    skip_python = pytest.mark.skip(reason="need --with-python option to run")
     skip_purview = pytest.mark.skip(reason="FABRIC_TEST_PURVIEW_ENDPOINT not set")
     skip_cross_workspace = pytest.mark.skip(
         reason="FABRIC_TEST_CROSS_WORKSPACE_NAME and FABRIC_TEST_CROSS_LAKEHOUSE_NAME not set"
@@ -204,9 +197,6 @@ def pytest_collection_modifyitems(config, items):
 
         if "grants" in item.keywords and not config.getoption("--with-grants"):
             item.add_marker(skip_grants)
-
-        if "python_model" in item.keywords and not config.getoption("--with-python"):
-            item.add_marker(skip_python)
 
         if "requires_purview" in item.keywords and not has_purview:
             item.add_marker(skip_purview)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,6 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "grants: mark test containing GRANT statements")
-    config.addinivalue_line("markers", "python_model: mark test exercising a Python model")
     config.addinivalue_line(
         "markers", "requires_purview: skip unless FABRIC_TEST_PURVIEW_ENDPOINT is set"
     )

--- a/tests/fabric/adapter/test_python_model.py
+++ b/tests/fabric/adapter/test_python_model.py
@@ -14,8 +14,6 @@ from dbt.tests.adapter.python_model.test_python_model import (
 from dbt.tests.adapter.python_model.test_spark import BasePySparkTests
 from dbt.tests.util import run_dbt
 
-pytestmark = pytest.mark.python_model
-
 input_model_sql = """
 {{ config(materialized='table', event_time='event_time') }}
 select 1 as id, cast('2025-01-01 01:25:00+00:00' as datetime2(6)) as event_time

--- a/tests/fabricspark/adapter/test_python_model.py
+++ b/tests/fabricspark/adapter/test_python_model.py
@@ -1,4 +1,3 @@
-import pytest
 
 from dbt.tests.adapter.python_model.test_python_model import (
     BasePythonEmptyTests,
@@ -9,8 +8,6 @@ from dbt.tests.adapter.python_model.test_python_model import (
 )
 from dbt.tests.adapter.python_model.test_spark import BasePySparkTests
 from dbt.tests.util import run_dbt
-
-pytestmark = pytest.mark.python_model
 
 
 class TestPythonModelTestsFabricSpark(BasePythonModelTests):


### PR DESCRIPTION
Follow-up to #276 and #278.

## What

Remove the `--with-python` pytest opt-in and stop skipping `python_model`-marked tests by default. They now run in every `--dw` / `--de` invocation, including local `uv run pytest` and every CI workflow.

## Why

`--with-python` was added because python-model tests left Livy sessions open and locked the test schema, breaking subsequent tests. #276 closes those sessions on teardown and #278 gives the schema-lock enough headroom for the DW to notice. The opt-in is no longer pulling its weight — keeping it means contributors silently skip python coverage in local runs.

## Notes

- Kept the `python_model` mark registered so `-m python_model` / `-m "not python_model"` still work as filters.
- Added `FABRIC_TEST_LIVY_SESSION_NAME: \${{ github.run_id }}` to `push-dw-tests` (which previously omitted it because python tests didn't run there) so the push-on-main job uses a unique session like the rest.
- Dropped the `with_python` `workflow_dispatch` input on the DW workflow and the conditional `--with-python` plumbing in `dispatch-dw-tests`.

## Test plan

- [x] `uv run pytest tests/unit/` → 357 passed
- [x] `ruff format --check` + `ruff check` clean
- [x] `uv run pytest --dw --with-python --collect-only` now errors with `unrecognized arguments: --with-python` (confirms removal)
- [x] `uv run pytest --dw --collect-only -k TestPythonModelTestsFabric` collects the test (confirms it runs by default)
- [ ] DW + DE CI runs after merge — verify both still pass end-to-end without `--with-python`

## Refs

- #276 (teardown cleanup), #278 (configurable LOCK_TIMEOUT)