### PR TITLE
Wire clustered_by to Delta liquid clustering for FabricSpark

### DIFF
--- a/src/dbt/include/fabricspark/macros/adapters/clustered_cols.sql
+++ b/src/dbt/include/fabricspark/macros/adapters/clustered_cols.sql
@@ -1,0 +1,48 @@
+{#-
+  Overrides dbt-spark's `spark__clustered_cols` (dbt-spark/macros/adapters.sql).
+
+  Upstream only emits a clause when both `clustered_by` and `buckets` are set
+  (Hive bucketing); `clustered_by` alone is a silent no-op. Fabric Lakehouse
+  Spark accepts `CLUSTER BY (cols)` on Delta CTAS for liquid clustering, so
+  we wire `clustered_by` through to that DDL when `buckets` is absent.
+
+  Branches:
+    - `clustered_by` + `buckets`           → unchanged Hive bucketing
+    - `clustered_by` alone on Delta        → `cluster by (cols)` (liquid clustering)
+    - `clustered_by` + `partition_by` Delta → compile-time error (mutually exclusive)
+    - `clustered_by` on non-Delta format   → no-op (Hive bucketing requires `buckets`)
+
+  Fabric Lakehouse is Delta-only; a missing `file_format` is treated as `delta`.
+-#}
+{% macro fabricspark__clustered_cols(label, required=false) %}
+  {%- set cols = config.get('clustered_by', validator=validation.any[list, basestring]) -%}
+  {%- set buckets = config.get('buckets', validator=validation.any[int]) -%}
+  {%- set file_format = config.get('file_format', default='delta') -%}
+  {%- set partition_by = config.get('partition_by') -%}
+
+  {%- if cols is not none -%}
+    {%- if cols is string -%}
+      {%- set cols = [cols] -%}
+    {%- endif -%}
+
+    {%- if buckets is not none -%}
+      {{ label }} (
+      {%- for item in cols -%}
+        {{ item }}{%- if not loop.last -%},{%- endif -%}
+      {%- endfor -%}
+      ) into {{ buckets }} buckets
+    {%- elif file_format == 'delta' -%}
+      {%- if partition_by is not none -%}
+        {{ exceptions.raise_compiler_error(
+          "Delta tables in Fabric Lakehouse cannot combine `clustered_by` (liquid clustering) with `partition_by`. "
+          ~ "Drop one, or set `buckets` to switch to Hive bucketing."
+        ) }}
+      {%- endif -%}
+      cluster by (
+      {%- for item in cols -%}
+        {{ item }}{%- if not loop.last -%},{%- endif -%}
+      {%- endfor -%}
+      )
+    {%- endif -%}
+  {%- endif -%}
+{% endmacro %}

--- a/tests/fabricspark/adapter/test_clustered_by.py
+++ b/tests/fabricspark/adapter/test_clustered_by.py
@@ -86,16 +86,23 @@ class TestNoClusteredBy:
 
 
 class TestClusteredByWithBuckets:
-    """`clustered_by` + `buckets` falls back to Hive bucketing (unchanged dbt-spark)."""
+    """`clustered_by` + `buckets` falls back to Hive bucketing (unchanged dbt-spark).
+
+    Fabric Lakehouse is Delta-only and Delta rejects Hive bucketing at runtime
+    (`DELTA_OPERATION_NOT_ALLOWED_DETAIL: Bucketing is not supported for Delta tables`).
+    `target/run/` is written before execution, so the run fails but the compiled
+    DDL is still on disk and proves the macro emitted Hive bucketing. The error
+    message itself is a second proof point.
+    """
 
     @pytest.fixture(scope="class")
     def models(self):
         return {"model_hive.sql": model_hive_bucketing}
 
     def test_hive_bucketing(self, project):
-        results = run_dbt(["run"])
-        assert len(results) == 1
-        assert results[0].status == "success"
+        _, log_output = run_dbt_and_capture(["run"], expect_pass=False)
+        lowered_log = log_output.lower()
+        assert "bucketing" in lowered_log and "not supported for delta" in lowered_log
 
         compiled_sql = _read_compiled_sql(project, "model_hive")
         lowered = compiled_sql.lower()

--- a/tests/fabricspark/adapter/test_clustered_by.py
+++ b/tests/fabricspark/adapter/test_clustered_by.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture
+
+model_single = """
+{{ config(materialized='table', clustered_by='id') }}
+select 1 as id, 'blue' as color
+"""
+
+model_multi = """
+{{ config(materialized='table', clustered_by=['id', 'color']) }}
+select 1 as id, 'blue' as color
+"""
+
+model_no_cluster = """
+{{ config(materialized='table') }}
+select 1 as id, 'blue' as color
+"""
+
+model_hive_bucketing = """
+{{ config(materialized='table', clustered_by=['id'], buckets=4) }}
+select 1 as id, 'blue' as color
+"""
+
+model_cluster_partition_conflict = """
+{{ config(materialized='table', clustered_by=['id'], partition_by=['color']) }}
+select 1 as id, 'blue' as color
+"""
+
+
+def _read_compiled_sql(project, model_name):
+    run_dir = Path(project.project_root) / "target" / "run"
+    candidates = list(run_dir.rglob(f"{model_name}.sql"))
+    assert candidates, f"No compiled SQL found for {model_name} in {run_dir}"
+    return candidates[0].read_text()
+
+
+class TestClusteredBySingleColumn:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_single.sql": model_single}
+
+    def test_clustered_by_single(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_single")
+        assert "cluster by" in compiled_sql.lower()
+        assert "id" in compiled_sql
+        assert "buckets" not in compiled_sql.lower()
+
+
+class TestClusteredByMultipleColumns:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_multi.sql": model_multi}
+
+    def test_clustered_by_multi(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_multi")
+        lowered = compiled_sql.lower()
+        assert "cluster by" in lowered
+        assert "id" in lowered
+        assert "color" in lowered
+        assert "buckets" not in lowered
+
+
+class TestNoClusteredBy:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_no_cluster.sql": model_no_cluster}
+
+    def test_no_clustered_by(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_no_cluster")
+        assert "cluster by" not in compiled_sql.lower()
+
+
+class TestClusteredByWithBuckets:
+    """`clustered_by` + `buckets` falls back to Hive bucketing (unchanged dbt-spark)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_hive.sql": model_hive_bucketing}
+
+    def test_hive_bucketing(self, project):
+        results = run_dbt(["run"])
+        assert len(results) == 1
+        assert results[0].status == "success"
+
+        compiled_sql = _read_compiled_sql(project, "model_hive")
+        lowered = compiled_sql.lower()
+        assert "clustered by" in lowered
+        assert "into 4 buckets" in lowered
+
+
+class TestClusteredByPartitionConflict:
+    """Delta `clustered_by` + `partition_by` must raise at compile time."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"model_conflict.sql": model_cluster_partition_conflict}
+
+    def test_run_error(self, project):
+        _, log_output = run_dbt_and_capture(["run"], expect_pass=False)
+        assert "clustered_by" in log_output
+        assert "partition_by" in log_output

--- a/tests/fabricspark/adapter/test_python_model.py
+++ b/tests/fabricspark/adapter/test_python_model.py
@@ -1,4 +1,3 @@
-
 from dbt.tests.adapter.python_model.test_python_model import (
     BasePythonEmptyTests,
     BasePythonIncrementalTests,


### PR DESCRIPTION
## Summary

- Override `fabricspark__clustered_cols` so `clustered_by` on Delta tables (no `buckets`) emits `CLUSTER BY (cols)` for liquid clustering instead of being a silent no-op.
- Keep dbt-spark's Hive bucketing path unchanged when `buckets` is also set.
- Raise a compile-time error when `clustered_by` and `partition_by` are both set on Delta (mutually exclusive on Fabric Lakehouse Delta).

Closes #280.

Mirrors microsoft/dbt-fabricspark#187 / #188 — wires the existing `clustered_by` config through to Delta liquid clustering DDL without introducing a new config name.

## Test plan

- [x] `uv run pytest tests/fabricspark/adapter/test_clustered_by.py --de` — 5 passed in 170s against Fabric Lakehouse
- [x] Verify `target/run/*.sql` for the single/multi tests contains `cluster by (...)` and no `buckets` — single emits `cluster by (id)`, multi emits `cluster by (id,color)`, no `into N buckets`
- [x] Verify the bucketing test still emits `clustered by (...) into 4 buckets` — Lakehouse Delta rejects Hive bucketing at runtime (`DELTA_OPERATION_NOT_ALLOWED_DETAIL: Bucketing is not supported for Delta tables`), so test now runs with `expect_pass=False` and verifies both the emitted DDL on disk (`clustered by (id) into 4 buckets`) and the Delta error — together they prove the macro routes the config to Hive bucketing
- [x] Verify the partition_by conflict raises with a message naming both configs — error reads: `Delta tables in Fabric Lakehouse cannot combine \`clustered_by\` (liquid clustering) with \`partition_by\`. Drop one, or set \`buckets\` to switch to Hive bucketing.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)