### PR TITLE
Exclude broken mssql-python 1.7.0/1.7.1 to fix silent dbt debug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mssql-python>=1.4.0",
+    "mssql-python>=1.4.0,!=1.7.0,!=1.7.1",
     "azure-identity>=1.12.0",
     "dbt-common>=1.37.3,<2.0",
     "dbt-adapters>=1.22.6,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ requires-dist = [
     { name = "dbt-adapters", specifier = ">=1.22.6,<2.0" },
     { name = "dbt-common", specifier = ">=1.37.3,<2.0" },
     { name = "dbt-spark", marker = "extra == 'spark'", specifier = ">=1.10.1" },
-    { name = "mssql-python", specifier = ">=1.4.0" },
+    { name = "mssql-python", specifier = ">=1.4.0,!=1.7.0,!=1.7.1" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
 provides-extras = ["spark"]


### PR DESCRIPTION
## Summary

- Pins `mssql-python` to `>=1.4.0,!=1.7.0,!=1.7.1` to avoid the broken 1.7.x line that crashes the Python interpreter with SIGBUS during `mssql_python.connect()`.
- Root cause of the 1.12.0 / 1.12.1 release breakage that led both to be yanked from PyPI on 2026-05-20.

## What goes wrong on mssql-python 1.7.1

When the adapter calls `mssql_python.connect(..., attrs_before={SQL_COPT_SS_ACCESS_TOKEN: ...})` to authenticate against a Fabric DWH with an Azure access token, the **host Python process dies with SIGBUS** (`Bus error: 10` on macOS) immediately on entering `Connection.__init__`. No Python exception is raised, no traceback is emitted, and `dbt debug` simply stops printing after `Registered adapter: fabric=1.12.1` — there is no "All checks passed" line and no error line. Users perceive this as "dbt does nothing".

`faulthandler` pins the fault to:

```
mssql_python/connection.py:374  in __init__
mssql_python/db_connection.py:55 in connect
```

This matches what the customer reported: silent dbt with no output and no errors.

## Bisect

Tested against the same Fabric DWH from the same machine (macOS 26.3.1 arm64, Python 3.13.7), using the published yanked 1.12.1 wheel:

| mssql-python | Result |
|---|---|
| 1.4.0 | works |
| 1.5.0 | works |
| 1.6.0 | works |
| 1.7.0 | not testable on macOS arm64 / py3.13 (no published wheel) |
| 1.7.1 | SIGBUS in `connect()` |

Excluded the whole 1.7.x line for now because 1.7.0 could not be verified on macOS arm64 and the 1.7.x release line clearly has stability problems. We can relax this once a fixed 1.7.x lands.

## Follow-up

A standalone Python reproducer (without dbt) was created and confirms the fault is in mssql-python itself, not in this adapter. An upstream issue against `microsoft/mssql-python` is pending.

## Test plan

- [x] `uv sync` resolves to `mssql-python==1.6.0`
- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] Standalone repro script connects successfully on 1.6.0; SIGBUS on 1.7.1
- [x] `dbt debug` against Fabric DWH works on 1.5.0, 1.6.0; silently dies on 1.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)