### PR TITLE
Lower requests dependency bound to >=2.32.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "azure-identity>=1.12.0",
     "dbt-common>=1.37.3,<2.0",
     "dbt-adapters>=1.22.6,<2.0",
-    "requests>=2.33.0",
+    "requests>=2.32.5",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -398,7 +398,7 @@ requires-dist = [
     { name = "dbt-common", specifier = ">=1.37.3,<2.0" },
     { name = "dbt-spark", marker = "extra == 'spark'", specifier = ">=1.10.1" },
     { name = "mssql-python", specifier = ">=1.4.0" },
-    { name = "requests", specifier = ">=2.33.0" },
+    { name = "requests", specifier = ">=2.32.5" },
 ]
 provides-extras = ["spark"]
 


### PR DESCRIPTION
## Summary
- Lower the `requests` dependency bound from `>=2.33.0` to `>=2.32.5`.
- The adapter only uses stable basic `requests` API (`request`, `get`, `put`, `patch`, `Response`, and the `ConnectionError`/`Timeout`/`ChunkedEncodingError` exceptions). None of this needs anything 2.33-specific.
- The `>=2.33.0` bound was introduced as part of a blanket "update all dependencies" commit (7463d6bf), not because a 2.33 feature was needed. Loosening the floor makes the adapter friendlier to environments pinned to slightly older `requests` releases.

## Test plan
- [x] `uv sync` resolves successfully with the new bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)