### PR TITLE
Support compare_and_classify_query_results on Fabric

### DIFF
--- a/docs/packages/dbt-audit-helper.md
+++ b/docs/packages/dbt-audit-helper.md
@@ -1,6 +1,6 @@
 # dbt-audit-helper
 
-**Tested version:** 0.13.0 | **Integration tested:** Yes
+**Tested version:** 0.14.0 | **Integration tested:** Yes
 
 [dbt-audit-helper](https://github.com/dbt-labs/dbt-audit-helper) provides macros for comparing relations and queries during data model refactoring.
 
@@ -33,13 +33,8 @@ Macros marked with **(override)** have a T-SQL-compatible override in this adapt
 | `compare_which_relation_columns_differ` | :white_check_mark: | Delegates to `compare_which_query_columns_differ` |
 | `quick_are_queries_identical` | :white_check_mark: | |
 | `quick_are_relations_identical` | :white_check_mark: | |
-
-### Not supported
-
-| Macro | Status | Notes |
-|---|---|---|
-| `compare_and_classify_query_results` | :x: | Not dispatched; uses `true`/`false` literals (no boolean type in T-SQL) |
-| `compare_and_classify_relation_rows` | :x: | Delegates to `compare_and_classify_query_results` |
+| `compare_and_classify_query_results` | :white_check_mark: **(override)** | 1/0 integers instead of `true`/`false`; companion overrides on `_classify_audit_row_status` (explicit `= 1` comparisons) and `_count_num_rows_in_status` (dense_rank trick — `COUNT(DISTINCT ...) OVER ()` is not supported in T-SQL) |
+| `compare_and_classify_relation_rows` | :white_check_mark: | Delegates to `compare_and_classify_query_results` |
 
 ## Implementation notes
 

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_audit_helper/_classify_audit_row_status.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_audit_helper/_classify_audit_row_status.sql
@@ -1,0 +1,16 @@
+{#- The default macro reads `dbt_audit_in_a`/`dbt_audit_in_b` as booleans and
+    wraps each with `bool_or` window functions. In our T-SQL pipeline those
+    flags are 1/0 integers (see `fabric__compare_and_classify_query_results`),
+    so we compare with `= 1` directly and use plain `max(... ) over ()` to find
+    presence within a partition. -#}
+{% macro fabric___classify_audit_row_status() %}
+    case
+        when max(dbt_audit_pk_row_num) over (partition by dbt_audit_surrogate_key) > 1 then 'nonunique_pk'
+        when dbt_audit_in_a = 1 and dbt_audit_in_b = 1 then 'identical'
+        when max(dbt_audit_in_a) over (partition by dbt_audit_surrogate_key, dbt_audit_pk_row_num) = 1
+            and max(dbt_audit_in_b) over (partition by dbt_audit_surrogate_key, dbt_audit_pk_row_num) = 1
+            then 'modified'
+        when dbt_audit_in_a = 1 then 'removed'
+        when dbt_audit_in_b = 1 then 'added'
+    end
+{% endmacro %}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_audit_helper/_count_num_rows_in_status.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_audit_helper/_count_num_rows_in_status.sql
@@ -1,0 +1,9 @@
+{#- T-SQL does not support `COUNT(DISTINCT col1, col2) OVER (...)`: `COUNT(DISTINCT)`
+    accepts a single column and is rejected in window functions. We use the
+    distinct-free dense_rank trick that postgres and databricks ship under
+    `_count_num_rows_in_status_without_distinct_window_func`. -#}
+{% macro fabric___count_num_rows_in_status() %}
+    dense_rank() over (partition by dbt_audit_row_status order by dbt_audit_surrogate_key, dbt_audit_pk_row_num)
+    + dense_rank() over (partition by dbt_audit_row_status order by dbt_audit_surrogate_key desc, dbt_audit_pk_row_num desc)
+    - 1
+{% endmacro %}

--- a/src/dbt/include/fabric/macros/dbt_package_support/dbt_audit_helper/compare_and_classify_query_results.sql
+++ b/src/dbt/include/fabric/macros/dbt_package_support/dbt_audit_helper/compare_and_classify_query_results.sql
@@ -1,0 +1,71 @@
+{#- T-SQL differences vs. upstream `default__compare_and_classify_query_results`:
+    1. No boolean literal: the `true`/`false` flags marking side membership
+       become 1/0 integers. The helper macros `_classify_audit_row_status` and
+       `_count_num_rows_in_status` are overridden to read those integers.
+    2. T-SQL views and derived tables disallow a trailing `ORDER BY` (unless
+       paired with `TOP`/`OFFSET`/`FOR XML`), so it is dropped — views don't
+       guarantee ordering anyway. Callers that want ordered output should sort
+       in their own SELECT. -#}
+{% macro fabric__compare_and_classify_query_results(a_query, b_query, primary_key_columns, columns, event_time, sample_limit) %}
+
+    {% set columns = audit_helper._ensure_all_pks_are_in_column_set(primary_key_columns, columns) %}
+    {% set joined_cols = columns | join(", ") %}
+
+    {% if event_time %}
+        {% set event_time_props = audit_helper._get_comparison_bounds(a_query, b_query, event_time) %}
+    {% endif %}
+
+    with
+
+    {{ audit_helper._generate_set_results(a_query, b_query, primary_key_columns, columns, event_time_props)}}
+
+    ,
+
+    all_records as (
+
+        {#- 1/0 integers instead of true/false (no boolean literal in T-SQL) #}
+        select
+            *,
+            1 as dbt_audit_in_a,
+            1 as dbt_audit_in_b
+        from a_intersect_b
+
+        union all
+
+        select
+            *,
+            1 as dbt_audit_in_a,
+            0 as dbt_audit_in_b
+        from a_except_b
+
+        union all
+
+        select
+            *,
+            0 as dbt_audit_in_a,
+            1 as dbt_audit_in_b
+        from b_except_a
+
+    ),
+
+    classified as (
+        select
+            *,
+            {{ audit_helper._classify_audit_row_status() }} as dbt_audit_row_status
+        from all_records
+    ),
+
+    final as (
+        select
+            *,
+            {{ audit_helper._count_num_rows_in_status() }} as dbt_audit_num_rows_in_status,
+            dense_rank() over (partition by dbt_audit_row_status order by dbt_audit_surrogate_key, dbt_audit_pk_row_num) as dbt_audit_sample_number
+        from classified
+    )
+
+    select * from final
+    {% if sample_limit %}
+        where dbt_audit_sample_number <= {{ sample_limit }}
+    {% endif %}
+
+{% endmacro %}

--- a/tests/fabric/packages/test_dbt_audit_helper.py
+++ b/tests/fabric/packages/test_dbt_audit_helper.py
@@ -14,7 +14,7 @@ class TestDbtAuditHelper(BaseDbtPackageTests):
 
     @pytest.fixture(scope="class")
     def package_revision(self) -> str:
-        return "0.13.0"
+        return "0.14.0"
 
     @pytest.fixture(scope="class")
     def models_config(self):
@@ -26,7 +26,6 @@ class TestDbtAuditHelper(BaseDbtPackageTests):
                 },
                 "unit_test_wrappers": {"+enabled": False},
                 "data_tests": {
-                    "compare_and_classify_query_results": {"+enabled": False},
                     "compare_all_columns_where_clause": {"+enabled": False},
                     # Macro works (run_query fetches metadata separately, view
                     # builds with correct VALUES), but the equality test fails:


### PR DESCRIPTION
## Summary

- Bump dbt-audit-helper integration test to 0.14.0 — the new release ([0.14.0](https://github.com/dbt-labs/dbt-audit-helper/releases/tag/0.14.0)) adds `adapter.dispatch` to `compare_and_classify_query_results`, the change we asked for in [dbt-labs/dbt-audit-helper#131](https://github.com/dbt-labs/dbt-audit-helper/issues/131) / [dbt-labs/dbt-audit-helper#132](https://github.com/dbt-labs/dbt-audit-helper/pull/132).
- Add three Fabric overrides that turn the upstream macro's boolean idioms into T-SQL:
  - `fabric__compare_and_classify_query_results` — 1/0 integers instead of `true`/`false`; trailing `ORDER BY` removed (T-SQL views/CTEs forbid it without `TOP`/`OFFSET`/`FOR XML`).
  - `fabric___classify_audit_row_status` — explicit `dbt_audit_in_a = 1` comparisons and plain `max() over (...)` for partition presence.
  - `fabric___count_num_rows_in_status` — distinct-free dense_rank trick (T-SQL doesn't support `COUNT(DISTINCT col1, col2) OVER ()`).
- `compare_and_classify_relation_rows` now also works on Fabric because it delegates to the dispatched query-results macro.
- Update docs to move both macros from the unsupported table into the supported list and mark them `(override)`.

Closes #242.

## Test plan

- [x] `uv run pytest tests/fabric/packages/test_dbt_audit_helper.py --dw` — 61/61 pass, including the newly enabled `compare_and_classify_query_results` model
- [x] `uv run ruff format --check .` + `uv run ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)