### PR TITLE
Refresh fabricspark draft issues 09 and 10

### DIFF
--- a/_toolbox/upstream_issues/dbt-fabricspark/09-aws-logging-debug-at-import.md
+++ b/_toolbox/upstream_issues/dbt-fabricspark/09-aws-logging-debug-at-import.md
@@ -5,25 +5,32 @@
 
 > [x] **Validated by maintainer** — code refs, line numbers, and claims confirmed against upstream HEAD
 
-> **Internal note (strip before filing):** Submittable as a PR — delete the 9 lines that configure boto3/botocore loggers. Consider opening with the issue *and* a draft PR linked from it.
+> **Internal note (strip before filing):** Submittable as a PR — drop `botocore` and `boto3` from the loop body. Consider opening with the issue *and* a draft PR linked from it.
 
 ## Summary
 
-[`src/dbt/adapters/fabricspark/connections.py#L42-L50`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/connections.py#L42-L50) sets the `botocore` and `boto3` loggers to DEBUG at module import time:
+[`src/dbt/adapters/fabricspark/connections.py#L42-L50`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/connections.py#L42-L50) iterates a list of logger names at module import time and sets each one to DEBUG via `AdapterLogger.set_adapter_dependency_log_level`:
 
 ```python
-logging.getLogger("botocore").setLevel(logging.DEBUG)
-logging.getLogger("boto3").setLevel(logging.DEBUG)
+logger = AdapterLogger("Microsoft Fabric-Spark")
+for logger_name in [
+    "fabricspark.connector",
+    "botocore",
+    "boto3",
+    "Microsoft Fabric-Spark.connector",
+]:
+    logger.debug(f"Setting {logger_name} to DEBUG")
+    logger.set_adapter_dependency_log_level(logger_name, "DEBUG")
 ```
 
-This adapter has no AWS dependency (no `boto3` / `botocore` in [`pyproject.toml`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/pyproject.toml)). The lines look like a leftover from a `dbt-spark` / Databricks ancestor.
+`botocore` and `boto3` have no business being in that list — the adapter has no AWS dependency (no `boto3` / `botocore` in [`pyproject.toml`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/pyproject.toml)). They look like a leftover from a `dbt-spark` / Databricks ancestor and survived a refactor of this block (the direct `logging.getLogger(...).setLevel(...)` calls were replaced with the loop-based `AdapterLogger` API, but the AWS entries were not pruned).
 
 ## User impact
 
-The lines are no-ops *until* the user's project transitively imports `boto3` — which is common in dbt projects with S3-backed assets, or in environments where other packages on the path pull AWS SDKs in. When that happens, this code path silently enables `boto3` DEBUG-level logging across the entire process. Every subsequent `boto3` call dumps debug noise (request signing, response bodies, retry traces) into the dbt log, regardless of dbt's own log level.
+The two AWS entries are no-ops *until* the user's project transitively imports `boto3` — which is common in dbt projects with S3-backed assets, or in environments where other packages on the path pull AWS SDKs in. When that happens, this code path silently enables `boto3` DEBUG-level logging across the entire process. Every subsequent `boto3` call dumps debug noise (request signing, response bodies, retry traces) into the dbt log, regardless of dbt's own log level.
 
 The effect is not catastrophic but it's invisible to the user — they did not configure boto3 debug logging anywhere in their project, but now it's on.
 
 ## Suggested fix
 
-Delete [`connections.py#L42-L50`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/connections.py#L42-L50). This adapter has no business configuring loggers for libraries it does not depend on. If a user wants verbose AWS logs they will set their own log level.
+Remove `"botocore"` and `"boto3"` from the loop in [`connections.py#L43-L48`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/connections.py#L43-L48). This adapter has no business configuring loggers for libraries it does not depend on. If a user wants verbose AWS logs they will set their own log level.

--- a/_toolbox/upstream_issues/dbt-fabricspark/10-parse-retry-after-duplicated.md
+++ b/_toolbox/upstream_issues/dbt-fabricspark/10-parse-retry-after-duplicated.md
@@ -1,32 +1,37 @@
-# `_parse_retry_after` duplicated verbatim across four files; all copies use deprecated `datetime.utcnow()`
+# `_parse_retry_after` duplicated across two files; both copies use deprecated `datetime.utcnow()`
 
 **Repo:** `microsoft/dbt-fabricspark`
 **Labels (suggested):** `bug`, `tech-debt`, `priority/low`
 
 > [x] **Validated by maintainer** — code refs, line numbers, and claims confirmed against upstream HEAD
 
-> **Internal note (strip before filing):** Submittable as a PR — extract to a shared `_http_utils.py`, replace `datetime.utcnow()` with `datetime.now(timezone.utc)`, update the 4 call sites. Consider opening with the issue *and* a draft PR linked from it.
+> **Internal note (strip before filing):** Submittable as a PR — extract to a shared helper module, replace `datetime.utcnow()` with `datetime.now(timezone.utc)`, and route the existing thin wrappers in `singleton_livy.py` / `concurrent_livy.py` through it as well. Consider opening with the issue *and* a draft PR linked from it.
 
 ## Summary
 
-The `_parse_retry_after` helper appears verbatim across four files:
+The `_parse_retry_after` helper exists in two independent full implementations:
 
 - [`src/dbt/adapters/fabricspark/livysession.py#L370`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/livysession.py#L370)
 - [`src/dbt/adapters/fabricspark/mlv_api.py#L141`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/mlv_api.py#L141)
-- [`src/dbt/adapters/fabricspark/concurrent_livy.py#L60`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/concurrent_livy.py#L60)
-- [`src/dbt/adapters/fabricspark/singleton_livy.py#L34`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/singleton_livy.py#L34)
 
-All four copies use `datetime.utcnow()`, which has been deprecated since Python 3.12 in favor of `datetime.now(timezone.utc)`. When `utcnow()` is eventually removed in a future Python release, the bug surfaces in four places at once — and any fix has to be applied in four places too.
+Plus two thin wrappers that re-export the `livysession.py` copy:
+
+- [`src/dbt/adapters/fabricspark/singleton_livy.py#L34`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/singleton_livy.py#L34) — `return _livy_helpers._parse_retry_after(response)`
+- [`src/dbt/adapters/fabricspark/concurrent_livy.py#L60`](https://github.com/microsoft/dbt-fabricspark/blob/d315a56/src/dbt/adapters/fabricspark/concurrent_livy.py#L60) — `return _livy_helpers._parse_retry_after(response)`
+
+The two full implementations both use `datetime.utcnow()`, which has been deprecated since Python 3.12 in favor of `datetime.now(timezone.utc)`. When `utcnow()` is eventually removed in a future Python release, the bug surfaces in two places at once — and any fix has to be applied in two places.
+
+The thin wrappers reach into `livysession`'s underscore-prefixed name (`_livy_helpers._parse_retry_after`), which is a clear signal that the helper wants to live in a dedicated module — pulling it through `livysession` is just convenient.
 
 ## User impact
 
 - Today: a `DeprecationWarning` from each call site when running on Python 3.12+.
-- When Python removes `utcnow()`: every HTTP request that needs to honor a `Retry-After` header breaks, simultaneously, in four files.
-- Right now: any future improvement to retry-after handling (timezone-aware HTTP date parsing, jitter, etc.) has to be made in four places and kept in sync.
+- When Python removes `utcnow()`: every HTTP request that needs to honor a `Retry-After` header breaks, simultaneously, in two files.
+- Right now: any future improvement to retry-after handling (timezone-aware HTTP date parsing, jitter, etc.) has to be made in two places and kept in sync. `mlv_api.py`'s copy has already diverged from `livysession.py`'s in subtle ways across past changes.
 
 ## Suggested fix
 
-Extract `_parse_retry_after` into a single shared module (e.g. `src/dbt/adapters/fabricspark/_http_utils.py`), import from there in all four files, and fix `datetime.utcnow()` → `datetime.now(timezone.utc)` once:
+Extract `parse_retry_after` into a dedicated module (e.g. `src/dbt/adapters/fabricspark/_http_utils.py`), import from there in `livysession.py`, `mlv_api.py`, and the two thin wrappers, and fix `datetime.utcnow()` → `datetime.now(timezone.utc)` once:
 
 ```python
 # _http_utils.py


### PR DESCRIPTION
## Summary

Updates two draft issues in `_toolbox/upstream_issues/dbt-fabricspark/` to reflect upstream refactors. Both bugs are still present; only the surrounding code shape changed.

- **09** (boto3/botocore DEBUG at import): upstream replaced the direct `logging.getLogger(...).setLevel(...)` lines with a loop using `AdapterLogger.set_adapter_dependency_log_level`. The two AWS entries survived the refactor. Updated the snippet, file refs, and "delete the 9 lines" → "drop `botocore` and `boto3` from the loop body".
- **10** (`_parse_retry_after` duplicated 4×): now 2 full copies (`livysession.py`, `mlv_api.py`) + 2 thin wrappers (`singleton_livy.py:34`, `concurrent_livy.py:60`) that route through `_livy_helpers._parse_retry_after`. Both full copies still use `datetime.utcnow()`. Updated title, body, and fix suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)