### PR TITLE
Fix outdated comment in not_empty_string override

### DIFF
--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_utils/generic_tests/not_empty_string.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_utils/generic_tests/not_empty_string.sql
@@ -24,7 +24,7 @@
     errors as (
 
         select * from all_values
-        {#- Upstream uses length() = 0. T-SQL LEN() ignores trailing spaces; datalength() is reliable. #}
+        {#- Override: upstream uses `where col = ''`. T-SQL/varchar uses SQL-92 trailing-whitespace-insensitive equality, so `'   ' = ''` is true; that would flag whitespace-only rows even when `trim_whitespace=false`. Using `datalength()` measures real byte length and preserves the `trim_whitespace=false` semantics. -#}
         where datalength({{ column_name }}) = 0
 
     )


### PR DESCRIPTION
## Summary

The inline comment in `fabric__test_not_empty_string` claimed upstream `dbt-utils` uses `length() = 0` and that `LEN()` quirks were the reason for the override. That's stale: upstream has used `where col = ''` for years. The override is still needed, but for a different reason.

T-SQL/`varchar` uses SQL-92 trailing-whitespace-insensitive equality, so `'   ' = ''` evaluates to true. Upstream's `where col = ''` would therefore flag whitespace-only rows on Fabric DW even when `trim_whitespace=false` is passed. Our `datalength() = 0` check measures real byte length and correctly preserves the `trim_whitespace=false` semantics.

Documentation-only change; no runtime behavior modified.

## Test plan

- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] No tests needed (comment-only change)